### PR TITLE
Readd removed XSD Schemata for XSLT and XML Schema

### DIFF
--- a/schema2beans/src/org/netbeans/modules/schema2beansdev/xmlschema.xsd
+++ b/schema2beans/src/org/netbeans/modules/schema2beansdev/xmlschema.xsd
@@ -1,0 +1,1252 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+W3C Software and Document Notice and License
+
+This work is being provided by the copyright holders under the following license.
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have 
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without 
+modification, for any purpose and without fee or royalty is hereby granted, 
+provided that you include the following on ALL copies of the work or portions 
+thereof, including modifications:
+
+- The full text of this NOTICE in a location viewable to users of the 
+  redistributed or derivative work.
+- Any pre-existing intellectual property disclaimers, notices, or terms and 
+  conditions. If none exist, the W3C Software and Document Short Notice should 
+  be included.
+- Notice of any changes or modifications, through a copyright statement on the
+  new code or document such as "This software or document includes material 
+  copied from or derived from [title and URI of the W3C document]. 
+  Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)." 
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+ WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF 
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE 
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, 
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR 
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or 
+publicity pertaining to the work without specific, written prior permission. 
+Title to copyright in this work will at all times remain with copyright 
+holders.
+
+Changes:
+
+- Added license header
+
+-->
+<!-- XML Schema schema for XML Schemas: Part 1: Structures -->
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" [
+
+<!-- provide ID type information even for parsers which only read the
+     internal subset -->
+<!ATTLIST xs:schema          id  ID  #IMPLIED>
+<!ATTLIST xs:complexType     id  ID  #IMPLIED>
+<!ATTLIST xs:complexContent  id  ID  #IMPLIED>
+<!ATTLIST xs:simpleContent   id  ID  #IMPLIED>
+<!ATTLIST xs:extension       id  ID  #IMPLIED>
+<!ATTLIST xs:element         id  ID  #IMPLIED>
+<!ATTLIST xs:group           id  ID  #IMPLIED> 
+<!ATTLIST xs:all             id  ID  #IMPLIED>
+<!ATTLIST xs:choice          id  ID  #IMPLIED>
+<!ATTLIST xs:sequence        id  ID  #IMPLIED>
+<!ATTLIST xs:any             id  ID  #IMPLIED>
+<!ATTLIST xs:anyAttribute    id  ID  #IMPLIED>
+<!ATTLIST xs:attribute       id  ID  #IMPLIED>
+<!ATTLIST xs:attributeGroup  id  ID  #IMPLIED>
+<!ATTLIST xs:unique          id  ID  #IMPLIED>
+<!ATTLIST xs:key             id  ID  #IMPLIED>
+<!ATTLIST xs:keyref          id  ID  #IMPLIED>
+<!ATTLIST xs:selector        id  ID  #IMPLIED>
+<!ATTLIST xs:field           id  ID  #IMPLIED>
+<!ATTLIST xs:include         id  ID  #IMPLIED>
+<!ATTLIST xs:import          id  ID  #IMPLIED>
+<!ATTLIST xs:redefine        id  ID  #IMPLIED>
+<!ATTLIST xs:notation        id  ID  #IMPLIED>
+]>
+<xs:schema targetNamespace="http://www.w3.org/2001/XMLSchema" blockDefault="#all" elementFormDefault="qualified" version="Id: XMLSchema.xsd,v 1.48 2001/04/24 18:56:39 ht Exp " xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="EN">
+
+ <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/2001/REC-xmlschema-1-20010502/structures.html">
+   The schema corresponding to this document is normative,
+   with respect to the syntactic constraints it expresses in the
+   XML Schema language.  The documentation (within &lt;documentation> elements)
+   below, is not normative, but rather highlights important aspects of
+   the W3C Recommendation of which this is a part</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+   <xs:documentation>
+   The simpleType element and all of its members are defined
+   in datatypes.xsd</xs:documentation>
+ </xs:annotation>
+
+ <xs:include schemaLocation="datatypes.xsd"/>
+
+ <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd">
+   <xs:annotation>
+     <xs:documentation>
+       Get access to the xml: attribute groups for xml:lang
+       as declared on 'schema' and 'documentation' below
+     </xs:documentation>
+   </xs:annotation>
+ </xs:import>
+
+ <xs:complexType name="openAttrs">
+   <xs:annotation>
+     <xs:documentation>
+       This type is extended by almost all schema types
+       to allow attributes from other namespaces to be
+       added to user schemas.
+     </xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+     <xs:restriction base="xs:anyType">
+       <xs:anyAttribute namespace="##other" processContents="lax"/>
+     </xs:restriction>
+   </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="annotated">
+   <xs:annotation>
+     <xs:documentation>
+       This type is extended by all types which allow annotation
+       other than &lt;schema&gt; itself
+     </xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+     <xs:extension base="xs:openAttrs">
+       <xs:sequence>
+	 <xs:element ref="xs:annotation" minOccurs="0"/>
+       </xs:sequence>
+       <xs:attribute name="id" type="xs:ID"/>
+     </xs:extension>
+   </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="schemaTop">
+  <xs:annotation>
+   <xs:documentation>
+   This group is for the
+   elements which occur freely at the top level of schemas.
+   All of their types are based on the "annotated" type by extension.</xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:group ref="xs:redefinable"/>
+   <xs:element ref="xs:element"/>
+   <xs:element ref="xs:attribute"/>
+   <xs:element ref="xs:notation"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:group name="redefinable">
+  <xs:annotation>
+   <xs:documentation>
+   This group is for the
+   elements which can self-redefine (see &lt;redefine> below).</xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element ref="xs:simpleType"/>
+   <xs:element ref="xs:complexType"/>
+   <xs:element ref="xs:group"/>
+   <xs:element ref="xs:attributeGroup"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:simpleType name="formChoice">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:NMTOKEN">
+   <xs:enumeration value="qualified"/>
+   <xs:enumeration value="unqualified"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:simpleType name="reducedDerivationControl">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:derivationControl">
+   <xs:enumeration value="extension"/>
+   <xs:enumeration value="restriction"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:simpleType name="derivationSet">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+   <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction}</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>    
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="#all"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list itemType="xs:reducedDerivationControl"/>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:element name="schema" id="schema">
+  <xs:annotation>
+    <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-schema"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:openAttrs">
+     <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+       <xs:element ref="xs:include"/>
+       <xs:element ref="xs:import"/>
+       <xs:element ref="xs:redefine"/>
+       <xs:element ref="xs:annotation"/>
+      </xs:choice>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+       <xs:group ref="xs:schemaTop"/>
+       <xs:element ref="xs:annotation" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+     </xs:sequence>
+     <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+     <xs:attribute name="version" type="xs:token"/>
+     <xs:attribute name="finalDefault" type="xs:derivationSet" use="optional" default=""/>
+     <xs:attribute name="blockDefault" type="xs:blockSet" use="optional" default=""/>
+     <xs:attribute name="attributeFormDefault" type="xs:formChoice" use="optional" default="unqualified"/>
+     <xs:attribute name="elementFormDefault" type="xs:formChoice" use="optional" default="unqualified"/>
+     <xs:attribute name="id" type="xs:ID"/>
+     <xs:attribute ref="xml:lang"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+
+  <xs:key name="element">
+   <xs:selector xpath="xs:element"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="attribute">
+   <xs:selector xpath="xs:attribute"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="type">
+   <xs:selector xpath="xs:complexType|xs:simpleType"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="group">
+   <xs:selector xpath="xs:group"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="attributeGroup">
+   <xs:selector xpath="xs:attributeGroup"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="notation">
+   <xs:selector xpath="xs:notation"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="identityConstraint">
+   <xs:selector xpath=".//xs:key|.//xs:unique|.//xs:keyref"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+ </xs:element>
+
+ <xs:simpleType name="allNNI">
+  <xs:annotation><xs:documentation>
+   for maxOccurs</xs:documentation></xs:annotation>
+  <xs:union memberTypes="xs:nonNegativeInteger">
+   <xs:simpleType>
+    <xs:restriction base="xs:NMTOKEN">
+     <xs:enumeration value="unbounded"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:attributeGroup name="occurs">
+  <xs:annotation><xs:documentation>
+   for all particles</xs:documentation></xs:annotation>
+  <xs:attribute name="minOccurs" type="xs:nonNegativeInteger" use="optional" default="1"/>
+  <xs:attribute name="maxOccurs" type="xs:allNNI" use="optional" default="1"/>
+ </xs:attributeGroup>
+
+ <xs:attributeGroup name="defRef">
+  <xs:annotation><xs:documentation>
+   for element, group and attributeGroup,
+   which both define and reference</xs:documentation></xs:annotation>
+  <xs:attribute name="name" type="xs:NCName"/>
+  <xs:attribute name="ref" type="xs:QName"/>
+ </xs:attributeGroup>
+
+ <xs:group name="typeDefParticle">
+  <xs:annotation>
+    <xs:documentation>
+   'complexType' uses this</xs:documentation></xs:annotation>
+  <xs:choice>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:all"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+  </xs:choice>
+ </xs:group>
+ 
+ 
+
+ <xs:group name="nestedParticle">
+  <xs:choice>
+   <xs:element name="element" type="xs:localElement"/>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+   <xs:element ref="xs:any"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:group name="particle">
+  <xs:choice>
+   <xs:element name="element" type="xs:localElement"/>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:all"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+   <xs:element ref="xs:any"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:complexType name="attribute">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:element name="simpleType" minOccurs="0" type="xs:localSimpleType"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attribute name="type" type="xs:QName"/>
+    <xs:attribute name="use" use="optional" default="optional">
+     <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+       <xs:enumeration value="prohibited"/>
+       <xs:enumeration value="optional"/>
+       <xs:enumeration value="required"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="default" type="xs:string"/>
+    <xs:attribute name="fixed" type="xs:string"/>
+    <xs:attribute name="form" type="xs:formChoice"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelAttribute">
+  <xs:complexContent>
+   <xs:restriction base="xs:attribute">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:element name="simpleType" minOccurs="0" type="xs:localSimpleType"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="form" use="prohibited"/>
+    <xs:attribute name="use" use="prohibited"/>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="attrDecls">
+  <xs:sequence>
+   <xs:choice minOccurs="0" maxOccurs="unbounded">
+    <xs:element name="attribute" type="xs:attribute"/>
+    <xs:element name="attributeGroup" type="xs:attributeGroupRef"/>
+   </xs:choice>
+   <xs:element ref="xs:anyAttribute" minOccurs="0"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:element name="anyAttribute" type="xs:wildcard" id="anyAttribute">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-anyAttribute"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:group name="complexTypeModel">
+  <xs:choice>
+      <xs:element ref="xs:simpleContent"/>
+      <xs:element ref="xs:complexContent"/>
+      <xs:sequence>
+       <xs:annotation>
+        <xs:documentation>
+   This branch is short for
+   &lt;complexContent>
+   &lt;restriction base="xs:anyType">
+   ...
+   &lt;/restriction>
+   &lt;/complexContent></xs:documentation>
+       </xs:annotation>
+       <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+       <xs:group ref="xs:attrDecls"/>
+      </xs:sequence>
+  </xs:choice>
+ </xs:group>
+
+ <xs:complexType name="complexType" abstract="true">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:complexTypeModel"/>
+    <xs:attribute name="name" type="xs:NCName">
+     <xs:annotation>
+      <xs:documentation>
+      Will be restricted to required or forbidden</xs:documentation>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="mixed" type="xs:boolean" use="optional" default="false">
+     <xs:annotation>
+      <xs:documentation>
+      Not allowed if simpleContent child is chosen.
+      May be overriden by setting on complexContent child.</xs:documentation>
+    </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="abstract" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="final" type="xs:derivationSet"/>
+    <xs:attribute name="block" type="xs:derivationSet"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelComplexType">
+  <xs:complexContent>
+   <xs:restriction base="xs:complexType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:complexTypeModel"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="required"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="localComplexType">
+  <xs:complexContent>
+   <xs:restriction base="xs:complexType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:complexTypeModel"/>
+    </xs:sequence>
+    <xs:attribute name="name" use="prohibited"/>
+    <xs:attribute name="abstract" use="prohibited"/>
+    <xs:attribute name="final" use="prohibited"/>
+    <xs:attribute name="block" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="restrictionType">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:choice>
+      <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+      <xs:group ref="xs:simpleRestrictionModel" minOccurs="0"/>
+     </xs:choice>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="base" type="xs:QName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:complexType name="complexRestrictionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:restrictionType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+   </xs:restriction>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:complexType name="extensionType">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="base" type="xs:QName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:element name="complexContent" id="complexContent">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-complexContent"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:choice>
+      <xs:element name="restriction" type="xs:complexRestrictionType"/>
+      <xs:element name="extension" type="xs:extensionType"/>
+     </xs:choice>     
+     <xs:attribute name="mixed" type="xs:boolean">
+      <xs:annotation>
+       <xs:documentation>
+       Overrides any setting on complexType parent.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:complexType name="simpleRestrictionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:restrictionType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:simpleRestrictionModel" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="simpleExtensionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:extensionType">
+    <xs:sequence>
+     <xs:annotation>
+      <xs:documentation>
+      No typeDefParticle group reference</xs:documentation>
+     </xs:annotation>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="simpleContent" id="simpleContent">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-simpleContent"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:choice>
+      <xs:element name="restriction" type="xs:simpleRestrictionType"/>
+      <xs:element name="extension" type="xs:simpleExtensionType"/>
+     </xs:choice>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+ 
+ <xs:element name="complexType" type="xs:topLevelComplexType" id="complexType">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-complexType"/>
+  </xs:annotation>
+ </xs:element>
+
+
+  <xs:simpleType name="blockSet">
+   <xs:annotation>
+    <xs:documentation>
+    A utility type, not for public use</xs:documentation>
+    <xs:documentation>
+    #all or (possibly empty) subset of {substitution, extension,
+    restriction}</xs:documentation>
+   </xs:annotation>
+   <xs:union>
+    <xs:simpleType>    
+     <xs:restriction base="xs:token">
+      <xs:enumeration value="#all"/>
+     </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType>
+     <xs:list>
+      <xs:simpleType>
+       <xs:restriction base="xs:derivationControl">
+        <xs:enumeration value="extension"/>
+        <xs:enumeration value="restriction"/>
+        <xs:enumeration value="substitution"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:list>
+    </xs:simpleType>
+   </xs:union>  
+  </xs:simpleType>
+
+ <xs:complexType name="element" abstract="true">
+  <xs:annotation>
+   <xs:documentation>
+   The element element can be used either
+   at the top level to define an element-type binding globally,
+   or within a content model to either reference a globally-defined
+   element or type or declare an element-type binding locally.
+   The ref form is not allowed at the top level.</xs:documentation>
+  </xs:annotation>
+
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attribute name="type" type="xs:QName"/>
+    <xs:attribute name="substitutionGroup" type="xs:QName"/>
+    <xs:attributeGroup ref="xs:occurs"/>
+    <xs:attribute name="default" type="xs:string"/>
+    <xs:attribute name="fixed" type="xs:string"/>
+    <xs:attribute name="nillable" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="abstract" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="final" type="xs:derivationSet"/>
+    <xs:attribute name="block" type="xs:blockSet"/>
+    <xs:attribute name="form" type="xs:formChoice"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelElement">
+  <xs:complexContent>
+   <xs:restriction base="xs:element">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="form" use="prohibited"/>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="localElement">
+  <xs:complexContent>
+   <xs:restriction base="xs:element">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="substitutionGroup" use="prohibited"/>
+    <xs:attribute name="final" use="prohibited"/>
+    <xs:attribute name="abstract" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="element" type="xs:topLevelElement" id="element">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-element"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="group" abstract="true">
+  <xs:annotation>
+   <xs:documentation>
+   group type for explicit groups, named top-level groups and
+   group references</xs:documentation>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:particle" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attributeGroup ref="xs:occurs"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="realGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:group">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0" maxOccurs="1">
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+     </xs:choice>
+    </xs:sequence>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="namedGroup">
+  <xs:annotation>
+   <xs:documentation>Should derive this from realGroup, but too complicated 
+                      for now</xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="1" maxOccurs="1">
+      <xs:element name="all">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:restriction base="xs:all">
+          <xs:group ref="xs:allModel"/>
+          <xs:attribute name="minOccurs" use="prohibited"/>
+          <xs:attribute name="maxOccurs" use="prohibited"/>
+         </xs:restriction>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+      <xs:element name="choice" type="xs:simpleExplicitGroup"/>
+      <xs:element name="sequence" type="xs:simpleExplicitGroup"/>
+     </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+ </xs:complexType>
+
+ <xs:complexType name="groupRef">
+  <xs:complexContent>
+   <xs:restriction base="xs:realGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="required" type="xs:QName"/>
+    <xs:attribute name="name" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="explicitGroup">
+  <xs:annotation>
+   <xs:documentation>
+   group type for the three kinds of group</xs:documentation>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:restriction base="xs:group">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="prohibited"/>
+    <xs:attribute name="ref" type="xs:QName" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="simpleExplicitGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:explicitGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:group name="allModel">
+  <xs:sequence>
+      <xs:element ref="xs:annotation" minOccurs="0"/>
+      <xs:element name="element" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:annotation>
+         <xs:documentation>restricted max/min</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+         <xs:restriction base="xs:localElement">
+          <xs:sequence>
+           <xs:element ref="xs:annotation" minOccurs="0"/>
+           <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+           </xs:choice>
+           <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="minOccurs" use="optional" default="1">
+           <xs:simpleType>
+            <xs:restriction base="xs:nonNegativeInteger">
+             <xs:enumeration value="0"/>
+             <xs:enumeration value="1"/>
+            </xs:restriction>
+           </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="maxOccurs" use="optional" default="1">
+           <xs:simpleType>
+            <xs:restriction base="xs:allNNI">
+             <xs:enumeration value="0"/>
+             <xs:enumeration value="1"/>
+            </xs:restriction>
+           </xs:simpleType>
+          </xs:attribute>
+         </xs:restriction>
+        </xs:complexContent>
+       </xs:complexType>    
+      </xs:element>
+     </xs:sequence>
+ </xs:group>
+
+  <xs:complexType name="all">
+   <xs:annotation>
+    <xs:documentation>
+   Only elements allowed inside</xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+    <xs:restriction base="xs:explicitGroup">
+     <xs:group ref="xs:allModel"/>
+     <xs:attribute name="minOccurs" use="optional" default="1">
+      <xs:simpleType>
+       <xs:restriction base="xs:nonNegativeInteger">
+        <xs:enumeration value="0"/>
+        <xs:enumeration value="1"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+     <xs:attribute name="maxOccurs" use="optional" default="1">
+      <xs:simpleType>
+       <xs:restriction base="xs:allNNI">
+        <xs:enumeration value="1"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+    </xs:restriction>
+   </xs:complexContent>
+  </xs:complexType>
+
+ <xs:element name="all" id="all" type="xs:all">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-all"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="choice" type="xs:explicitGroup" id="choice">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-choice"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="sequence" type="xs:explicitGroup" id="sequence">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-sequence"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="group" type="xs:namedGroup" id="group">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-group"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="wildcard">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:attribute name="namespace" type="xs:namespaceList" use="optional" default="##any"/>
+    <xs:attribute name="processContents" use="optional" default="strict">
+     <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+       <xs:enumeration value="skip"/>
+       <xs:enumeration value="lax"/>
+       <xs:enumeration value="strict"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="any" id="any">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-any"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:wildcard">
+     <xs:attributeGroup ref="xs:occurs"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+  <xs:annotation>
+   <xs:documentation>
+   simple type for the value of the 'namespace' attr of
+   'any' and 'anyAttribute'</xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+   <xs:documentation>
+   Value is
+              ##any      - - any non-conflicting WFXML/attribute at all
+
+              ##other    - - any non-conflicting WFXML/attribute from
+                              namespace other than targetNS
+
+              ##local    - - any unqualified non-conflicting WFXML/attribute 
+
+              one or     - - any non-conflicting WFXML/attribute from
+              more URI        the listed namespaces
+              references
+              (space separated)
+
+    ##targetNamespace or ##local may appear in the above list, to
+        refer to the targetNamespace of the enclosing
+        schema or an absent targetNamespace respectively</xs:documentation>
+  </xs:annotation>
+
+ <xs:simpleType name="namespaceList">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="##any"/>
+     <xs:enumeration value="##other"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list>
+     <xs:simpleType>
+      <xs:union memberTypes="xs:anyURI">
+       <xs:simpleType>
+        <xs:restriction base="xs:token">
+         <xs:enumeration value="##targetNamespace"/>
+         <xs:enumeration value="##local"/>
+        </xs:restriction>
+       </xs:simpleType>
+      </xs:union>
+     </xs:simpleType>
+    </xs:list>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:element name="attribute" type="xs:topLevelAttribute" id="attribute">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-attribute"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="attributeGroup" abstract="true">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:attrDecls"/>
+    <xs:attributeGroup ref="xs:defRef"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="namedAttributeGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:attributeGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:attribute name="ref" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="attributeGroupRef">
+  <xs:complexContent>
+   <xs:restriction base="xs:attributeGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="required" type="xs:QName"/>
+    <xs:attribute name="name" use="prohibited"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="attributeGroup" type="xs:namedAttributeGroup" id="attributeGroup">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-attributeGroup"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="include" id="include">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-include"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="redefine" id="redefine">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-redefine"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:openAttrs">
+     <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="xs:annotation"/>
+      <xs:group ref="xs:redefinable"/>
+     </xs:choice>
+     <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+     <xs:attribute name="id" type="xs:ID"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="import" id="import">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-import"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="namespace" type="xs:anyURI"/>
+     <xs:attribute name="schemaLocation" type="xs:anyURI"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="selector" id="selector">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-selector"/>
+  </xs:annotation>
+  <xs:complexType>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+     <xs:attribute name="xpath" use="required">
+      <xs:simpleType>
+       <xs:annotation>
+        <xs:documentation>A subset of XPath expressions for use
+in selectors</xs:documentation>
+        <xs:documentation>A utility type, not for public
+use</xs:documentation>
+       </xs:annotation>
+       <xs:restriction base="xs:token">
+        <xs:annotation>
+         <xs:documentation>The following pattern is intended to allow XPath
+                           expressions per the following EBNF:
+	  Selector    ::=    Path ( '|' Path )*  
+	  Path    ::=    ('.//')? Step ( '/' Step )*  
+	  Step    ::=    '.' | NameTest  
+	  NameTest    ::=    QName | '*' | NCName ':' '*'  
+                           child:: is also allowed
+         </xs:documentation>
+        </xs:annotation>
+        <xs:pattern value="(\.//)?(((child::)?((\i\c*:)?(\i\c*|\*)))|\.)(/(((child::)?((\i\c*:)?(\i\c*|\*)))|\.))*(\|(\.//)?(((child::)?((\i\c*:)?(\i\c*|\*)))|\.)(/(((child::)?((\i\c*:)?(\i\c*|\*)))|\.))*)*">
+        </xs:pattern>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ </xs:element>
+
+ <xs:element name="field" id="field">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-field"/>
+  </xs:annotation>
+  <xs:complexType>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+     <xs:attribute name="xpath" use="required">
+      <xs:simpleType>
+       <xs:annotation>
+        <xs:documentation>A subset of XPath expressions for use
+in fields</xs:documentation>
+        <xs:documentation>A utility type, not for public
+use</xs:documentation>
+       </xs:annotation>
+       <xs:restriction base="xs:token">
+        <xs:annotation>
+         <xs:documentation>The following pattern is intended to allow XPath
+                           expressions per the same EBNF as for selector,
+                           with the following change:
+          Path    ::=    ('.//')? ( Step '/' )* ( Step | '@' NameTest ) 
+         </xs:documentation>
+        </xs:annotation>
+        <xs:pattern value="(\.//)?((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)/)*((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)|((attribute::|@)((\i\c*:)?(\i\c*|\*))))(\|(\.//)?((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)/)*((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)|((attribute::|@)((\i\c*:)?(\i\c*|\*)))))*">
+        </xs:pattern>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ </xs:element>
+
+ <xs:complexType name="keybase">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:element ref="xs:selector"/>
+     <xs:element ref="xs:field" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="identityConstraint">
+  <xs:annotation>
+   <xs:documentation>The three kinds of identity constraints, all with
+                     type of or derived from 'keybase'.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element ref="xs:unique"/>
+   <xs:element ref="xs:key"/>
+   <xs:element ref="xs:keyref"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:element name="unique" type="xs:keybase" id="unique">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-unique"/>
+  </xs:annotation>
+ </xs:element>
+ <xs:element name="key" type="xs:keybase" id="key">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-key"/>
+  </xs:annotation>
+ </xs:element>
+ <xs:element name="keyref" id="keyref">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-keyref"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:keybase">
+     <xs:attribute name="refer" type="xs:QName" use="required"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="notation" id="notation">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-notation"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="name" type="xs:NCName" use="required"/>
+     <xs:attribute name="public" type="xs:public" use="required"/>
+     <xs:attribute name="system" type="xs:anyURI"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:simpleType name="public">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+   <xs:documentation>
+   A public identifier, per ISO 8879</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token"/>
+ </xs:simpleType>
+
+ <xs:element name="appinfo" id="appinfo">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-appinfo"/>
+   </xs:annotation>
+   <xs:complexType mixed="true">
+     <xs:sequence minOccurs="0" maxOccurs="unbounded">
+       <xs:any processContents="lax"/>
+     </xs:sequence>
+     <xs:attribute name="source" type="xs:anyURI"/>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:element name="documentation" id="documentation">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-documentation"/>
+   </xs:annotation>
+   <xs:complexType mixed="true">
+     <xs:sequence minOccurs="0" maxOccurs="unbounded">
+       <xs:any processContents="lax"/>
+     </xs:sequence>
+     <xs:attribute name="source" type="xs:anyURI"/>
+   <xs:attribute ref="xml:lang"/>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:element name="annotation" id="annotation">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-annotation"/>
+   </xs:annotation>
+   <xs:complexType>
+    <xs:complexContent>
+     <xs:extension base="xs:openAttrs">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+       <xs:element ref="xs:appinfo"/>
+       <xs:element ref="xs:documentation"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+     </xs:extension>
+    </xs:complexContent>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:annotation>
+  <xs:documentation>
+   notations for use within XML Schema schemas</xs:documentation>
+ </xs:annotation>
+
+ <xs:notation name="XMLSchemaStructures" public="structures" system="http://www.w3.org/2000/08/XMLSchema.xsd"/>
+ <xs:notation name="XML" public="REC-xml-19980210" system="http://www.w3.org/TR/1998/REC-xml-19980210"/>
+ 
+ <xs:complexType name="anyType" mixed="true">
+  <xs:annotation>
+   <xs:documentation>
+   Not the real urType, but as close an approximation as we can
+   get in the XML representation</xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:any minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:anyAttribute/>
+ </xs:complexType>
+</xs:schema>

--- a/xml.catalog/src/org/netbeans/modules/xml/catalog/resources/Transform.xsd
+++ b/xml.catalog/src/org/netbeans/modules/xml/catalog/resources/Transform.xsd
@@ -1,0 +1,1181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+W3C Software and Document Notice and License
+
+This work is being provided by the copyright holders under the following license.
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have 
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without 
+modification, for any purpose and without fee or royalty is hereby granted, 
+provided that you include the following on ALL copies of the work or portions 
+thereof, including modifications:
+
+- The full text of this NOTICE in a location viewable to users of the 
+  redistributed or derivative work.
+- Any pre-existing intellectual property disclaimers, notices, or terms and 
+  conditions. If none exist, the W3C Software and Document Short Notice should 
+  be included.
+- Notice of any changes or modifications, through a copyright statement on the
+  new code or document such as "This software or document includes material 
+  copied from or derived from [title and URI of the W3C document]. 
+  Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)." 
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+ WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF 
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE 
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, 
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR 
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or 
+publicity pertaining to the work without specific, written prior permission. 
+Title to copyright in this work will at all times remain with copyright 
+holders.
+
+Changes:
+
+- Added license header
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" targetNamespace="http://www.w3.org/1999/XSL/Transform" elementFormDefault="qualified">
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<xs:annotation>
+  <xs:documentation>
+  
+    This is a schema for XSLT 2.0 stylesheets.
+    
+    It defines all the elements that appear in the XSLT namespace; it also
+    provides hooks that allow the inclusion of user-defined literal result elements,
+    extension instructions, and top-level data elements.
+    
+    The schema is derived (with kind permission) from a schema for XSLT 1.0 stylesheets
+    produced by Asir S Vedamuthu of WebMethods Inc.
+    
+    This schema is available for use under the conditions of the W3C Software License
+    published at http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    
+    The schema is organized as follows:
+    
+    PART A: definitions of complex types and model groups used as the basis 
+            for element definitions
+    PART B: definitions of individual XSLT elements
+    PART C: definitions for literal result elements
+    PART D: definitions of simple types used in attribute definitions
+    
+    This schema does not attempt to define all the constraints that apply to a valid
+    XSLT 2.0 stylesheet module. It is the intention that all valid stylesheet modules 
+    should conform to this schema; however, the schema is non-normative and in the event 
+    of any conflict, the text of the Recommendation takes precedence.
+
+    This schema does not implement the special rules that apply when a stylesheet
+    has sections that use forwards-compatible-mode. In this mode, setting version="3.0"
+    allows elements from the XSLT namespace to be used that are not defined in XSLT 2.0.
+
+    Simplified stylesheets (those with a literal result element as the outermost element)
+    will validate against this schema only if validation starts in lax mode.
+    
+    This version is dated 2007-03-16
+    Authors: Michael H Kay, Saxonica Limited
+             Jeni Tennison, Jeni Tennison Consulting Ltd.
+             
+    2007-03-15: added xsl:document element
+                revised xsl:sequence element
+                see http://www.w3.org/Bugs/Public/show_bug.cgi?id=4237         
+    
+  </xs:documentation>
+</xs:annotation>   
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+ 
+<!--
+The declaration of xml:space and xml:lang may need to be commented out because
+of problems processing the schema using various tools
+-->
+      
+<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+<!-- 
+    An XSLT stylesheet may contain an in-line schema within an xsl:import-schema element,
+    so the Schema for schemas needs to be imported
+-->
+  
+<xs:import namespace="http://www.w3.org/2001/XMLSchema" schemaLocation="http://www.w3.org/2001/XMLSchema.xsd"/>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<xs:annotation>
+  <xs:documentation>
+    PART A: definitions of complex types and model groups used as the basis 
+            for element definitions
+  </xs:documentation>
+</xs:annotation>   
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+<xs:complexType name="generic-element-type" mixed="true">
+  <xs:attribute name="default-collation" type="xsl:uri-list"/>
+  <xs:attribute name="exclude-result-prefixes" type="xsl:prefix-list-or-all"/>
+  <xs:attribute name="extension-element-prefixes" type="xsl:prefix-list"/>
+  <xs:attribute name="use-when" type="xsl:expression"/>
+  <xs:attribute name="xpath-default-namespace" type="xs:anyURI"/>
+  <xs:anyAttribute namespace="##other" processContents="lax"/>
+</xs:complexType>
+
+<xs:complexType name="versioned-element-type" mixed="true">
+  <xs:complexContent>
+    <xs:extension base="xsl:generic-element-type">    
+      <xs:attribute name="version" type="xs:decimal" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:complexType name="element-only-versioned-element-type" mixed="false">
+  <xs:complexContent>
+    <xs:restriction base="xsl:versioned-element-type">
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:restriction>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:complexType name="sequence-constructor">
+  <xs:complexContent mixed="true">
+    <xs:extension base="xsl:versioned-element-type">    
+      <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:group name="sequence-constructor-group">
+  <xs:choice>
+    <xs:element ref="xsl:variable"/>
+    <xs:element ref="xsl:instruction"/>
+    <xs:group ref="xsl:result-elements"/>
+  </xs:choice>
+</xs:group>
+
+<xs:element name="declaration" type="xsl:generic-element-type" abstract="true"/>
+
+<xs:element name="instruction" type="xsl:versioned-element-type" abstract="true"/>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<xs:annotation>
+  <xs:documentation>
+    PART B: definitions of individual XSLT elements    
+    Elements are listed in alphabetical order.    
+  </xs:documentation>
+</xs:annotation>   
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+<xs:element name="analyze-string" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:matching-substring" minOccurs="0"/>
+          <xs:element ref="xsl:non-matching-substring" minOccurs="0"/>
+          <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="select" type="xsl:expression" use="required"/>
+        <xs:attribute name="regex" type="xsl:avt" use="required"/>
+        <xs:attribute name="flags" type="xsl:avt" default=""/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="apply-imports" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="apply-templates" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xsl:sort"/>
+          <xs:element ref="xsl:with-param"/>
+        </xs:choice>
+        <xs:attribute name="select" type="xsl:expression" default="child::node()"/>
+        <xs:attribute name="mode" type="xsl:mode"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="attribute" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:avt" use="required"/>
+        <xs:attribute name="namespace" type="xsl:avt"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="separator" type="xsl:avt"/>   
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>        
+
+<xs:element name="attribute-set" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xsl:attribute"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="use-attribute-sets" type="xsl:QNames" default=""/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="call-template" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="character-map" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:output-character" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="use-character-maps" type="xsl:QNames" default=""/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="choose" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:when" maxOccurs="unbounded"/>
+          <xs:element ref="xsl:otherwise" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="comment" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="select" type="xsl:expression"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="copy" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="copy-namespaces" type="xsl:yes-or-no" default="yes"/>
+        <xs:attribute name="inherit-namespaces" type="xsl:yes-or-no" default="yes"/>
+        <xs:attribute name="use-attribute-sets" type="xsl:QNames" default=""/>
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="copy-of" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:attribute name="select" type="xsl:expression" use="required"/>
+        <xs:attribute name="copy-namespaces" type="xsl:yes-or-no" default="yes"/>
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="document" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="decimal-format" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="name" type="xsl:QName"/>
+        <xs:attribute name="decimal-separator" type="xsl:char" default="."/>
+        <xs:attribute name="grouping-separator" type="xsl:char" default=","/>
+        <xs:attribute name="infinity" type="xs:string" default="Infinity"/>
+        <xs:attribute name="minus-sign" type="xsl:char" default="-"/>
+        <xs:attribute name="NaN" type="xs:string" default="NaN"/>
+        <xs:attribute name="percent" type="xsl:char" default="%"/>
+        <xs:attribute name="per-mille" type="xsl:char" default="‰"/>
+        <xs:attribute name="zero-digit" type="xsl:char" default="0"/>
+        <xs:attribute name="digit" type="xsl:char" default="#"/>
+        <xs:attribute name="pattern-separator" type="xsl:char" default=";"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="element" substitutionGroup="xsl:instruction">
+  <xs:complexType mixed="true">
+    <xs:complexContent>
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:avt" use="required"/>
+        <xs:attribute name="namespace" type="xsl:avt"/>
+        <xs:attribute name="inherit-namespaces" type="xsl:yes-or-no" default="yes"/>
+        <xs:attribute name="use-attribute-sets" type="xsl:QNames" default=""/>
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="fallback" substitutionGroup="xsl:instruction" type="xsl:sequence-constructor"/>
+
+<xs:element name="for-each" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:sort" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="select" type="xsl:expression" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="for-each-group" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:sort" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="select" type="xsl:expression" use="required"/>
+        <xs:attribute name="group-by" type="xsl:expression"/>
+        <xs:attribute name="group-adjacent" type="xsl:expression"/>            
+        <xs:attribute name="group-starting-with" type="xsl:pattern"/>            
+        <xs:attribute name="group-ending-with" type="xsl:pattern"/>            
+        <xs:attribute name="collation" type="xs:anyURI"/>            
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="function" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:param" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="override" type="xsl:yes-or-no" default="yes"/>
+        <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="if" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="test" type="xsl:expression" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="import">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="href" type="xs:anyURI" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="import-schema" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xs:schema" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="namespace" type="xs:anyURI"/>
+        <xs:attribute name="schema-location" type="xs:anyURI"/>                  
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="include" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="href" type="xs:anyURI" use="required"/>
+        </xs:extension>
+      </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="key" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="match" type="xsl:pattern" use="required"/>
+        <xs:attribute name="use" type="xsl:expression"/>
+        <xs:attribute name="collation" type="xs:anyURI"/>               
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="matching-substring" type="xsl:sequence-constructor"/>
+
+<xs:element name="message" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="terminate" type="xsl:avt" default="no"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="namespace" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:avt" use="required"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="namespace-alias" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="stylesheet-prefix" type="xsl:prefix-or-default" use="required"/>
+        <xs:attribute name="result-prefix" type="xsl:prefix-or-default" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="next-match" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xsl:with-param"/>
+          <xs:element ref="xsl:fallback"/>
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+
+<xs:element name="number" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:attribute name="value" type="xsl:expression"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="level" type="xsl:level" default="single"/>
+        <xs:attribute name="count" type="xsl:pattern"/>
+        <xs:attribute name="from" type="xsl:pattern"/>
+        <xs:attribute name="format" type="xsl:avt" default="1"/>
+        <xs:attribute name="lang" type="xsl:avt"/>
+        <xs:attribute name="letter-value" type="xsl:avt"/>
+        <xs:attribute name="ordinal" type="xsl:avt"/>        
+        <xs:attribute name="grouping-separator" type="xsl:avt"/>
+        <xs:attribute name="grouping-size" type="xsl:avt"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="otherwise" type="xsl:sequence-constructor"/>
+
+<xs:element name="output" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:generic-element-type">
+        <xs:attribute name="name" type="xsl:QName"/>
+        <xs:attribute name="method" type="xsl:method"/>
+        <xs:attribute name="byte-order-mark" type="xsl:yes-or-no"/>
+        <xs:attribute name="cdata-section-elements" type="xsl:QNames"/>
+        <xs:attribute name="doctype-public" type="xs:string"/>
+        <xs:attribute name="doctype-system" type="xs:string"/>
+        <xs:attribute name="encoding" type="xs:string"/>
+        <xs:attribute name="escape-uri-attributes" type="xsl:yes-or-no"/>
+        <xs:attribute name="include-content-type" type="xsl:yes-or-no"/>
+        <xs:attribute name="indent" type="xsl:yes-or-no"/>
+        <xs:attribute name="media-type" type="xs:string"/>
+        <xs:attribute name="normalization-form" type="xs:NMTOKEN"/>
+        <xs:attribute name="omit-xml-declaration" type="xsl:yes-or-no"/>
+        <xs:attribute name="standalone" type="xsl:yes-or-no-or-omit"/>
+        <xs:attribute name="undeclare-prefixes" type="xsl:yes-or-no"/>
+        <xs:attribute name="use-character-maps" type="xsl:QNames"/>
+        <xs:attribute name="version" type="xs:NMTOKEN"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="output-character">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="character" type="xsl:char" use="required"/>
+        <xs:attribute name="string" type="xs:string" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="param">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="as" type="xsl:sequence-type"/>
+        <xs:attribute name="required" type="xsl:yes-or-no"/>
+        <xs:attribute name="tunnel" type="xsl:yes-or-no"/>        
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="perform-sort" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:sort" minOccurs="1" maxOccurs="unbounded"/>
+          <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="select" type="xsl:expression"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="preserve-space" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="elements" type="xsl:nametests" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="processing-instruction" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:avt" use="required"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="result-document" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="format" type="xsl:avt"/>
+        <xs:attribute name="href" type="xsl:avt"/>
+        <xs:attribute name="type" type="xsl:QName"/>
+        <xs:attribute name="validation" type="xsl:validation-type"/>
+        <xs:attribute name="method" type="xsl:avt"/>
+        <xs:attribute name="byte-order-mark" type="xsl:avt"/>
+        <xs:attribute name="cdata-section-elements" type="xsl:avt"/>
+        <xs:attribute name="doctype-public" type="xsl:avt"/>
+        <xs:attribute name="doctype-system" type="xsl:avt"/>
+        <xs:attribute name="encoding" type="xsl:avt"/>
+        <xs:attribute name="escape-uri-attributes" type="xsl:avt"/>
+        <xs:attribute name="include-content-type" type="xsl:avt"/>
+        <xs:attribute name="indent" type="xsl:avt"/>
+        <xs:attribute name="media-type" type="xsl:avt"/>
+        <xs:attribute name="normalization-form" type="xsl:avt"/>
+        <xs:attribute name="omit-xml-declaration" type="xsl:avt"/>
+        <xs:attribute name="standalone" type="xsl:avt"/>
+        <xs:attribute name="undeclare-prefixes" type="xsl:avt"/>
+        <xs:attribute name="use-character-maps" type="xsl:QNames"/>
+        <xs:attribute name="output-version" type="xsl:avt"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="sequence" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xsl:fallback"/>
+        </xs:sequence>
+        <xs:attribute name="select" type="xsl:expression"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="sort">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="select" type="xsl:expression"/>  
+        <xs:attribute name="lang" type="xsl:avt"/>        
+        <xs:attribute name="data-type" type="xsl:avt" default="text"/>        
+        <xs:attribute name="order" type="xsl:avt" default="ascending"/>        
+        <xs:attribute name="case-order" type="xsl:avt"/>
+        <xs:attribute name="collation" type="xsl:avt"/>
+        <xs:attribute name="stable" type="xsl:yes-or-no"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="strip-space" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:element-only-versioned-element-type">
+        <xs:attribute name="elements" type="xsl:nametests" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
+
+<xs:element name="template" substitutionGroup="xsl:declaration">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:versioned-element-type">
+        <xs:sequence>
+          <xs:element ref="xsl:param" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xsl:sequence-constructor-group" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="match" type="xsl:pattern"/>
+        <xs:attribute name="priority" type="xs:decimal"/>
+        <xs:attribute name="mode" type="xsl:modes"/>
+        <xs:attribute name="name" type="xsl:QName"/>
+        <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="text-element-base-type">
+  <xs:simpleContent>
+    <xs:restriction base="xsl:versioned-element-type">
+      <xs:simpleType>
+        <xs:restriction base="xs:string"/>
+      </xs:simpleType>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:restriction>
+  </xs:simpleContent>
+</xs:complexType>
+
+<xs:element name="text" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:simpleContent>
+      <xs:extension base="xsl:text-element-base-type">
+        <xs:attribute name="disable-output-escaping" type="xsl:yes-or-no" default="no"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="transform-element-base-type">
+  <xs:complexContent>
+    <xs:restriction base="xsl:element-only-versioned-element-type">
+      <xs:attribute name="version" type="xs:decimal" use="required"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:restriction>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:element name="transform">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="xsl:transform-element-base-type">
+        <xs:sequence>
+          <xs:element ref="xsl:import" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:declaration"/>
+            <xs:element ref="xsl:variable"/>
+            <xs:element ref="xsl:param"/>              
+            <xs:any namespace="##other" processContents="lax"/> <!-- weaker than XSLT 1.0 -->
+          </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:ID"/>
+        <xs:attribute name="default-validation" type="xsl:validation-strip-or-preserve" default="strip"/>
+        <xs:attribute name="input-type-annotations" type="xsl:input-type-annotations-type" default="unspecified"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="value-of" substitutionGroup="xsl:instruction">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="separator" type="xsl:avt"/>            
+        <xs:attribute name="disable-output-escaping" type="xsl:yes-or-no" default="no"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="variable">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="select" type="xsl:expression" use="optional"/>
+        <xs:attribute name="as" type="xsl:sequence-type" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="when">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="test" type="xsl:expression" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="with-param">
+  <xs:complexType>
+    <xs:complexContent mixed="true">
+      <xs:extension base="xsl:sequence-constructor">
+        <xs:attribute name="name" type="xsl:QName" use="required"/>
+        <xs:attribute name="select" type="xsl:expression"/>
+        <xs:attribute name="as" type="xsl:sequence-type"/>
+        <xs:attribute name="tunnel" type="xsl:yes-or-no"/>   
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<xs:annotation>
+  <xs:documentation>
+    PART C: definition of literal result elements
+    
+    There are three ways to define the literal result elements
+    permissible in a stylesheet.
+    
+    (a) do nothing. This allows any element to be used as a literal
+        result element, provided it is not in the XSLT namespace
+    
+    (b) declare all permitted literal result elements as members
+        of the xsl:literal-result-element substitution group
+        
+    (c) redefine the model group xsl:result-elements to accommodate
+        all permitted literal result elements.
+        
+    Literal result elements are allowed to take certain attributes
+    in the XSLT namespace. These are defined in the attribute group
+    literal-result-element-attributes, which can be included in the
+    definition of any literal result element.
+    
+  </xs:documentation>
+</xs:annotation>   
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+<xs:element name="literal-result-element" abstract="true" type="xs:anyType"/>
+
+<xs:attributeGroup name="literal-result-element-attributes">
+  <xs:attribute name="default-collation" form="qualified" type="xsl:uri-list"/>
+  <xs:attribute name="extension-element-prefixes" form="qualified" type="xsl:prefixes"/>
+  <xs:attribute name="exclude-result-prefixes" form="qualified" type="xsl:prefixes"/>
+  <xs:attribute name="xpath-default-namespace" form="qualified" type="xs:anyURI"/>    
+  <xs:attribute name="inherit-namespaces" form="qualified" type="xsl:yes-or-no" default="yes"/>
+  <xs:attribute name="use-attribute-sets" form="qualified" type="xsl:QNames" default=""/>
+  <xs:attribute name="use-when" form="qualified" type="xsl:expression"/>
+  <xs:attribute name="version" form="qualified" type="xs:decimal"/>
+  <xs:attribute name="type" form="qualified" type="xsl:QName"/>
+  <xs:attribute name="validation" form="qualified" type="xsl:validation-type"/>
+</xs:attributeGroup>
+
+<xs:group name="result-elements">
+  <xs:choice>
+    <xs:element ref="xsl:literal-result-element"/>
+    <xs:any namespace="##other" processContents="lax"/>
+    <xs:any namespace="##local" processContents="lax"/>
+  </xs:choice>
+</xs:group>
+
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+<xs:annotation>
+  <xs:documentation>
+    PART D: definitions of simple types used in stylesheet attributes 
+  </xs:documentation>
+</xs:annotation>   
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+<xs:simpleType name="avt">
+  <xs:annotation>
+    <xs:documentation>
+      This type is used for all attributes that allow an attribute value template.
+      The general rules for the syntax of attribute value templates, and the specific
+      rules for each such attribute, are described in the XSLT 2.0 Recommendation.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string"/>
+</xs:simpleType>
+
+<xs:simpleType name="char">
+  <xs:annotation>
+    <xs:documentation>
+      A string containing exactly one character.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:string">
+    <xs:length value="1"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="expression">
+  <xs:annotation>
+    <xs:documentation>
+      An XPath 2.0 expression.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:pattern value=".+"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="input-type-annotations-type">
+  <xs:annotation>
+    <xs:documentation>
+      Describes how type annotations in source documents are handled.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:enumeration value="preserve"/>
+    <xs:enumeration value="strip"/>   
+    <xs:enumeration value="unspecified"/>        
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="level">
+  <xs:annotation>
+    <xs:documentation>
+      The level attribute of xsl:number: 
+      one of single, multiple, or any.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:NCName">
+    <xs:enumeration value="single"/>
+    <xs:enumeration value="multiple"/>
+    <xs:enumeration value="any"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="mode">
+  <xs:annotation>
+    <xs:documentation>
+      The mode attribute of xsl:apply-templates: 
+      either a QName, or #current, or #default.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:union memberTypes="xsl:QName">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="#default"/>
+        <xs:enumeration value="#current"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:union>
+</xs:simpleType>
+
+<xs:simpleType name="modes">
+  <xs:annotation>
+    <xs:documentation>
+      The mode attribute of xsl:template: 
+      either a list, each member being either a QName or #default;
+      or the value #all
+    </xs:documentation>
+  </xs:annotation>
+  <xs:union>
+    <xs:simpleType>
+      <xs:list>
+        <xs:simpleType>
+          <xs:union memberTypes="xsl:QName">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="#default"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:list>
+    </xs:simpleType>
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="#all"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:union>
+</xs:simpleType>
+
+<xs:simpleType name="nametests">
+  <xs:annotation>
+    <xs:documentation>
+      A list of NameTests, as defined in the XPath 2.0 Recommendation.
+      Each NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
+    </xs:documentation>
+  </xs:annotation>
+  <xs:list>
+    <xs:simpleType>
+      <xs:union memberTypes="xsl:QName">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="*"/>
+          </xs:restriction>
+        </xs:simpleType>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:pattern value="\i\c*:\*"/>
+            <xs:pattern value="\*:\i\c*"/>            
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+  </xs:list>
+</xs:simpleType>
+
+<xs:simpleType name="prefixes">
+  <xs:list itemType="xs:NCName"/>
+</xs:simpleType>
+
+<xs:simpleType name="prefix-list-or-all">
+  <xs:union memberTypes="xsl:prefix-list">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="#all"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:union>
+</xs:simpleType>
+      
+<xs:simpleType name="prefix-list">
+  <xs:list itemType="xsl:prefix-or-default"/>
+</xs:simpleType>
+
+<xs:simpleType name="method">
+  <xs:annotation>
+    <xs:documentation>
+      The method attribute of xsl:output:
+      Either one of the recognized names "xml", "xhtml", "html", "text",
+      or a QName that must include a prefix.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:union>
+    <xs:simpleType>
+      <xs:restriction base="xs:NCName">
+        <xs:enumeration value="xml"/>
+        <xs:enumeration value="xhtml"/>
+        <xs:enumeration value="html"/>
+        <xs:enumeration value="text"/>
+      </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType>
+      <xs:restriction base="xsl:QName">
+        <xs:pattern value="\c*:\c*"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:union>
+</xs:simpleType>
+
+<xs:simpleType name="pattern">
+  <xs:annotation>
+    <xs:documentation>
+      A match pattern as defined in the XSLT 2.0 Recommendation.
+      The syntax for patterns is a restricted form of the syntax for
+      XPath 2.0 expressions.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xsl:expression"/>
+</xs:simpleType>
+
+<xs:simpleType name="prefix-or-default">
+  <xs:annotation>
+    <xs:documentation>
+      Either a namespace prefix, or #default.
+      Used in the xsl:namespace-alias element.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:union memberTypes="xs:NCName">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="#default"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:union>
+</xs:simpleType>
+
+<xs:simpleType name="QNames">
+  <xs:annotation>
+    <xs:documentation>
+      A list of QNames.
+      Used in the [xsl:]use-attribute-sets attribute of various elements,
+      and in the cdata-section-elements attribute of xsl:output
+    </xs:documentation>
+  </xs:annotation>
+  <xs:list itemType="xsl:QName"/>          
+</xs:simpleType>
+
+<xs:simpleType name="QName">
+  <xs:annotation>
+    <xs:documentation>
+      A QName.
+      This schema does not use the built-in type xs:QName, but rather defines its own
+      QName type. Although xs:QName would define the correct validation on these attributes,
+      a schema processor would expand unprefixed QNames incorrectly when constructing the PSVI,
+      because (as defined in XML Schema errata) an unprefixed xs:QName is assumed to be in
+      the default namespace, which is not the correct assumption for XSLT.
+      The data type is defined as a restriction of the built-in type Name, restricted
+      so that it can only contain one colon which must not be the first or last character.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:Name">
+    <xs:pattern value="([^:]+:)?[^:]+"/>      
+  </xs:restriction>        
+</xs:simpleType>
+
+<xs:simpleType name="sequence-type">
+  <xs:annotation>
+    <xs:documentation>
+      The description of a data type, conforming to the
+      SequenceType production defined in the XPath 2.0 Recommendation
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:pattern value=".+"/>      
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="uri-list">
+  <xs:list itemType="xs:anyURI"/>
+</xs:simpleType>
+
+<xs:simpleType name="validation-strip-or-preserve">
+  <xs:annotation>
+    <xs:documentation>
+      Describes different ways of type-annotating an element or attribute.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xsl:validation-type">
+    <xs:enumeration value="preserve"/>
+    <xs:enumeration value="strip"/>    
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="validation-type">
+  <xs:annotation>
+    <xs:documentation>
+      Describes different ways of type-annotating an element or attribute.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:enumeration value="strict"/>
+    <xs:enumeration value="lax"/>
+    <xs:enumeration value="preserve"/>
+    <xs:enumeration value="strip"/>    
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="yes-or-no">
+  <xs:annotation>
+    <xs:documentation>
+      One of the values "yes" or "no".
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:enumeration value="yes"/>
+    <xs:enumeration value="no"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="yes-or-no-or-omit">
+  <xs:annotation>
+    <xs:documentation>
+      One of the values "yes" or "no" or "omit".
+    </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token">
+    <xs:enumeration value="yes"/>
+    <xs:enumeration value="no"/>
+    <xs:enumeration value="omit"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
These were removed in:

http://hg.netbeans.org/releases/rev/905ace65e3d3?revcount=1500

and there is no reason not to ship them (there are other w3c licensed files already in the repository)