### PR TITLE
[NETBEANS-224] Fixing handling of methods without names; stripping th…

### DIFF
--- a/java.editor.base/nbproject/project.xml
+++ b/java.editor.base/nbproject/project.xml
@@ -197,6 +197,10 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.java.source.base</code-name-base>
                         <recursive/>
                         <compile-dependency/>

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
@@ -140,7 +140,8 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
         //detect caret inside the return type or throws clause:
         if (typePath != null && typePath.getParentPath().getLeaf().getKind() == Kind.METHOD) {
             //hopefully found something, check:
-            MethodTree decl = (MethodTree) typePath.getParentPath().getLeaf();
+            TreePath declPath = typePath.getParentPath();
+            MethodTree decl = (MethodTree) declPath.getLeaf();
             Tree type = decl.getReturnType();
 
             if (   node.getBoolean(MarkOccurencesSettingsNames.EXIT, true)
@@ -150,7 +151,7 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
                 setExitDetector(med);
 
                 try {
-                    return med.process(info, doc, decl, null);
+                    return med.process(info, doc, declPath, null);
                 } finally {
                     setExitDetector(null);
                 }
@@ -164,7 +165,7 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
                     setExitDetector(med);
 
                     try {
-                        return med.process(info, doc, decl, Collections.singletonList(exc));
+                        return med.process(info, doc, declPath, Collections.singletonList(exc));
                     } finally {
                         setExitDetector(null);
                     }
@@ -189,7 +190,7 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
                     try {
                         TreePath tryPath = tu.getPathElementOfKind(Kind.TRY, typePath);
                         if (tryPath != null) {
-                            return med.process(info, doc, ((TryTree)tryPath.getLeaf()).getBlock(), Collections.singletonList(typePath.getLeaf()));
+                            return med.process(info, doc, new TreePath(tryPath, ((TryTree)tryPath.getLeaf()).getBlock()), Collections.singletonList(typePath.getLeaf()));
                         }
                     } finally {
                         setExitDetector(null);

--- a/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
+++ b/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
@@ -63,7 +63,7 @@ public class MethodExitDetector extends CancellableTreePathScanner<Boolean, Stac
     private Collection<TypeMirror> exceptions;
     private Stack<Map<TypeMirror, List<Tree>>> exceptions2HighlightsStack;
     
-    public List<int[]> process(CompilationInfo info, Document document, Tree methoddeclorblock, Collection<Tree> excs) {
+    public List<int[]> process(CompilationInfo info, Document document, TreePath methoddeclorblock, Collection<Tree> excs) {
         this.info = info;
         this.doc  = document;
         this.highlights = new ArrayList<int[]>();
@@ -76,13 +76,13 @@ public class MethodExitDetector extends CancellableTreePathScanner<Boolean, Stac
             //"return" exit point only if not searching for exceptions:
             doExitPoints = excs == null;
             
-            Boolean wasReturn = scan(TreePath.getPath(cu, methoddeclorblock), null);
+            Boolean wasReturn = scan(methoddeclorblock, null);
             
             if (isCanceled())
                 return null;
             
             if (doExitPoints && wasReturn != Boolean.TRUE) {
-                int lastBracket = Utilities.findLastBracket(methoddeclorblock, cu, info.getTrees().getSourcePositions(), document);
+                int lastBracket = Utilities.findLastBracket(methoddeclorblock.getLeaf(), cu, info.getTrees().getSourcePositions(), document);
                 
                 if (lastBracket != (-1)) {
                     //highlight the "fall over" exitpoint:

--- a/java.editor.base/test/unit/data/org/netbeans/modules/java/editor/base/semantic/data/ErroneousMethod.java
+++ b/java.editor.base/test/unit/data/org/netbeans/modules/java/editor/base/semantic/data/ErroneousMethod.java
@@ -1,0 +1,5 @@
+package test;
+
+public class ErroneousMethod {
+    public abstract void
+}

--- a/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/MarkOccDetTest.java
+++ b/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/MarkOccDetTest.java
@@ -316,6 +316,10 @@ public class MarkOccDetTest extends TestBase {
         performTest("ExitPoints", 115, 22);
     }
 
+    public void testErroneousMethodNETBEANS_224() throws Exception {
+        performTest("ErroneousMethod", 3, 24);
+    }
+
     //Support for exotic identifiers has been removed 6999438
     public void REMOVEDtestExoticIdentifiers1() throws Exception {
         performTest("ExoticIdentifier", 3, 43);

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -192,4 +192,26 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
         assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
                      createdFiles);
     }
+
+    public void testErroneousMethodClassNETBEANS_224() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test1.java", "package test; public class Test1 { public abstract void }"),
+                                                         compileTuple("test/Test2.java", "package test; public class Test2 { public abstract Object }"),
+                                                         compileTuple("test/Test3.java", "package test; public class Test3 { public abstract class }"),
+                                                         compileTuple("test/Test4.java", "package test; public class ")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test1.sig",
+                                                       "cache/s1/java/15/classes/test/Test2.sig",
+                                                       "cache/s1/java/15/classes/test/Test3.sig")),
+                     createdFiles);
+    }
 }


### PR DESCRIPTION
…e broken methods from the source, not using TreePath.getPath as it uses the not-error aware TreePathScanner (as is slow anyway).