### PR TITLE
Cleanup javac warnings and xmlcatalog in nbbuild

### DIFF
--- a/core.startup.base/arch.xml
+++ b/core.startup.base/arch.xml
@@ -599,7 +599,6 @@
           limited dependencies - e.g. only module system and filesystem API.
           </p>
       </api>
-      </api>
   </p>
  </answer>
 

--- a/dbapi/arch.xml
+++ b/dbapi/arch.xml
@@ -131,6 +131,7 @@
     In particular, this feature is used to register database support modules
     that want to register a node for managing a local server.  
     </p>
+  </usecase>
   <usecase id="registering-actions" name="Registering actions in the Database Explorer">
    <p>
     This feature allows modules to add actions to the Datbase Explorer under
@@ -138,6 +139,7 @@
     an implementation of the <code>ActionProvider</code> interface in
     the <code>Databases/ActionProviders</code> folder of the system file system.
     </p>
+  </usecase>
   <usecase id="sql-keywords" name="Determining whether an identifier is an SQL-99 keyword">
    <p>
     The SQL editor and the J2EE verifier need to determine whether an identifier

--- a/dbschema/arch.xml
+++ b/dbschema/arch.xml
@@ -19,12 +19,11 @@
     under the License.
 
 -->
-<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "${nbroot}/nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
-  <!ENTITY api-questions SYSTEM "${nbroot}/nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
 ]>
 
 <api-answers
-  version="$Revision$" date="$date$"
   question-version="1.7"
   author="rnajman@netbeans.org"
 >

--- a/j2ee.core.utilities/arch.xml
+++ b/j2ee.core.utilities/arch.xml
@@ -174,8 +174,7 @@
    Several classes exposed in the friend APIs of the j2ee/utilities and j2ee/persistence 
    modules will be removed and all their clients will need to be changed to use the new module instead.
  </p>
- <p>
-     The following classes will be removed:
+ <p>The following classes will be removed:</p>
      <ul>
          <li>o.n.m.j2ee.common.source.GenarationUtils</li>
          <li>o.n.m.j2ee.common.source.SourceUtils</li>
@@ -195,7 +194,6 @@
          <li>o.n.m.j2ee.persistence.wizard.Util#mergeSteps(WizardDescriptor, WizardDescriptor.Panel[], String[])</li>
          <li>o.n.m.j2ee.persistence.wizard.Util#String simpleClassName(String)</li>
      </ul>
-  </p>
  </answer>
 
 

--- a/maven/arch.xml
+++ b/maven/arch.xml
@@ -291,7 +291,7 @@
              One can define following code in nbactions.xml file to start
              a process during goal execution and attach a debugger to it
              when the external process prints a text indicating it's ready for attaching debugger. 
-                 One example is debugging applications using <a href="https://software.intel.com/en-us/multi-os-engine" target="_blank" >Multi-OS Engine</a>:
+                 One example is debugging applications using <a href="https://software.intel.com/en-us/multi-os-engine">Multi-OS Engine</a>:
              </p>
 <pre>
     &lt;action&gt;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
@@ -210,7 +210,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
         if (generateTemplate) {
             log ("Input file " + questionsFile + " does not exist. Generating it with skeleton answers.");
             try {
-                SortedSet<String> s = new TreeSet<String>(questions.keySet());
+                SortedSet<String> s = new TreeSet<>(questions.keySet());
                 generateTemplateFile(questionsVersion, s);
             } catch (IOException ex) {
                 throw new BuildException (ex);
@@ -250,7 +250,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
         
         {
             // check all answers have their questions
-            SortedSet<String> s = new TreeSet<String>(questions.keySet());
+            SortedSet<String> s = new TreeSet<>(questions.keySet());
             s.removeAll (answers.keySet ());
             if (!s.isEmpty()) {
                 if ("true".equals (this.getProject().getProperty ("arch.generate"))) {
@@ -615,7 +615,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
     }
 
     private static Map<String,Element> readElements (Document q, String name) {
-        Map<String,Element> map = new HashMap<String,Element>();
+        Map<String,Element> map = new HashMap<>();
        
         NodeList list = q.getElementsByTagName(name);
         for (int i = 0; i < list.getLength(); i++) {
@@ -682,7 +682,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
     
     private static Set<String> localDTDs;
     static {
-        localDTDs = new HashSet<String>();
+        localDTDs = new HashSet<>();
         localDTDs.add("Arch.dtd");
         localDTDs.add("Arch-api-questions.xml");
         localDTDs.add("xhtml1-strict.dtd");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
@@ -261,9 +261,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
                     qSource = new StreamSource (questionsFile);
                     try {
                         q = builder.parse(questionsFile);
-                    } catch (IOException ex) {
-                        throw new BuildException(ex);
-                    } catch (SAXException ex) {
+                    } catch (IOException | SAXException ex) {
                         throw new BuildException(ex);
                     }
                 } else {
@@ -405,9 +403,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
                         TransformerFactory fack = TransformerFactory.newInstance();
                         Transformer t = fack.newTransformer(defXSL);
                         t.transform(prjSrc, res);
-                    } catch (IOException ex) {
-                        throw new BuildException (ex);
-                    } catch (TransformerException ex) {
+                    } catch (IOException | TransformerException ex) {
                         throw new BuildException (ex);
                     }
                     
@@ -503,11 +499,7 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
                 }
                 t.transform(qSource, r);
             }
-        } catch (IOException ex) {
-            throw new BuildException (ex);
-        } catch (TransformerConfigurationException ex) {
-            throw new BuildException (ex);
-        } catch (TransformerException ex) {
+        } catch (IOException | TransformerException ex) {
             throw new BuildException (ex);
         }
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -67,7 +67,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 public class AutoUpdate extends Task {
-    private List<Modules> modules = new ArrayList<Modules>();
+    private List<Modules> modules = new ArrayList<>();
     private FileSet nbmSet;
     private File download;
     private File dir;
@@ -134,7 +134,7 @@ public class AutoUpdate extends Task {
             }
             DirectoryScanner s = nbmSet.getDirectoryScanner(getProject());
             File basedir = s.getBasedir();
-            units = new HashMap<String, ModuleItem>();
+            units = new HashMap<>();
             for (String incl : s.getIncludedFiles()) {
                 File nbm = new File(basedir, incl);
                 try {
@@ -487,7 +487,7 @@ public class AutoUpdate extends Task {
     }
 
     private Map<String,List<String>> findExistingModules(File... clusters) {
-        Map<String,List<String>> all = new HashMap<String, List<String>>();
+        Map<String,List<String>> all = new HashMap<>();
         for (File c : clusters) {
             File mc = new File(c, "update_tracking");
             final File[] arr = mc.listFiles();
@@ -541,7 +541,7 @@ public class AutoUpdate extends Task {
                     if (name == null || version == null) {
                         throw new BuildException("Cannot find version in " + config);
                     }
-                    arr = new ArrayList<String>();
+                    arr = new ArrayList<>();
                     arr.add(version);
                     toAdd.put(name, arr);
                     return;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -431,9 +431,7 @@ public class AutoUpdate extends Task {
             //https://netbeans.org/bugzilla/show_bug.cgi?id=119861
             result = process.waitFor();
             process.destroy();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
         return result == 0;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -256,8 +256,7 @@ public class AutoUpdate extends Task {
                 module_version.setAttribute("origin", "Ant"); // XXX set to URL origin
                 module_version.setAttribute("specification_version", uu.getSpecVersion());
 
-                JarFile  zf = new JarFile(tmp);
-                try {
+                try (JarFile zf = new JarFile(tmp)) {
                 Manifest manifest = zf.getManifest();
                 if (manifest == null || manifest.getMainAttributes().getValue("Bundle-SymbolicName") == null) { // regular NBM
                 Enumeration<? extends ZipEntry> en = zf.entries();
@@ -326,21 +325,17 @@ public class AutoUpdate extends Task {
                     String relName = "config/Modules/" + dash + ".xml";
                     File configModulesXml = new File(whereTo, relName);
                     configModulesXml.getParentFile().mkdirs();
-                    PrintWriter w = new PrintWriter(configModulesXml);
-                    try {
+                    try (PrintWriter w = new PrintWriter(configModulesXml)) {
                         w.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE module PUBLIC \"-//NetBeans//DTD Module Status 1.0//EN\"\n                        \"http://www.netbeans.org/dtds/module-status-1_0.dtd\">\n<module name=\"");
                         w.print(uu.getCodeName());
                         w.print("\">\n    <param name=\"autoload\">true</param>\n    <param name=\"eager\">false</param>\n    <param name=\"jar\">modules/");
                         w.print(dash);
                         w.print(".jar</param>\n    <param name=\"reloadable\">false</param>\n</module>\n");
-                    } finally {
-                        w.close();
                     }
                     Element file = (Element) module_version.appendChild(doc.createElement("file"));
                     file.setAttribute("crc", String.valueOf(getFileCRC(configModulesXml)));
                     file.setAttribute("name", relName);
                     relName = "modules/" + dash + ".jar";
-                    zf.close();
                     File bundle = new File(whereTo, relName);
                     bundle.getParentFile().mkdirs();
                     FileUtils.getFileUtils().copyFile(tmp, bundle);
@@ -348,8 +343,6 @@ public class AutoUpdate extends Task {
                     file.setAttribute("crc", String.valueOf(getFileCRC(bundle)));
                     file.setAttribute("name", relName);
                 }
-                } finally {
-                    zf.close();
                 }
                 File tracking = new File(new File(whereTo, "update_tracking"), dash + ".xml");
                 log("Writing tracking file " + tracking, Project.MSG_VERBOSE);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
@@ -131,7 +131,7 @@ class AutoUpdateCatalogParser extends DefaultHandler {
     private static URI cacheURI;
     synchronized static Map<String, ModuleItem> getUpdateItems (URL url, URL provider, Task task) throws IOException {
 
-        Map<String, ModuleItem> items = new HashMap<String, ModuleItem> ();
+        Map<String, ModuleItem> items = new HashMap<> ();
         URI base;
         try {
             if (provider != null) {
@@ -204,12 +204,12 @@ class AutoUpdateCatalogParser extends DefaultHandler {
         return src;
     }
     
-    private Stack<String> currentGroup = new Stack<String> ();
+    private Stack<String> currentGroup = new Stack<> ();
     private String catalogDate;
-    private Stack<ModuleDescriptor> currentModule = new Stack<ModuleDescriptor> ();
-    private Stack<Map <String,String>> currentLicense = new Stack<Map <String,String>> ();
-    private Stack<String> currentNotificationUrl = new Stack<String> ();
-    private List<String> lines = new ArrayList<String> ();
+    private Stack<ModuleDescriptor> currentModule = new Stack<> ();
+    private Stack<Map <String,String>> currentLicense = new Stack<> ();
+    private Stack<String> currentNotificationUrl = new Stack<> ();
+    private List<String> lines = new ArrayList<> ();
     private int bufferInitSize = 0;
 
     @Override
@@ -355,7 +355,7 @@ class AutoUpdateCatalogParser extends DefaultHandler {
                 ERR.info ("Not supported yet.");
                 break;
             case license :
-                Map <String, String> map = new HashMap<String,String> ();
+                Map <String, String> map = new HashMap<> ();
                 map.put(attributes.getValue (LICENSE_ATTR_NAME), attributes.getValue (LICENSE_ATTR_URL));
                 currentLicense.push (map);
                 break;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
@@ -508,9 +508,7 @@ class AutoUpdateCatalogParser extends DefaultHandler {
                     }
                 }
                 retval = distributionURI.toURL ();
-            } catch (MalformedURLException ex) {
-                ERR.log (Level.INFO, null, ex);
-            } catch (URISyntaxException ex) {
+            } catch (MalformedURLException | URISyntaxException ex) {
                 ERR.log (Level.INFO, null, ex);
             }
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
@@ -54,8 +54,6 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class CheckBundles extends Task {
     
-    private static HashSet knownKeys;    
-    
     private static String [] moduleKeys = new String [] {
         "OpenIDE-Module-Name",
         "OpenIDE-Module-Display-Category",

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckBundles.java
@@ -79,8 +79,8 @@ public class CheckBundles extends Task {
 
         Map<String,File> knownNames = parseManifest(srcdir);
 
-        Collection<File> bundles = new ArrayList<File>();
-        Map<File,String[]> sources = new TreeMap<File,String[]>();
+        Collection<File> bundles = new ArrayList<>();
+        Map<File,String[]> sources = new TreeMap<>();
 
 
         try {        
@@ -217,7 +217,7 @@ public class CheckBundles extends Task {
      * Get a list of keys in a bundle file, with accompanying line numbers.
      */
     private Map<String,Integer> entries(File bundle) throws IOException {
-        Map<String,Integer> entries = new LinkedHashMap<String,Integer>();
+        Map<String,Integer> entries = new LinkedHashMap<>();
         BufferedReader r = new BufferedReader (new FileReader (bundle));
         String l;
         boolean multi = false;
@@ -241,7 +241,7 @@ public class CheckBundles extends Task {
     }
 
     private Map<String,File> parseManifest(File dir) {
-        Map<String,File> files = new HashMap<String,File>(10);
+        Map<String,File> files = new HashMap<>(10);
         try {
             File mf = new File(srcdir, "manifest.mf");
             if (!mf.exists()) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
@@ -80,9 +80,7 @@ public class CheckHelpSets extends Task {
     }
     
     public void execute() throws BuildException {
-        Iterator it = filesets.iterator();
-        while (it.hasNext()) {
-            FileSet fs = (FileSet)it.next();
+        for(FileSet fs: filesets) {
             FileScanner scanner = fs.getDirectoryScanner(getProject());
             File dir = scanner.getBasedir();
             String[] files = scanner.getIncludedFiles();
@@ -122,12 +120,13 @@ public class CheckHelpSets extends Task {
         log("Checking for duplicate map IDs...");
         HelpSet.parse(hsfile.toURI().toURL(), null, new VerifyHSFactory());
         log("Checking links from help map and between HTML files...");
-        Enumeration e = map.getAllIDs();
+        @SuppressWarnings("unchecked")
+        Enumeration<javax.help.Map.ID> e = map.getAllIDs();
         Set<URI> okurls = new HashSet<>(1000);
         Set<URI> badurls = new HashSet<>(1000);
         Set<URI> cleanurls = new HashSet<>(1000);
         while (e.hasMoreElements()) {
-            javax.help.Map.ID id = (javax.help.Map.ID)e.nextElement();
+            javax.help.Map.ID id = e.nextElement();
             URL u = map.getURLFromID(id);
             if (u == null) {
                 throw new BuildException("Bogus map ID: " + id.id, new Location(hsfile.getAbsolutePath()));
@@ -158,7 +157,8 @@ public class CheckHelpSets extends Task {
         
         // The useful method:
         
-        public TreeItem createItem(String str, Hashtable hashtable, HelpSet helpSet, Locale locale) {
+        @Override
+        public TreeItem createItem(String str, @SuppressWarnings("rawtypes") Hashtable hashtable, HelpSet helpSet, Locale locale) {
             String target = (String)hashtable.get("target");
             if (target != null) {
                 if (! map.isValidID(target, hs)) {
@@ -172,20 +172,25 @@ public class CheckHelpSets extends Task {
         
         // Filler methods:
         
-        public Enumeration listMessages() {
+        @Override
+        public @SuppressWarnings("rawtypes") Enumeration listMessages() {
             return Collections.enumeration(Collections.<String>emptyList());
         }
         
+        @Override
         public void processPI(HelpSet helpSet, String str, String str2) {
         }
         
+        @Override
         public void reportMessage(String str, boolean param) {
             log(str, param ? Project.MSG_VERBOSE : Project.MSG_WARN);
         }
         
+        @Override
         public void processDOCTYPE(String str, String str1, String str2) {
         }
         
+        @Override
         public void parsingStarted(URL uRL) {
         }
         
@@ -193,6 +198,7 @@ public class CheckHelpSets extends Task {
             return defaultMutableTreeNode;
         }
         
+        @Override
         public TreeItem createItem() {
             if (toc) {
                 return new TOCItem();
@@ -205,9 +211,10 @@ public class CheckHelpSets extends Task {
     
     private final class VerifyHSFactory extends HelpSet.DefaultHelpSetFactory {
         
-        private Set<String> ids = new HashSet<>(1000);
+        private final Set<String> ids = new HashSet<>(1000);
         
-        public void processMapRef(HelpSet hs, Hashtable attrs) {
+        @Override
+        public void processMapRef(HelpSet hs, @SuppressWarnings("rawtypes") Hashtable attrs) {
             try {
                 URL map = new URL(hs.getHelpSetURL(), (String)attrs.get("location"));
                 SAXParserFactory factory = SAXParserFactory.newInstance();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSets.java
@@ -69,7 +69,7 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class CheckHelpSets extends Task {
     
-    private List<FileSet> filesets = new ArrayList<FileSet>();
+    private List<FileSet> filesets = new ArrayList<>();
     
     /** Add a fileset with one or more helpsets in it.
      * <strong>Only</strong> the <samp>*.hs</samp> should match!
@@ -123,9 +123,9 @@ public class CheckHelpSets extends Task {
         HelpSet.parse(hsfile.toURI().toURL(), null, new VerifyHSFactory());
         log("Checking links from help map and between HTML files...");
         Enumeration e = map.getAllIDs();
-        Set<URI> okurls = new HashSet<URI>(1000);
-        Set<URI> badurls = new HashSet<URI>(1000);
-        Set<URI> cleanurls = new HashSet<URI>(1000);
+        Set<URI> okurls = new HashSet<>(1000);
+        Set<URI> badurls = new HashSet<>(1000);
+        Set<URI> cleanurls = new HashSet<>(1000);
         while (e.hasMoreElements()) {
             javax.help.Map.ID id = (javax.help.Map.ID)e.nextElement();
             URL u = map.getURLFromID(id);
@@ -133,7 +133,7 @@ public class CheckHelpSets extends Task {
                 throw new BuildException("Bogus map ID: " + id.id, new Location(hsfile.getAbsolutePath()));
             }
             log("Checking ID " + id.id, Project.MSG_VERBOSE);
-            List<String> errors = new ArrayList<String>();
+            List<String> errors = new ArrayList<>();
             CheckLinks.scan(this, null, null, id.id, "", 
             u.toURI(), okurls, badurls, cleanurls, false, false, false, 2, 
             Collections.<Mapper>emptyList(), errors);
@@ -205,7 +205,7 @@ public class CheckHelpSets extends Task {
     
     private final class VerifyHSFactory extends HelpSet.DefaultHelpSetFactory {
         
-        private Set<String> ids = new HashSet<String>(1000);
+        private Set<String> ids = new HashSet<>(1000);
         
         public void processMapRef(HelpSet hs, Hashtable attrs) {
             try {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
@@ -97,11 +97,8 @@ public class CheckHelpSetsBin extends Task {
         for (int i = 0; i < files.length; i++) {
             File moduleJar = new File(dir, files[i]);
             Manifest manifest;
-            JarFile jar = new JarFile(moduleJar);
-            try {
+            try (JarFile jar = new JarFile(moduleJar)) {
                 manifest = jar.getManifest();
-            } finally {
-                jar.close();
             }
             if (manifest == null) {
                 log(moduleJar + " has no manifest", Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
@@ -272,9 +272,7 @@ public class CheckHelpSetsBin extends Task {
                     log(error, Project.MSG_WARN);
                 }
                 //System.out.println("RETURN OF CheckLinks.scan");
-            } catch (URISyntaxException ex) {
-                ex.printStackTrace();
-            } catch (IOException ex) {
+            } catch (URISyntaxException | IOException ex) {
                 ex.printStackTrace();
             }
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckHelpSetsBin.java
@@ -73,7 +73,7 @@ import org.xml.sax.SAXException;
  */
 public class CheckHelpSetsBin extends Task {
     
-    private List<FileSet> filesets = new ArrayList<FileSet>();
+    private List<FileSet> filesets = new ArrayList<>();
     
     private Set<String> excludedModulesSet;
     
@@ -93,7 +93,7 @@ public class CheckHelpSetsBin extends Task {
     }
 
     private Map<String,URLClassLoader> createClassLoaderMap(File dir, String[] files) throws IOException {
-        Map<String,URLClassLoader> m = new TreeMap<String,URLClassLoader>();
+        Map<String,URLClassLoader> m = new TreeMap<>();
         for (int i = 0; i < files.length; i++) {
             File moduleJar = new File(dir, files[i]);
             Manifest manifest;
@@ -121,7 +121,7 @@ public class CheckHelpSetsBin extends Task {
         if (prop == null) {
             return Collections.emptySet();
         }
-        return new HashSet<String>(Arrays.asList(prop.split(",")));
+        return new HashSet<>(Arrays.asList(prop.split(",")));
     }
     
     public @Override void execute() throws BuildException {
@@ -249,9 +249,9 @@ public class CheckHelpSetsBin extends Task {
         }
         javax.help.Map map = hs.getCombinedMap();
         Enumeration<?> e = map.getAllIDs();
-        Set<URI> okurls = new HashSet<URI>(1000);
-        Set<URI> badurls = new HashSet<URI>(1000);
-        Set<URI> cleanurls = new HashSet<URI>(1000);
+        Set<URI> okurls = new HashSet<>(1000);
+        Set<URI> badurls = new HashSet<>(1000);
+        Set<URI> cleanurls = new HashSet<>(1000);
         while (e.hasMoreElements()) {
             javax.help.Map.ID id = (javax.help.Map.ID)e.nextElement();
             URL u = null;
@@ -267,7 +267,7 @@ public class CheckHelpSetsBin extends Task {
             log("Checking ID " + id.id, Project.MSG_VERBOSE);
             try {
                 //System.out.println("CALL OF CheckLinks.scan");
-                List<String> errors = new ArrayList<String>();
+                List<String> errors = new ArrayList<>();
                 CheckLinks.scan(this, globalClassLoader, classLoaderMap, id.id, "",
                 new URI(u.toExternalForm()), okurls, badurls, cleanurls, false, false, false, 2, 
                 Collections.<Mapper>emptyList(), errors);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
@@ -97,8 +97,7 @@ public class CheckLicense extends Task {
                 for (int i = 0; i < files.length; i++) {
                     File f = new File (baseDir, files[i]);
                     //log("Scanning " + f, Project.MSG_VERBOSE);
-                    BufferedReader br = new BufferedReader (new FileReader (f));
-                    try {
+                    try (BufferedReader br = new BufferedReader (new FileReader (f))) {
                         String line;
                         while ((line = br.readLine ()) != null) {
                             if (line.indexOf (fragment) != -1) {
@@ -122,8 +121,6 @@ public class CheckLicense extends Task {
                                 log (msg, Project.MSG_ERR);
                             }
                         }
-                    } finally {
-                        br.close ();
                     }
                 }
             }
@@ -156,10 +153,10 @@ public class CheckLicense extends Task {
                     String workingString = new String(workingArray, 0, workingLength);
                     boolean changed = false;
                     String prefix = null;
-                    
+
                     for (Convert f : fragments) {
                         Matcher matcher = f.orig.matcher(workingString);
-                        
+
                         while (matcher.find()) {
                             if (f.prefix) {
                                 if (prefix != null) {
@@ -170,7 +167,7 @@ public class CheckLicense extends Task {
                                 }
                                 prefix = matcher.group(1);
                             }
-                            
+
                             String before = workingString.substring(0, matcher.start());
                             String after = workingString.substring(matcher.end());
                             String middle = wrapWithPrefix(f.repl, prefix, before.length() == 0 || before.endsWith("\n"));
@@ -182,7 +179,7 @@ public class CheckLicense extends Task {
                             } else {
                                 log("Matched, but no change: " + middle, Project.MSG_VERBOSE);
                             }
-                            
+
                             if (!f.all) {
                                 break;
                             } else {
@@ -190,17 +187,16 @@ public class CheckLicense extends Task {
                             }
                         }
                     }
-                    
+
                     byte[] rest = null;
                     if (is.available() > 0 && changed) {
                         rest = new byte[is.available()];
                         int read = is.read(rest);
                         assert read == rest.length;
                     }
-                    
+
                     is.close();
 
-                    
                     if (changed) {
                         log ("Rewriting " + file);
                         FileOutputStream os = new FileOutputStream(file);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLicense.java
@@ -41,7 +41,7 @@ import org.apache.tools.ant.types.FileSet;
  */
 public class CheckLicense extends Task {
 
-    private final List<FileSet> filesets = new ArrayList<FileSet>(1);
+    private final List<FileSet> filesets = new ArrayList<>(1);
     private String fragment;
     private List<Convert> fragments;
     private FailType fail;
@@ -68,7 +68,7 @@ public class CheckLicense extends Task {
     public Convert createConvert() {
         Convert f = new Convert();
         if (fragments == null) {
-            fragments = new ArrayList<Convert>();
+            fragments = new ArrayList<>();
         }
         
         fragments.add(f);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -46,8 +46,8 @@ public class CheckLinks extends MatchingTask {
     private boolean checkexternal = true;
     private boolean checkspaces = true;
     private boolean checkforbidden = true;
-    private List<Mapper> mappers = new LinkedList<Mapper>();
-    private List<Filter> filters = new ArrayList<Filter>();
+    private List<Mapper> mappers = new LinkedList<>();
+    private List<Filter> filters = new ArrayList<>();
     private File report;
 
     /** Set whether to check external links (absolute URLs).
@@ -106,10 +106,10 @@ public class CheckLinks extends MatchingTask {
         if (! checkexternal) message += " (external URLs will be skipped)";
         log (message);
         String[] files = scanner.getIncludedFiles ();
-        Set<URI> okurls = new HashSet<URI>(1000);
-        Set<URI> badurls = new HashSet<URI>(100);
-        Set<URI> cleanurls = new HashSet<URI>(100);
-        List<String> errors = new ArrayList<String>();
+        Set<URI> okurls = new HashSet<>(1000);
+        Set<URI> badurls = new HashSet<>(100);
+        Set<URI> cleanurls = new HashSet<>(100);
+        List<String> errors = new ArrayList<>();
         for (int i = 0; i < files.length; i++) {
             File file = new File (basedir, files[i]);
             URI fileurl = file.toURI();
@@ -449,7 +449,7 @@ public class CheckLinks extends MatchingTask {
         // map from other URIs (hrefs) to line/col info where they occur in this file (format: ":1:2")
         Map<URI,String> others = null;
         if (recurse > 0 && cleanurls.add(base)) {
-            others = new HashMap<URI,String>(100);
+            others = new HashMap<>(100);
         }
         if (recurse == 0 && frag == null) {
             // That is all we wanted to check.
@@ -458,7 +458,7 @@ public class CheckLinks extends MatchingTask {
         if ("text/html".equals(mimeType)) {
             task.log("Parsing " + base, Project.MSG_VERBOSE);
             Matcher m = hrefOrAnchor.matcher(content);
-            Set<String> names = new HashSet<String>(100); // Set<String>
+            Set<String> names = new HashSet<>(100); // Set<String>
             while (m.find()) {
                 // Get the stuff involved:
                 String type = m.group(3);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -22,6 +22,7 @@ package org.netbeans.nbbuild;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.regex.*;
 
 import org.apache.tools.ant.BuildException;
@@ -151,7 +152,7 @@ public class CheckLinks extends MatchingTask {
      * @param mappers a list of Mappers to apply to get source files from HTML files
      */
     public static void scan
-    (Task task, ClassLoader globalClassLoader, java.util.Map classLoaderMap,
+    (Task task, ClassLoader globalClassLoader, java.util.Map<String,URLClassLoader> classLoaderMap,
      String referrer, String referrerLocation, 
      URI u, Set<URI> okurls, Set<URI> badurls, Set<URI> cleanurls, 
      boolean checkexternal, boolean checkspaces, boolean checkforbidden, int recurse, 
@@ -161,7 +162,7 @@ public class CheckLinks extends MatchingTask {
     }
     
     private static void scan
-    (Task task, ClassLoader globalClassLoader, java.util.Map classLoaderMap,
+    (Task task, ClassLoader globalClassLoader, java.util.Map<String,URLClassLoader> classLoaderMap,
      String referrer, String referrerLocation, 
      URI u, Set<URI> okurls, Set<URI> badurls, Set<URI> cleanurls,
      boolean checkexternal, boolean checkspaces, boolean checkforbidden, int recurse,
@@ -310,14 +311,12 @@ public class CheckLinks extends MatchingTask {
                         ex.printStackTrace();
                     }
                     //Try to find out module for link
-                    Set keySet = classLoaderMap.keySet();
-                    for (Iterator it1 = keySet.iterator(); it1.hasNext(); ) {
-                        Object key = it1.next();
-                        URLClassLoader cl = (URLClassLoader) classLoaderMap.get(key);
+                    for (Entry<String,URLClassLoader> e: classLoaderMap.entrySet()) {
+                        URLClassLoader cl = e.getValue();
                         if (cl != null) {
                             URL moduleRes = cl.findResource(name);
                             if (moduleRes != null) {
-                                task.log("INFO: Link found in module:" + key + ". URI: " + u, Project.MSG_INFO);
+                                task.log("INFO: Link found in module:" + e.getKey() + ". URI: " + u, Project.MSG_INFO);
                                 task.log("INFO: Referrer: " + referrer, Project.MSG_INFO);
                                 break;
                             }
@@ -337,7 +336,7 @@ public class CheckLinks extends MatchingTask {
                     //System.out.println("name:" + name);
                 }
                 URL res = null;
-                URLClassLoader moduleClassLoader = (URLClassLoader) classLoaderMap.get(toURL(u).getHost());
+                URLClassLoader moduleClassLoader = classLoaderMap.get(toURL(u).getHost());
                 //Log warning
                 if (moduleClassLoader == null) {
                     errors.add("Module " + toURL(u).getHost() + " not found among modules containing helpsets. URI: " + u);
@@ -374,14 +373,12 @@ public class CheckLinks extends MatchingTask {
                             ex.printStackTrace();
                         }
                         //Try to find out module for link
-                        Set keySet = classLoaderMap.keySet();
-                        for (Iterator it1 = keySet.iterator(); it1.hasNext(); ) {
-                            Object key = it1.next();
-                            URLClassLoader cl = (URLClassLoader) classLoaderMap.get(key);
+                        for (Entry<String,URLClassLoader> e: classLoaderMap.entrySet()) {
+                            URLClassLoader cl = e.getValue();
                             if (cl != null) {
                                 URL moduleRes = cl.findResource(name);
                                 if (moduleRes != null) {
-                                    task.log("INFO: Link found in module:" + key + ". URI: " + u, Project.MSG_INFO);
+                                    task.log("INFO: Link found in module:" + e.getKey() + ". URI: " + u, Project.MSG_INFO);
                                     task.log("INFO: Referrer: " + referrer, Project.MSG_INFO);
                                     break;
                                 }
@@ -527,11 +524,9 @@ public class CheckLinks extends MatchingTask {
             badurls.add(u); // #97784
         }
         if (others != null) {
-            Iterator it = others.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry entry = (Map.Entry)it.next();
-                URI other = (URI)entry.getKey();
-                String location = (String)entry.getValue();
+            for(Entry<URI,String> entry: others.entrySet()) {
+                URI other = entry.getKey();
+                String location = entry.getValue();
                 //System.out.println("CALL OF scan basepath:" + basepath + " location:" + location + " other:" + other);
                 scan(task, globalClassLoader, classLoaderMap,
                 basepath, location, other, okurls, badurls, cleanurls, checkexternal, checkspaces, checkforbidden, recurse == 1 ? 0 : 2, mappers, filters, errors);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
@@ -57,7 +57,7 @@ public final class CheckModuleConfigs extends Task {
         File clusterPropertiesFile = new File(nbroot, "nbbuild" + File.separatorChar + "cluster.properties");
         Map<String,Object> properties = getProject().getProperties();
         Map<String,Set<String>> clusters = loadModuleClusters(properties, clusterPropertiesFile);
-        Set<String> allClusterModules = new TreeSet<String>();
+        Set<String> allClusterModules = new TreeSet<>();
         for (Set<String> s : clusters.values()) {
             allClusterModules.addAll(s);
         }
@@ -72,7 +72,7 @@ public final class CheckModuleConfigs extends Task {
         }
         // Verify sorting and overlaps:
         Pattern clusterNamePat = Pattern.compile("nb\\.cluster\\.([^.]+)");
-        Map<String,List<String>> allClusters = new HashMap<String,List<String>>();
+        Map<String,List<String>> allClusters = new HashMap<>();
         for (Map.Entry<String,Object> clusterDef : properties.entrySet()) {
             Matcher m = clusterNamePat.matcher(clusterDef.getKey());
             if (!m.matches()) {
@@ -85,7 +85,7 @@ public final class CheckModuleConfigs extends Task {
         for (Map.Entry<String,List<String>> entry : allClusters.entrySet()) {
             String name = entry.getKey();
             List<String> modules = entry.getValue();
-            Set<String> modulesS = new HashSet<String>(modules);
+            Set<String> modulesS = new HashSet<>(modules);
             if (modulesS.size() < modules.size()) {
                 throw new BuildException("duplicates found in " + name + ": " + modules);
             }
@@ -98,7 +98,7 @@ public final class CheckModuleConfigs extends Task {
                     throw new BuildException("some entries in " + name + " also found in " + other);
                 }
             }
-            List<String> sorted = new ArrayList<String>(modules);
+            List<String> sorted = new ArrayList<>(modules);
             Collections.sort(sorted);
             if (!sorted.equals(modules)) {
                 throw new BuildException("unsorted list for " + name + ": " + modules);
@@ -114,14 +114,14 @@ public final class CheckModuleConfigs extends Task {
         if (list.matches(".*\\s.*|^,.*|.*,$|.*,,.*")) {
             throw new BuildException("remove whitespaces or fix leading/trailing commas in " + what + ": " + list);
         }
-        List<String> r = new ArrayList<String>(Arrays.asList(list.split(",")));
+        List<String> r = new ArrayList<>(Arrays.asList(list.split(",")));
         assert !r.contains(null) : r;
         assert !r.contains("") : r;
         return r;
     }
     private Set<String> splitToSet(String list, String what) {
         List<String> elements = splitToList(list, what);
-        Set<String> set = new HashSet<String>(elements);
+        Set<String> set = new HashSet<>(elements);
         for (String s : set) {
             elements.remove(s);
         }
@@ -137,13 +137,13 @@ public final class CheckModuleConfigs extends Task {
         if (l == null) {
             throw new BuildException(clusterPropertiesFile + ": no definition for clusters.config.full.list");
         }
-        Map<String,Set<String>> clusters = new TreeMap<String,Set<String>>();
+        Map<String,Set<String>> clusters = new TreeMap<>();
         for (String cluster : splitToSet(l, fullConfig)) {
             l = (String) clusterProperties.get(cluster);
             if (l == null) {
                 throw new BuildException(clusterPropertiesFile + ": no definition for " + cluster);
             }
-            clusters.put(cluster, new TreeSet<String>(splitToSet(l, fullConfig)));
+            clusters.put(cluster, new TreeSet<>(splitToSet(l, fullConfig)));
         }
         return clusters;
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
@@ -45,7 +45,7 @@ public class CleanAll extends Task {
     private File [] topdirs = null;
     private boolean resolvedependencies = false; // resolve compile-time dependencies for clean
     private String deptargetprefix = "";  // target prefix for resolving dependencies
-    private Hashtable targets;
+    private Hashtable<String,Target> targets;
     private boolean failonerror = true; // fail if particular module build failed?
     
     /** Comma-separated list of modules to include. */

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CleanAll.java
@@ -38,8 +38,8 @@ import org.apache.tools.ant.taskdefs.Ant;
  */
 public class CleanAll extends Task {
 
-    private List<String> modules = new ArrayList<String>();
-    private List<String> failedmodules = new ArrayList<String>();
+    private List<String> modules = new ArrayList<>();
+    private List<String> failedmodules = new ArrayList<>();
     private String targetname = "clean";
     private File topdir = null;
     private File [] topdirs = null;
@@ -51,7 +51,7 @@ public class CleanAll extends Task {
     /** Comma-separated list of modules to include. */
     public void setModules (String s) {
         StringTokenizer tok = new StringTokenizer (s, ", ");
-        modules = new ArrayList<String>();
+        modules = new ArrayList<>();
         while (tok.hasMoreTokens ())
             modules.add(tok.nextToken());
     }
@@ -111,7 +111,7 @@ public class CleanAll extends Task {
         // Now remove earlier ones: already done.
         @SuppressWarnings("unchecked")
         Vector<Target> doneList = getProject().topoSort(getOwningTarget().getName(), targets);
-        List<Target> todo = new ArrayList<Target>(fullList.subList(0, fullList.indexOf(dummy)));
+        List<Target> todo = new ArrayList<>(fullList.subList(0, fullList.indexOf(dummy)));
         todo.removeAll(doneList.subList(0, doneList.indexOf(getOwningTarget())));
 
         for (Target t : todo) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ConvertClusterPath.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ConvertClusterPath.java
@@ -28,6 +28,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.util.FileUtils;
 
@@ -91,7 +92,7 @@ public class ConvertClusterPath extends Task {
             final Pattern pat = Pattern.compile("(?:.*[\\\\/])?([^/\\\\]*?)([0-9.]+)?[/\\\\]?$");
             Path convPath = new Path(fakeproj);
 
-            for (Iterator it = absPath.iterator(); it.hasNext();) {
+            for (Iterator<Resource> it = absPath.iterator(); it.hasNext();) {
                 FileResource element = (FileResource) it.next();
                 File f = element.getFile();
                 String fPath = f.getAbsolutePath();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
@@ -49,11 +49,8 @@ public class ConvertImport extends Task {
         }
         byte bytes[] = new byte[(int)file.length()];
         try {
-            FileInputStream fis = new FileInputStream(file);
-            try {
+            try (FileInputStream fis = new FileInputStream(file)) {
                 fis.read(bytes);
-            } finally {
-                fis.close();
             }
             String xml = new String(bytes);
             String oldXml = xml;
@@ -95,11 +92,8 @@ public class ConvertImport extends Task {
             } // while 
             if (oldXml != xml) {
                 // changed file
-                PrintStream ps = new PrintStream(file);
-                try {
+                try ( PrintStream ps = new PrintStream(file)) {
                     ps.print(xml);
-                } finally {
-                    ps.close();
                 }
             }
         } catch (IOException ex) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
@@ -124,9 +124,7 @@ public class CopyIcons extends MatchingTask {
     private ImageInfo readImageInfo(File fl) throws IOException {
         Dimension dim = null;
         ImageInfo imageInfo = null;
-        ByteArrayInputStream bais = null;
-        try {
-            bais = readSomeBytes(fl);
+        try (ByteArrayInputStream bais = readSomeBytes(fl)) {
             if (isGIF(bais)) {
                 imageInfo = new ImageInfo(readGIFDimension(bais), ImageInfo.GIF);
             } else if (isPNG(bais)) {
@@ -134,8 +132,6 @@ public class CopyIcons extends MatchingTask {
             }
         } catch (IOException ex) {
             ex.printStackTrace();
-        } finally {
-            bais.close();
         }
         return imageInfo;
     }
@@ -307,69 +303,69 @@ public class CopyIcons extends MatchingTask {
         } catch (FileNotFoundException ex) {
             ex.printStackTrace();
         }
-        PrintWriter pw = new PrintWriter(new BufferedOutputStream(fos));
-        pw.println("<html>");
-        pw.println("<head>");
-        pw.println("<style type=\"text/css\">\nbody { font-family: Tahoma, Verdana, sans-serif }\n</style>");
-        pw.println("</head>");
-        pw.println("<body>");
-        pw.println("<h2>List of icons in NetBeans projects</h2>");
-        pw.println("<h3>NetBeans Source Root: " + baseDir + "<br/>");
-        pw.println("Destination Directory: " + destDir + "</h3>");
-        pw.println("<p style=\"width: 70%\"><b>Description:</b><br/> New Image is image in the Destination Directory, Orig. Image is image in NetBeans Source Root. " +
-                "By replacing the image in Destination Directory under coresponding module and path you can prepare rebranded " +
-                "icons in paralel directory structure and then copy them over to NetBeans Source Root. Orig. Image is " +
-                "in the table just for comparison and reference what image was already changed.</p>");
-        for (Iterator<ProjectIconInfo> iter = prjIconInfoList.iterator(); iter.hasNext(); ) {
-            ProjectIconInfo info = iter.next();
-            if (!showEmpty && info.matchingIcons.size() == 0) {
-                continue;
-            }
-            pw.println("<p>Module name: <b>" + info.prjPath + "</b></p>");
-            pw.println("<p style=\"margin-left: 20px\">");
-            if (info.matchingIcons.size() == 0) {
-                pw.println("<i>--- No icons ---</i>");
-                pw.println("</p>");
-                continue;
-            }
-            pw.println("<table width=\"80%\"border=\"1\" cellpadding=\"3\" cellspacing=\"0\">");
-            pw.println("<tr><td><b>Resource Path</b></td>" +
-                    "<td align=\"center\"><b>&nbsp;New Image&nbsp;</b></td>" +
-                    "<td align=\"center\"><b>&nbsp;Orig. image&nbsp;</b></td>" +
-                    "<td align=\"center\"><b>&nbsp;W x H&nbsp;</b></td>" +
-                    "<td align=\"center\"><b>&nbsp;Extension&nbsp;</b></td>" +
-                    "<td align=\"center\"><b>&nbsp;Real Type&nbsp;</b></td></tr>");
-            for (Iterator<ImageInfo> goodIter = info.matchingIcons.iterator(); goodIter.hasNext(); ) {
-                ImageInfo goodInfo = goodIter.next();
-                String iconPath = goodInfo.getPath();
-                String copiedIconPath = info.prjPath + File.separator + iconPath;
-                String originalIconPath = baseDir.getAbsolutePath() + File.separator + info.prjPath + File.separator + iconPath;
-                pw.println("<tr>");
-                pw.println("<td>");
-                pw.println("<a href=\"" + copiedIconPath + "\">" + iconPath + "</a>");
-                pw.println("</td>");
-                pw.println("<td align=\"center\">");
-                pw.println("<img src=\"" + copiedIconPath + "\"/>"); // copied image
-                pw.println("</td>");
-                pw.println("<td align=\"center\">");
-                pw.println("<img src=\"file://" + originalIconPath + "\"/>"); // original image
-                pw.println("</td>");
-                pw.println("<td align=\"center\">" + goodInfo.getWidth() + " x " + goodInfo.getHeight() + "</td>");
-                pw.println("<td align=\"center\">" + goodInfo.getExt().toUpperCase() + "</td>");
-                if (!goodInfo.getExt().equalsIgnoreCase(goodInfo.getType())) {
-                    pw.println("<td align=\"center\"><font color=\"Orange\">" + goodInfo.getType() + "</font></td>");
-                } else {
-                    pw.println("<td align=\"center\">" + goodInfo.getType() + "</td>");
+        try (PrintWriter pw = new PrintWriter(new BufferedOutputStream(fos))) {
+            pw.println("<html>");
+            pw.println("<head>");
+            pw.println("<style type=\"text/css\">\nbody { font-family: Tahoma, Verdana, sans-serif }\n</style>");
+            pw.println("</head>");
+            pw.println("<body>");
+            pw.println("<h2>List of icons in NetBeans projects</h2>");
+            pw.println("<h3>NetBeans Source Root: " + baseDir + "<br/>");
+            pw.println("Destination Directory: " + destDir + "</h3>");
+            pw.println("<p style=\"width: 70%\"><b>Description:</b><br/> New Image is image in the Destination Directory, Orig. Image is image in NetBeans Source Root. " +
+                    "By replacing the image in Destination Directory under coresponding module and path you can prepare rebranded " +
+                    "icons in paralel directory structure and then copy them over to NetBeans Source Root. Orig. Image is " +
+                    "in the table just for comparison and reference what image was already changed.</p>");
+            for (Iterator<ProjectIconInfo> iter = prjIconInfoList.iterator(); iter.hasNext(); ) {
+                ProjectIconInfo info = iter.next();
+                if (!showEmpty && info.matchingIcons.size() == 0) {
+                    continue;
                 }
-                pw.println("</tr>");
+                pw.println("<p>Module name: <b>" + info.prjPath + "</b></p>");
+                pw.println("<p style=\"margin-left: 20px\">");
+                if (info.matchingIcons.size() == 0) {
+                    pw.println("<i>--- No icons ---</i>");
+                    pw.println("</p>");
+                    continue;
+                }
+                pw.println("<table width=\"80%\"border=\"1\" cellpadding=\"3\" cellspacing=\"0\">");
+                pw.println("<tr><td><b>Resource Path</b></td>" +
+                        "<td align=\"center\"><b>&nbsp;New Image&nbsp;</b></td>" +
+                        "<td align=\"center\"><b>&nbsp;Orig. image&nbsp;</b></td>" +
+                        "<td align=\"center\"><b>&nbsp;W x H&nbsp;</b></td>" +
+                        "<td align=\"center\"><b>&nbsp;Extension&nbsp;</b></td>" +
+                        "<td align=\"center\"><b>&nbsp;Real Type&nbsp;</b></td></tr>");
+                for (Iterator<ImageInfo> goodIter = info.matchingIcons.iterator(); goodIter.hasNext(); ) {
+                    ImageInfo goodInfo = goodIter.next();
+                    String iconPath = goodInfo.getPath();
+                    String copiedIconPath = info.prjPath + File.separator + iconPath;
+                    String originalIconPath = baseDir.getAbsolutePath() + File.separator + info.prjPath + File.separator + iconPath;
+                    pw.println("<tr>");
+                    pw.println("<td>");
+                    pw.println("<a href=\"" + copiedIconPath + "\">" + iconPath + "</a>");
+                    pw.println("</td>");
+                    pw.println("<td align=\"center\">");
+                    pw.println("<img src=\"" + copiedIconPath + "\"/>"); // copied image
+                    pw.println("</td>");
+                    pw.println("<td align=\"center\">");
+                    pw.println("<img src=\"file://" + originalIconPath + "\"/>"); // original image
+                    pw.println("</td>");
+                    pw.println("<td align=\"center\">" + goodInfo.getWidth() + " x " + goodInfo.getHeight() + "</td>");
+                    pw.println("<td align=\"center\">" + goodInfo.getExt().toUpperCase() + "</td>");
+                    if (!goodInfo.getExt().equalsIgnoreCase(goodInfo.getType())) {
+                        pw.println("<td align=\"center\"><font color=\"Orange\">" + goodInfo.getType() + "</font></td>");
+                    } else {
+                        pw.println("<td align=\"center\">" + goodInfo.getType() + "</td>");
+                    }
+                    pw.println("</tr>");
+                }
+                pw.println("</table>");
+                pw.println("</p>");
             }
-            pw.println("</table>");
-            pw.println("</p>");
+            pw.println("</body>");
+            pw.println("</html>");
+            pw.flush();
         }
-        pw.println("</body>");
-        pw.println("</html>");
-        pw.flush();
-        pw.close();
         log("---> Report was written to file: " + reportFile.getAbsolutePath());
     }
         

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CopyIcons.java
@@ -64,8 +64,8 @@ import org.apache.tools.ant.types.FileSet;
 public class CopyIcons extends MatchingTask {
     
     private int depth = 0;
-    private List<File> projectDirList = new ArrayList<File>();
-    private List<ProjectIconInfo> prjIconInfoList = new ArrayList<ProjectIconInfo>();
+    private List<File> projectDirList = new ArrayList<>();
+    private List<ProjectIconInfo> prjIconInfoList = new ArrayList<>();
     
     File baseDir = null;
     public void setNbsrcroot(File f) {
@@ -475,8 +475,8 @@ public class CopyIcons extends MatchingTask {
         ds.scan();
         String[] files = ds.getIncludedFiles();
         log("    Found " + files.length + " files in " + f);
-        List<ImageInfo> goodIcons = new ArrayList<ImageInfo>();
-        List<ImageInfo> badIcons = new ArrayList<ImageInfo>();
+        List<ImageInfo> goodIcons = new ArrayList<>();
+        List<ImageInfo> badIcons = new ArrayList<>();
         for (String file : files) {
             String ext = file.substring(file.lastIndexOf('.') + 1);
             if (ext.equalsIgnoreCase("gif") || ext.equalsIgnoreCase("png")) {
@@ -506,7 +506,7 @@ public class CopyIcons extends MatchingTask {
     }
     
     private String[] getAsArray(String s) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (StringTokenizer stok = new StringTokenizer(s, ","); stok.hasMoreTokens(); ) {
           String token = stok.nextToken().trim();
           list.add(token);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
@@ -215,8 +215,7 @@ public class CreateModuleXML extends Task {
             throw new BuildException("Only *.jar may be listed, check the fileset: " + module, getLocation());
         }
         try {
-            JarFile jar = new JarFile(module);
-            try {
+            try (JarFile jar = new JarFile(module)) {
                 Manifest m = jar.getManifest();
                 Attributes attr = null;
                 String codename = null;
@@ -263,15 +262,12 @@ public class CreateModuleXML extends Task {
                             if (!moduleloc.isFile()) {
                                 throw new BuildException("Expecting localizing bundle: " + bundle + " in: " + module);
                             }
-                            JarFile jarloc = new JarFile(moduleloc);
-                            try {
+                            try (JarFile jarloc = new JarFile(moduleloc)) {
                                 ZipEntry entry2 = jarloc.getEntry(bundle);
                                 if (entry2 == null) {
                                     throw new BuildException("Expecting localizing bundle: " + bundle + " in: " + module);
                                 }
                                 is = jarloc.getInputStream(entry2);
-                            } finally {
-                                jarloc.close();
                             }
                         }
                         try {
@@ -297,8 +293,7 @@ public class CreateModuleXML extends Task {
                     File h = new File(xml.getParentFile(), xml.getName() + "_hidden");
                     h.createNewFile();
                 } else {
-                    OutputStream os = new FileOutputStream(xml);
-                    try {
+                    try (OutputStream os = new FileOutputStream(xml)) {
                         PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
                         // Please make sure formatting matches what the IDE actually spits
                         // out; it could matter.
@@ -325,15 +320,11 @@ public class CreateModuleXML extends Task {
                         pw.println("</module>");
                         pw.flush();
                         pw.close();
-                    } finally {
-                        os.close();
                     }
                     if (v != null) {
                         v.addFileForRoot(xml);
                     }
                 }
-            } finally {
-                jar.close();
             }
             if (ut != null) {
                 ut.write();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CreateModuleXML.java
@@ -32,11 +32,11 @@ import java.util.zip.ZipEntry;
  */
 public class CreateModuleXML extends Task {
 
-    private final List<FileSet> enabled = new ArrayList<FileSet>(1);
-    private final List<FileSet> disabled = new ArrayList<FileSet>(1);
-    private final List<FileSet> autoload = new ArrayList<FileSet>(1);
-    private final List<FileSet> eager = new ArrayList<FileSet>(1);
-    private final List<FileSet> hidden = new ArrayList<FileSet>(1);
+    private final List<FileSet> enabled = new ArrayList<>(1);
+    private final List<FileSet> disabled = new ArrayList<>(1);
+    private final List<FileSet> autoload = new ArrayList<>(1);
+    private final List<FileSet> eager = new ArrayList<>(1);
+    private final List<FileSet> hidden = new ArrayList<>(1);
     private Integer level;
     private boolean checkBundle = true;
 
@@ -106,11 +106,11 @@ public class CreateModuleXML extends Task {
         this.checkBundle = check;
     }
     
-    private List<String> enabledNames = new ArrayList<String>(50);
-    private List<String> disabledNames = new ArrayList<String>(10);
-    private List<String> autoloadNames = new ArrayList<String>(10);
-    private List<String> eagerNames = new ArrayList<String>(10);
-    private List<String> hiddenNames = new ArrayList<String>(10);
+    private List<String> enabledNames = new ArrayList<>(50);
+    private List<String> disabledNames = new ArrayList<>(10);
+    private List<String> autoloadNames = new ArrayList<>(10);
+    private List<String> eagerNames = new ArrayList<>(10);
+    private List<String> hiddenNames = new ArrayList<>(10);
     private String hiddenList;
 
     /**

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -115,7 +115,7 @@ public class CustomJavac extends Javac {
         if (!d.isDirectory()) {
             return;
         }
-        List<File> sources = new ArrayList<File>();
+        List<File> sources = new ArrayList<>();
         for (String s : getSrcdir().list()) {
             sources.add(new File(s));
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/DeleteUnreferencedClusterFiles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/DeleteUnreferencedClusterFiles.java
@@ -73,7 +73,7 @@ public class DeleteUnreferencedClusterFiles extends Task {
             if (!updateTracking.isDirectory()) {
                 continue;
             }
-            Map</*path*/String,/*CNB*/String> files = new HashMap<String,String>();
+            Map</*path*/String,/*CNB*/String> files = new HashMap<>();
             for (File module : updateTracking.listFiles()) {
                 if (!module.getName().endsWith(".xml")) {
                     continue;
@@ -99,7 +99,7 @@ public class DeleteUnreferencedClusterFiles extends Task {
             }
             scanForExtraFiles(cluster, "", files.keySet(), cluster.getName(), extraFiles);
         }
-        Map<String,String> pseudoTests = new LinkedHashMap<String,String>();
+        Map<String,String> pseudoTests = new LinkedHashMap<>();
         pseudoTests.put("testMissingFiles", missingFiles.length() > 0 ? "Some files were missing" + missingFiles : null);
         pseudoTests.put("testExtraFiles", extraFiles.length() > 0 ? "Some extra files were present" + extraFiles : null);
         pseudoTests.put("testDuplicatedFiles", duplicatedFiles.length() > 0 ? "Some files were registered in two or more NBMs" + duplicatedFiles : null);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FindExecutables.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FindExecutables.java
@@ -44,7 +44,7 @@ public class FindExecutables extends Task {
         StringBuilder b = new StringBuilder();
         for (String module : allmodules.split(",")) {
             // Have to replace substitutions in e.g. o.jruby.distro/nbproject/project.properties:
-            final AtomicReference<String> execFiles = new AtomicReference<String>();
+            final AtomicReference<String> execFiles = new AtomicReference<>();
             final String prefix = "Load.";
             class Load extends Property {
                 protected @Override void addProperty(String n, String v) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
@@ -41,7 +41,7 @@ import org.apache.tools.ant.util.FileUtils;
  */
 public class FixDependencies extends Task {
     /** Replace*/
-    private List<Replace> replaces = new ArrayList<Replace>();
+    private List<Replace> replaces = new ArrayList<>();
     /** files to fix */
     private FileSet set;
     /** verify target */
@@ -537,7 +537,7 @@ public class FixDependencies extends Task {
 
     public static final class Replace extends Object {
         String codeNameBase;
-        List<Module> modules = new ArrayList<Module>();
+        List<Module> modules = new ArrayList<>();
         boolean addCompileTime;
 
         public void setCodeNameBase (String s) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixDependencies.java
@@ -195,12 +195,11 @@ public class FixDependencies extends Task {
     private boolean fix (File file, File script, org.apache.tools.ant.taskdefs.Ant task, org.apache.tools.ant.taskdefs.Ant cleanTask, boolean compiled) throws IOException, BuildException {
         int s = (int)file.length ();
         byte[] data = new byte[s];
-        InputStream is = new FileInputStream(file);
-        if (s != is.read (data)) {
-            is.close ();
-            throw new BuildException ("Cannot read " + file);
+        try (InputStream is = new FileInputStream(file)) {
+            if (s != is.read (data)) {
+                throw new BuildException ("Cannot read " + file);
+            }
         }
-        is.close ();
         
         String stream = new String (data);
         String old = stream;
@@ -381,9 +380,9 @@ public class FixDependencies extends Task {
             }
 
             if (!old.equals (stream)) {
-                FileWriter fw = new FileWriter (file);
-                fw.write (stream);
-                fw.close ();
+                try (FileWriter fw = new FileWriter (file)) {
+                    fw.write (stream);
+                }
                 return true;
             } else {
                 return false;
@@ -406,12 +405,11 @@ public class FixDependencies extends Task {
         
         int s = (int)file.length ();
         byte[] data = new byte[s];
-        InputStream is = new FileInputStream(file);
-        if (s != is.read (data)) {
-            is.close ();
-            throw new BuildException ("Cannot read " + file);
+        try (InputStream is = new FileInputStream(file)) {
+            if (s != is.read (data)) {
+                throw new BuildException ("Cannot read " + file);
+            }
         }
-        is.close ();
         
         String stream = new String (data);
         String old = stream;
@@ -443,10 +441,10 @@ public class FixDependencies extends Task {
             last = after;
             begin = last;
 
-            // write the file without the 
-            FileWriter fw = new FileWriter (file);
-            fw.write (stream.substring (0, from) + stream.substring (after));
-            fw.close ();
+            // write the file without the
+            try (FileWriter fw = new FileWriter (file)) {
+                fw.write (stream.substring (0, from) + stream.substring (after));
+            }
             
             String dep = stream.substring (from, after);
             if (dep.indexOf ("compile-dependency") == -1) {
@@ -485,10 +483,10 @@ public class FixDependencies extends Task {
         }
 
         if (first != -1) {
-            // write the file without the 
-            FileWriter fw = new FileWriter (file);
-            fw.write (stream.substring (0, first) + sb.toString () + stream.substring (last));
-            fw.close ();
+            // write the file without the
+            try (FileWriter fw = new FileWriter (file)) {
+                fw.write (stream.substring (0, first) + sb.toString () + stream.substring (last));
+            }
         }
         
         log ("Final verification runs " + tgt + " in " + script, Project.MSG_INFO);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
@@ -75,11 +75,8 @@ public class FixTestDependencies extends Task {
                 throw new BuildException("project.xml file doesn't exist.");
             }
             byte xmlBytes [] = new byte[(int)projectXmlFile.length()];
-            FileInputStream prjFis = new FileInputStream(projectXmlFile);
-            try {
+            try (FileInputStream prjFis = new FileInputStream(projectXmlFile)) {
                 prjFis.read(xmlBytes);
-            } finally {
-                prjFis.close();
             }
             String xml = new String(xmlBytes);
             String oldXsd = "<data xmlns=\"http://www.netbeans.org/ns/nb-module-project/2";
@@ -114,9 +111,9 @@ public class FixTestDependencies extends Task {
                 if (td && !testFix) {
                     // yes -> exit
                     xml = fixOpenideUtil(fixCoreStartup(xml));
-                    PrintStream ps = new PrintStream(projectXmlFile);
-                    ps.print(xml);
-                    ps.close();                  
+                    try (PrintStream ps = new PrintStream(projectXmlFile)) {
+                        ps.print(xml);
+                    }                  
                     return ;
                 }
                 Set<ModuleListParser.Entry> entries = getModuleList(projectType);
@@ -205,12 +202,12 @@ public class FixTestDependencies extends Task {
                 }
                 resultXml.append(xml.substring(moduleDepEnd + 1, xml.length()));
                 if (!testFix) {
-                   PrintStream ps = new PrintStream(projectXmlFile);
-                   ps.print(fixOpenideUtil(
-                           fixCoreStartup(
-                                   resultXml.toString()
-                           )));
-                   ps.close();
+                    try (PrintStream ps = new PrintStream(projectXmlFile)) {
+                        ps.print(fixOpenideUtil(
+                                fixCoreStartup(
+                                        resultXml.toString()
+                                )));
+                    }
                 } else {
                     System.out.println(resultXml);
                 }
@@ -364,11 +361,8 @@ public class FixTestDependencies extends Task {
             return new Properties();
         }
         Properties props = new Properties();
-        FileInputStream fis = new FileInputStream(propertiesFile);
-        try {
+        try (FileInputStream fis = new FileInputStream(propertiesFile)) {
             props.load(fis);
-        } finally {
-            fis.close();
         }
         return props;
     }
@@ -391,12 +385,12 @@ public class FixTestDependencies extends Task {
             List<String> lines = new ArrayList<>();
             if (propertiesFile.isFile()) {
                 // read properties
-                BufferedReader reader = new BufferedReader (new FileReader(propertiesFile));
-                String line = null;
-                while ((line = reader.readLine()) != null) {
-                    lines.add(line);
+                try (BufferedReader reader = new BufferedReader (new FileReader(propertiesFile))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        lines.add(line);
+                    }
                 }
-                reader.close();
             }
             
             // merge properties
@@ -409,11 +403,11 @@ public class FixTestDependencies extends Task {
             }
 
             // store properties
-            PrintStream ps = new PrintStream(propertiesFile);
-            for (String l : lines) {
-                ps.println(l);
+            try (PrintStream ps = new PrintStream(propertiesFile)) {
+                for (String l : lines) {
+                    ps.println(l);
+                }
             }
-            ps.close();
             
         } catch (IOException ioe) {
             throw new BuildException(ioe);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/FixTestDependencies.java
@@ -127,10 +127,10 @@ public class FixTestDependencies extends Task {
 
                 // unittest
                 //
-                Set<String> compileCNB = new TreeSet<String>();
-                Set<String> compileTestCNB = new TreeSet<String>();
-                Set<String> runtimeCNB = new TreeSet<String>();
-                Set<String> runtimeTestCNB = new TreeSet<String>();
+                Set<String> compileCNB = new TreeSet<>();
+                Set<String> compileTestCNB = new TreeSet<>();
+                Set<String> runtimeCNB = new TreeSet<>();
+                Set<String> runtimeTestCNB = new TreeSet<>();
 
                 Properties projectProperties = getTestProperties();
                 boolean found;
@@ -235,7 +235,7 @@ public class FixTestDependencies extends Task {
     }
     
     private Set<String> getCNBsFromEntries(Set<ModuleListParser.Entry> entries) {
-        Set<String> cnbs = new HashSet<String>();
+        Set<String> cnbs = new HashSet<>();
         for (ModuleListParser.Entry e : entries) {
             cnbs.add(e.getCnb());
         }
@@ -388,7 +388,7 @@ public class FixTestDependencies extends Task {
             return;
         }
         try {
-            List<String> lines = new ArrayList<String>();
+            List<String> lines = new ArrayList<>();
             if (propertiesFile.isFile()) {
                 // read properties
                 BufferedReader reader = new BufferedReader (new FileReader(propertiesFile));
@@ -422,7 +422,7 @@ public class FixTestDependencies extends Task {
     }
 
     private List<String> replaceProperty(String name, String value, List<String> lines) {
-        List<String> retLines = new ArrayList<String>();
+        List<String> retLines = new ArrayList<>();
         for (int i = 0 ; i < lines.size() ; i++) {
             String line = lines.get(i);
             String trimmedLine = line.trim();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
@@ -82,8 +82,7 @@ public class GenerateFilesLayout extends Task {
                 }
                 ownersByCluster.put(cluster, owners);
             }
-            Writer w = new FileWriter(output);
-            try {
+            try (Writer w = new FileWriter(output)) {
                 PrintWriter pw = new PrintWriter(w);
                 for (String incl : ds.getIncludedFiles()) {
                     String inclSlash = incl.replace(File.separatorChar, '/');
@@ -105,8 +104,6 @@ public class GenerateFilesLayout extends Task {
                 }
                 pw.flush();
                 pw.close();
-            } finally {
-                w.close();
             }
         } catch (IOException x) {
             throw new BuildException(x, getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
@@ -58,13 +58,13 @@ public class GenerateFilesLayout extends Task {
         }
         DirectoryScanner ds = fs.getDirectoryScanner();
         try {
-            Map</*cluster*/String,Map</*path*/String,/*cnb*/String>> ownersByCluster = new HashMap<String,Map<String,String>>();
+            Map</*cluster*/String,Map</*path*/String,/*cnb*/String>> ownersByCluster = new HashMap<>();
             int maxlength = 0;
             for (String cluster : ds.getIncludedDirectories()) {
                 if (cluster.isEmpty() || cluster.indexOf(File.separatorChar) != -1) {
                     continue;
                 }
-                Map<String,String> owners = new HashMap<String,String>();
+                Map<String,String> owners = new HashMap<>();
                 File updateTracking = new File(ds.getBasedir(), cluster + "/update_tracking");
                 if (!updateTracking.isDirectory()) {
                     log("No such dir: " + updateTracking, Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/GenerateFilesLayout.java
@@ -105,9 +105,7 @@ public class GenerateFilesLayout extends Task {
                 pw.flush();
                 pw.close();
             }
-        } catch (IOException x) {
-            throw new BuildException(x, getLocation());
-        } catch (SAXException x) {
+        } catch (IOException | SAXException x) {
             throw new BuildException(x, getLocation());
         }
         log(output + ": generated");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/HgId.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/HgId.java
@@ -68,15 +68,12 @@ public class HgId extends Task {
         String id = "unknown-revn";
         if (dirstate != null && dirstate.length() >= 6) {
             try {
-                InputStream is = new FileInputStream(dirstate);
-                try {
+                try (InputStream is = new FileInputStream(dirstate)) {
                     byte[] data = new byte[6];
                     if (is.read(data) < 6) {
                         throw new IOException("truncated read");
                     }
                     id = String.format("%012x", new BigInteger(1, data));
-                } finally {
-                    is.close();
                 }
             } catch (IOException x) {
                 log("Could not read " + dirstate + ": " + x, Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
@@ -246,8 +246,7 @@ public final class IncrementSpecificationVersions extends Task {
     }
 
     private static String[] gulp(File file, String enc) throws IOException {
-        InputStream is = new FileInputStream(file);
-        try {
+        try (InputStream is = new FileInputStream(file)) {
             BufferedReader r = new BufferedReader(new InputStreamReader(is, enc));
             List<String> l = new ArrayList<>();
             String line;
@@ -255,21 +254,16 @@ public final class IncrementSpecificationVersions extends Task {
                 l.add(line);
             }
             return l.toArray(new String[l.size()]);
-        } finally {
-            is.close();
         }
     }
     
     private static void spit(File file, String enc, String[] lines) throws IOException {
-        OutputStream os = new FileOutputStream(file);
-        try {
+        try (OutputStream os = new FileOutputStream(file)) {
             PrintWriter w = new PrintWriter(new OutputStreamWriter(os, enc));
             for (String line : lines) {
                 w.println(line);
             }
             w.flush();
-        } finally {
-            os.close();
         }
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java
@@ -57,7 +57,7 @@ public final class IncrementSpecificationVersions extends Task {
     }
     
     public void setModules(String m) {
-        modules = new ArrayList<String>();
+        modules = new ArrayList<>();
         for (Object o : Collections.list(new StringTokenizer(m, ", "))) {
             modules.add((String) o);
         }
@@ -249,7 +249,7 @@ public final class IncrementSpecificationVersions extends Task {
         InputStream is = new FileInputStream(file);
         try {
             BufferedReader r = new BufferedReader(new InputStreamReader(is, enc));
-            List<String> l = new ArrayList<String>();
+            List<String> l = new ArrayList<>();
             String line;
             while ((line = r.readLine()) != null) {
                 l.add(line);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/InsertModuleAllTargets.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/InsertModuleAllTargets.java
@@ -103,7 +103,7 @@ public final class InsertModuleAllTargets extends Task {
                 }
             }
             
-            Map<String,String> clustersOfModules = new HashMap<String,String>();
+            Map<String,String> clustersOfModules = new HashMap<>();
             if (useClusters) {
                 for (Map.Entry<String,Object> pair : props.entrySet()) {
                     String cluster = pair.getKey();
@@ -116,7 +116,7 @@ public final class InsertModuleAllTargets extends Task {
                 }
             }
             ModuleListParser mlp = new ModuleListParser(props, ModuleType.NB_ORG, prj);
-            SortedMap<String,ModuleListParser.Entry> entries = new TreeMap<String,ModuleListParser.Entry>();
+            SortedMap<String,ModuleListParser.Entry> entries = new TreeMap<>();
             for (ModuleListParser.Entry entry : mlp.findAll()) {
                 String path = entry.getNetbeansOrgPath();
                 if (path == null) continue; // It is taken from binary

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
@@ -60,7 +60,7 @@ public class JHIndexer extends MatchingTask {
     private File db;
     private File basedir;
     private String locale;
-    private List<BrandedFileSet> brandings = new LinkedList<BrandedFileSet>();
+    private List<BrandedFileSet> brandings = new LinkedList<>();
 
     /** Set the location of <samp>jhall.jar</samp> or <samp>jsearch.jar</samp> (JavaHelp tools library). */
     public Path createClasspath() {
@@ -356,7 +356,7 @@ public class JHIndexer extends MatchingTask {
                         "-db", db.getAbsolutePath()
                     );
                     if (locale != null) {
-                        args = new ArrayList<String>(args); // #35244
+                        args = new ArrayList<>(args); // #35244
                         args.add("-locale");
                         args.add(locale);
                     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JHIndexer.java
@@ -329,8 +329,7 @@ public class JHIndexer extends MatchingTask {
         try {
             File config = File.createTempFile ("jhindexer-config", ".txt");
             try {
-                OutputStream os = new FileOutputStream (config);
-                try {
+                try (OutputStream os = new FileOutputStream (config)) {
                     PrintWriter pw = new PrintWriter (os);
                     pw.println ("IndexRemove " + basedir + File.separator);
                     String message = "Files to be indexed:";
@@ -343,8 +342,6 @@ public class JHIndexer extends MatchingTask {
                     }
                     log (message, Project.MSG_VERBOSE);
                     pw.flush ();
-                } finally {
-                    os.close ();
                 }
                 AntClassLoader loader = new AntClassLoader(getProject(), classpath);
                 loader.addLoaderPackageRoot("com.sun.java.help.search");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
@@ -65,7 +65,7 @@ public class JNLPUpdateManifestBranding extends Task {
     private static final String ATTR_PERMISSIONS = "Permissions";   //NOI18N
     private static final String ATTR_APPLICATION_NAME = "Application-Name"; //NOI18N
 
-    private final Vector<FileSet> filesets = new Vector<FileSet>();
+    private final Vector<FileSet> filesets = new Vector<>();
 
     public void addFileset(FileSet fileset) {
         filesets.add(fileset);
@@ -108,7 +108,7 @@ public class JNLPUpdateManifestBranding extends Task {
 
     @Override
     public void execute() throws BuildException {
-        Set<String> filePaths = new HashSet<String>();
+        Set<String> filePaths = new HashSet<>();
         File tmpFile = null;
         for (FileSet fs : filesets) {
             if (fs != null) {
@@ -158,7 +158,7 @@ public class JNLPUpdateManifestBranding extends Task {
         cp.execute();
         boolean success = false;
         try {
-            final Map<String, String> extendedAttrs = new HashMap<String, String>();
+            final Map<String, String> extendedAttrs = new HashMap<>();
             final org.apache.tools.zip.ZipFile zf = new org.apache.tools.zip.ZipFile(sourceJar);
             try {
                 final org.apache.tools.zip.ZipEntry manifestEntry = zf.getEntry(MANIFEST);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
@@ -132,11 +132,7 @@ public class JNLPUpdateManifestBranding extends Task {
                 }
 
             }
-        } catch (IOException ex) {
-            getProject().log(
-                    "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
-                    Project.MSG_WARN);
-        } catch (ManifestException ex) {
+        } catch (IOException | ManifestException ex) {
             getProject().log(
                     "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
                     Project.MSG_WARN);
@@ -305,17 +301,7 @@ public class JNLPUpdateManifestBranding extends Task {
             Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
             Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
             sdaMethod.invoke(getSignTask(), "SHA1");
-        } catch (ClassNotFoundException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (NoSuchMethodException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (SecurityException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (IllegalAccessException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (IllegalArgumentException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (InvocationTargetException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
         }
         // end of getSignTask().setDigestAlg("SHA1");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
@@ -26,8 +26,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -37,8 +35,6 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.tools.ant.BuildException;
@@ -297,14 +293,7 @@ public class JNLPUpdateManifestBranding extends Task {
         }
         getSignTask().setSignedjar(to);
         // use reflection for calling getSignTask().setDigestAlg("SHA1");
-        try {
-            Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
-            Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
-            sdaMethod.invoke(getSignTask(), "SHA1");
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        // end of getSignTask().setDigestAlg("SHA1");
+        getSignTask().setDigestAlg("SHA1");
         getSignTask().execute();
 
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestBranding.java
@@ -272,8 +272,7 @@ public class JNLPUpdateManifestBranding extends Task {
      * return alias if signed, or null if not
      */
     private static String isSigned(File f) throws IOException {
-        JarFile jar = new JarFile(f);
-        try {
+        try (JarFile jar = new JarFile(f)) {
             Enumeration<JarEntry> en = jar.entries();
             while (en.hasMoreElements()) {
                 Matcher m = SF.matcher(en.nextElement().getName());
@@ -282,8 +281,6 @@ public class JNLPUpdateManifestBranding extends Task {
                 }
             }
             return null;
-        } finally {
-            jar.close();
         }
     }
     private static final Pattern SF = Pattern.compile("META-INF/(.+)\\.SF");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
@@ -27,16 +27,12 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.tools.ant.BuildException;
@@ -299,15 +295,7 @@ public class JNLPUpdateManifestStartup extends Task {
             to.getParentFile().mkdirs();
         }
         getSignTask().setSignedjar(to);
-        // use reflection for calling getSignTask().setDigestAlg("SHA1");
-        try {
-            Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
-            Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
-            sdaMethod.invoke(getSignTask(), "SHA1");
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        // end of getSignTask().setDigestAlg("SHA1");
+        getSignTask().setDigestAlg("SHA1");
         getSignTask().execute();
 
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
@@ -153,7 +153,7 @@ public class JNLPUpdateManifestStartup extends Task {
         cp.execute();
         boolean success = false;
         try {
-            final Map<String, String> extendedAttrs = new HashMap<String, String>();
+            final Map<String, String> extendedAttrs = new HashMap<>();
             final org.apache.tools.zip.ZipFile zf = new org.apache.tools.zip.ZipFile(sourceJar);
             try {
                 final org.apache.tools.zip.ZipEntry manifestEntry = zf.getEntry(MANIFEST);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
@@ -121,11 +121,7 @@ public class JNLPUpdateManifestStartup extends Task {
             if (isSigned(jar) == null) {
                 tmpFile = extendLibraryManifest(getProject(), jar, destJar, codebase, permissions, appName);
             }
-        } catch (IOException ex) {
-            getProject().log(
-                    "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
-                    Project.MSG_WARN);
-        } catch (ManifestException ex) {
+        } catch (IOException | ManifestException ex) {
             getProject().log(
                     "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
                     Project.MSG_WARN);
@@ -308,17 +304,7 @@ public class JNLPUpdateManifestStartup extends Task {
             Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
             Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
             sdaMethod.invoke(getSignTask(), "SHA1");
-        } catch (ClassNotFoundException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (NoSuchMethodException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (SecurityException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (IllegalAccessException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (IllegalArgumentException ex) {
-            Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-        } catch (InvocationTargetException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
         }
         // end of getSignTask().setDigestAlg("SHA1");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JNLPUpdateManifestStartup.java
@@ -275,8 +275,7 @@ public class JNLPUpdateManifestStartup extends Task {
      * return alias if signed, or null if not
      */
     private static String isSigned(File f) throws IOException {
-        JarFile jar = new JarFile(f);
-        try {
+        try (JarFile jar = new JarFile(f)) {
             Enumeration<JarEntry> en = jar.entries();
             while (en.hasMoreElements()) {
                 Matcher m = SF.matcher(en.nextElement().getName());
@@ -285,8 +284,6 @@ public class JNLPUpdateManifestStartup extends Task {
                 }
             }
             return null;
-        } finally {
-            jar.close();
         }
     }
     private static final Pattern SF = Pattern.compile("META-INF/(.+)\\.SF");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JUnitReportWriter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JUnitReportWriter.java
@@ -89,11 +89,8 @@ public class JUnitReportWriter {
             testsuite.setAttribute("failures", Integer.toString(failures));
             testsuite.setAttribute("tests", Integer.toString(pseudoTests.size()));
             try {
-                OutputStream os = new FileOutputStream(reportFile);
-                try {
+                try (OutputStream os = new FileOutputStream(reportFile)) {
                     XMLUtil.write(reportDoc, os);
-                } finally {
-                    os.close();
                 }
             } catch (IOException x) {
                 throw new BuildException("Could not write " + reportFile + ": " + x, x, task.getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
@@ -253,7 +253,7 @@ public class JarWithModuleAttributes extends Jar {
                         specVersBaseWarning(manifestFile, "use of spec.version.base with non-integer OpenIDE-Module-Implementation-Version");
                     }
                 }
-                SortedMap<String,Integer> additions = new TreeMap<String,Integer>();
+                SortedMap<String,Integer> additions = new TreeMap<>();
                 if (moduleDeps != null) {
                     for (String individualDep : COMMA_SPACE.split(moduleDeps)) {
                         Matcher m = IMPL_DEP.matcher(individualDep);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
@@ -39,7 +39,7 @@ import org.apache.tools.ant.types.FileSet;
 public class JavadocIndex extends Task {
     private File target;
     private FileSet set;
-    private Map<String,List<Clazz>> classes = new HashMap<String,List<Clazz>>(101);
+    private Map<String,List<Clazz>> classes = new HashMap<>(101);
     
     /** The file to generate the index to.
      */
@@ -151,7 +151,7 @@ public class JavadocIndex extends Task {
                     
                     List<Clazz> l = classes.get(c.pkg);
                     if (l == null) {
-                        l = new ArrayList<Clazz>();
+                        l = new ArrayList<>();
                         classes.put (c.pkg, l);
                     }
                     l.add (c);
@@ -173,9 +173,9 @@ public class JavadocIndex extends Task {
         ps.println ("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">");
         ps.println ("<HTML>\n<HEAD><TITLE>List of All Classes</TITLE></HEAD>");
         ps.println ();
-        for (String pkg : new TreeSet<String>(classes.keySet())) {
+        for (String pkg : new TreeSet<>(classes.keySet())) {
             ps.println ("<H2>" + pkg + "</H2>");
-            for (Clazz c : new TreeSet<Clazz>(classes.get(pkg))) {
+            for (Clazz c : new TreeSet<>(classes.get(pkg))) {
                 ps.print ("<A HREF=\"" + c.url + "\">");
                 if (c.isInterface) {
                     ps.print ("<I>");
@@ -193,8 +193,8 @@ public class JavadocIndex extends Task {
     private void printClassesAsXML (PrintStream ps) {
         ps.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         ps.println ("<classes>");
-        for (String pkg : new TreeSet<String>(classes.keySet())) {
-            for (Clazz c : new TreeSet<Clazz>(classes.get(pkg))) {
+        for (String pkg : new TreeSet<>(classes.keySet())) {
+            for (Clazz c : new TreeSet<>(classes.get(pkg))) {
                 ps.print ("<class name=\"");
                 ps.print (c.name);
                 ps.print ("\"");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JavadocIndex.java
@@ -73,15 +73,15 @@ public class JavadocIndex extends Task {
 
         try {
             log ("Generating list of all classes to " + target);
-            PrintStream ps = new PrintStream (new BufferedOutputStream (
-                new FileOutputStream (target)
-            ));
-            if (target.getName ().endsWith (".xml")) {
-                printClassesAsXML (ps);
-            } else {
-                printClassesAsHtml (ps);
+            try (PrintStream ps = new PrintStream (new BufferedOutputStream (
+                    new FileOutputStream (target)
+            ))) {
+                if (target.getName ().endsWith (".xml")) {
+                    printClassesAsXML (ps);
+                } else {
+                    printClassesAsHtml (ps);
+                }
             }
-            ps.close ();
         } catch (IOException ex) {
             throw new BuildException (ex);
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/L10nTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/L10nTask.java
@@ -86,9 +86,9 @@ public class L10nTask extends Task {
 
             lnr = new LineNumberReader(new FileReader(patternsFile));
             String line;
-            Map<String, Set<String>> includes = new HashMap<String, Set<String>>();
-            Map<String, Set<String>> excludes = new HashMap<String, Set<String>>();
-            Set<String> excludeFiles = new HashSet<String>();
+            Map<String, Set<String>> includes = new HashMap<>();
+            Map<String, Set<String>> excludes = new HashMap<>();
+            Set<String> excludeFiles = new HashSet<>();
 
             //Read all the patterns from patternsFile
             while ((line = lnr.readLine()) != null) {
@@ -111,13 +111,13 @@ public class L10nTask extends Task {
                     }
                     Set<String> files = includes.get(p[0]);
                     if (files == null) {
-                        files = new HashSet<String>();
+                        files = new HashSet<>();
                         includes.put(p[0], files);
                     }
                     files.add(p[1]);
                 } else {        //Exlude pattern
 
-                    List<String> lines = new ArrayList<String> ();
+                    List<String> lines = new ArrayList<> ();
                     String lineRaw = line.substring("exclude ".length());
                     if (lineRaw.contains(LOCALES_TOKEN)) {
                         for (String locale : getLocales(locales)) {
@@ -144,7 +144,7 @@ public class L10nTask extends Task {
                         }
                         Set<String> files = excludes.get(p[0]);
                         if (files == null) {
-                            files = new HashSet<String>();
+                            files = new HashSet<>();
                             excludes.put(p[0], files);
                         }
                         files.add(p[1]);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LayerIndex.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LayerIndex.java
@@ -71,7 +71,7 @@ public class LayerIndex extends Task {
 
     public LayerIndex() {}
 
-    List<FileSet> filesets = new ArrayList<FileSet>();
+    List<FileSet> filesets = new ArrayList<>();
     public void addConfiguredModules(FileSet fs) {
         filesets.add(fs);
     }
@@ -102,11 +102,11 @@ public class LayerIndex extends Task {
         if (filesets.isEmpty()) {
             throw new BuildException();
         }
-        SortedMap<String,String> files = new TreeMap<String,String>(); // layer path -> cnb
-        SortedMap<String,SortedMap<String,String>> labels = new TreeMap<String,SortedMap<String,String>>(); // layer path -> cnb -> label
-        final Map<String,Integer> positions = new TreeMap<String,Integer>(); // layer path -> position
-        SortedMap<String,SortedMap<String,Set<String>>> serviceImpls = new TreeMap<String,SortedMap<String,Set<String>>>(); // path -> interface -> [impl]
-        Map<String,Integer> servicePositions = new HashMap<String,Integer>(); // impl -> position
+        SortedMap<String,String> files = new TreeMap<>(); // layer path -> cnb
+        SortedMap<String,SortedMap<String,String>> labels = new TreeMap<>(); // layer path -> cnb -> label
+        final Map<String,Integer> positions = new TreeMap<>(); // layer path -> position
+        SortedMap<String,SortedMap<String,Set<String>>> serviceImpls = new TreeMap<>(); // path -> interface -> [impl]
+        Map<String,Integer> servicePositions = new HashMap<>(); // impl -> position
         for (FileSet fs : filesets) {
             DirectoryScanner ds = fs.getDirectoryScanner(getProject());
             File basedir = ds.getBasedir();
@@ -277,7 +277,7 @@ public class LayerIndex extends Task {
             private void loadDisplayName(String label) {
                 SortedMap<String,String> cnb2label = labels.get(prefix);
                 if (cnb2label == null) {
-                    cnb2label = new TreeMap<String,String>();
+                    cnb2label = new TreeMap<>();
                     labels.put(prefix, cnb2label);
                 }
                 cnb2label.put(cnb, label);
@@ -330,12 +330,12 @@ public class LayerIndex extends Task {
                         lastImpl = line;
                         SortedMap<String,Set<String>> serviceImpls = serviceImplsByPath.get(path);
                         if (serviceImpls == null) {
-                            serviceImpls = new TreeMap<String,Set<String>>();
+                            serviceImpls = new TreeMap<>();
                             serviceImplsByPath.put(path, serviceImpls);
                         }
                         Set<String> impls = serviceImpls.get(xface);
                         if (impls == null) {
-                            impls = new HashSet<String>();
+                            impls = new HashSet<>();
                             serviceImpls.put(xface, impls);
                         }
                         impls.add(lastImpl);
@@ -393,9 +393,9 @@ public class LayerIndex extends Task {
         updateMap(files, virtualEntries);
         updateMap(positions, virtualEntries);
         updateMap(labels, virtualEntries);
-        SortedSet<String> layerPaths = new TreeSet<String>(new LayerPathComparator(positions));
+        SortedSet<String> layerPaths = new TreeSet<>(new LayerPathComparator(positions));
         layerPaths.addAll(files.keySet());
-        SortedSet<String> remaining = new TreeSet<String>(files.keySet());
+        SortedSet<String> remaining = new TreeSet<>(files.keySet());
         remaining.removeAll(layerPaths);
         assert remaining.isEmpty() : remaining;
         for (String path : layerPaths) {
@@ -439,14 +439,14 @@ public class LayerIndex extends Task {
      */
     private Map<String,String> computeMIMELookupEntries(Set<String> files) {
         Pattern editorFolderPattern = Pattern.compile("Editors/(application|text)/([^/]+)(.*/)");
-        Map<String,String> result = new HashMap<String,String>();
+        Map<String,String> result = new HashMap<>();
         for (String editorFolder : files) {
             Matcher m = editorFolderPattern.matcher(editorFolder);
             if (!m.matches()) {
                 continue;
             }
             // $0="Editors/text/html/Popup/" $1="text" $2="html" $3="/Popup/"
-            List<String> prefixen = new ArrayList<String>(2);
+            List<String> prefixen = new ArrayList<>(2);
             prefixen.add("Editors" + m.group(3)); // "Editors/Popup/"
             if (m.group(2).endsWith("+xml")) { // Editors/text/x-ant+xml/Popup/
                 prefixen.add("Editors/" + m.group(1) + "/xml" + m.group(3)); // Editors/text/xml/Popup/
@@ -543,9 +543,9 @@ public class LayerIndex extends Task {
                 } else {
                     pw.println();
                 }
-                SortedSet<String> impls = new TreeSet<String>(new ServiceComparator(servicePositions));
+                SortedSet<String> impls = new TreeSet<>(new ServiceComparator(servicePositions));
                 impls.addAll(entry.getValue());
-                Set<String> masked = new HashSet<String>();
+                Set<String> masked = new HashSet<>();
                 for (String impl : impls) {
                     if (impl.startsWith("#-")) {
                         masked.add(impl);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
@@ -77,8 +77,7 @@ public class LayerOptionsImport extends Task {
             for (String path : ds.getIncludedFiles()) {
                 File jar = new File(basedir, path);
                 try {
-                    JarFile jf = new JarFile(jar);
-                    try {
+                    try (JarFile jf = new JarFile(jar)) {
                         Manifest mf = jf.getManifest();
                         if (mf == null) {
                             continue;
@@ -96,8 +95,6 @@ public class LayerOptionsImport extends Task {
                         if (generatedLayer != null) {
                             parse(jf.getInputStream(generatedLayer), files, cnb, attributesMap);
                         }
-                    } finally {
-                        jf.close();
                     }
                 } catch (Exception x) {
                     throw new BuildException("Reading " + jar + ": " + x, x, getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LayerOptionsImport.java
@@ -53,7 +53,7 @@ public class LayerOptionsImport extends Task {
 
     public LayerOptionsImport() {
     }
-    List<FileSet> filesets = new ArrayList<FileSet>();
+    List<FileSet> filesets = new ArrayList<>();
 
     public void addConfiguredModules(FileSet fs) {
         filesets.add(fs);
@@ -69,8 +69,8 @@ public class LayerOptionsImport extends Task {
         if (filesets.isEmpty()) {
             throw new BuildException();
         }
-        SortedMap<String, String> files = new TreeMap<String, String>(); // layer path -> cnb
-        final SortedMap<String, Map<String, String>> attributesMap = new TreeMap<String, Map<String, String>>(); // layer path -> attribute name -> value
+        SortedMap<String, String> files = new TreeMap<>(); // layer path -> cnb
+        final SortedMap<String, Map<String, String>> attributesMap = new TreeMap<>(); // layer path -> attribute name -> value
         for (FileSet fs : filesets) {
             DirectoryScanner ds = fs.getDirectoryScanner(getProject());
             File basedir = ds.getBasedir();
@@ -183,7 +183,7 @@ public class LayerOptionsImport extends Task {
 		    }
                     Map<String, String> name2value = attributesMap.get(prefix);
                     if (name2value == null) {
-                        name2value = new HashMap<String, String>();
+                        name2value = new HashMap<>();
                         attributesMap.put(prefix, name2value);
                     }
                     name2value.put(attrName, attrValue);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocFiles.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocFiles.java
@@ -77,7 +77,7 @@ public final class LocFiles extends Task {
     
     @Override
     public void execute() throws BuildException {
-        List<String> includes = new ArrayList<String>();
+        List<String> includes = new ArrayList<>();
         if (locales != null && !locales.isEmpty()) {
             if (!srcDir.exists()) {
                 log("No l10n files present. Do hg clone http://hg.netbeans.org/main/l10n!", Project.MSG_VERBOSE);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocJHIndexer.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocJHIndexer.java
@@ -197,8 +197,8 @@ public class LocJHIndexer extends MatchingTask {
     Path path ;
 
     // For each regular expression. //
-    dirs = new LinkedList<String>() ;
-    regexps = new LinkedList<String>() ;
+    dirs = new LinkedList<>() ;
+    regexps = new LinkedList<>() ;
     jhlib = getJhall() ;
     st = new StringTokenizer( jhlib, " 	\n,") ;
     while( st.hasMoreTokens()) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocMakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocMakeNBM.java
@@ -106,7 +106,7 @@ public class LocMakeNBM extends Task {
   public void really_execute() throws BuildException {
     String locs, loc ;
     StringTokenizer stok ;
-    LinkedList<String> build_locales = new LinkedList<String>() ;
+    LinkedList<String> build_locales = new LinkedList<>() ;
 
     // Set default values. //
     if( mainDir == null) {
@@ -185,7 +185,7 @@ public class LocMakeNBM extends Task {
   /** Build the NBM for this locale. */
   protected void buildNbm( String locale) throws BuildException {
     MakeLNBM makenbm ;
-    LinkedList<String> list = new LinkedList<String>() ;
+    LinkedList<String> list = new LinkedList<>() ;
     String includes = new String() ;
     File licenseFile ;
     boolean first_time ;
@@ -339,7 +339,7 @@ public class LocMakeNBM extends Task {
   /** Add the patterns to include the localized files for the given locale. */
   protected void addLocalePatterns( FileSet fs,
 				    String loc) {
-    LinkedList<String> list = new LinkedList<String>() ;
+    LinkedList<String> list = new LinkedList<>() ;
 
     // Get the list of patterns for this locale. //
     addLocalePatterns( list, loc) ;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
@@ -306,9 +306,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
                 idx = testpath.lastIndexOf ('.');
                 if (idx != -1) testpath = testpath.substring (0, idx);
                 String thisLocale = null;
-                Iterator it2 = locales2.iterator ();
-                while (it2.hasNext ()) {
-                    String tryLocale = (String) it2.next ();
+                for(String tryLocale: locales2) {
                     if (testpath.endsWith ("_" + tryLocale)) {
                         thisLocale = tryLocale;
                         testpath = testpath.substring (0, testpath.length () - 1 - tryLocale.length ());
@@ -316,9 +314,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
                     }
                 }
                 String thisBranding = null;
-                it2 = brandings2.iterator ();
-                while (it2.hasNext ()) {
-                    String tryBranding = (String) it2.next ();
+                for(String tryBranding: brandings2) {
                     if (testpath.endsWith ("_" + tryBranding)) {
                         thisBranding = tryBranding;
                         break;
@@ -408,9 +404,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
                     long time = jar.lastModified ();
                     if (manifest == null || manifest.lastModified () <= time) {
                         boolean upToDate = true;
-                        Iterator it2 = files.values ().iterator ();
-                        while (it2.hasNext ()) {
-                            File f = (File) it2.next ();
+                        for(File f: files.values()) {
                             if (f.lastModified () > time) {
                                 upToDate = false;
                                 break;
@@ -614,9 +608,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
 
       // If the path contains a dir with the same name as the //
       // locale.					      //
-      locale_dir = new String( file.separator) ;
-      locale_dir += loc ;
-      locale_dir += file.separator ;
+      locale_dir = File.separator + loc + File.separator;
       idx = path.indexOf( locale_dir) ;
       if( idx != -1) {
 
@@ -694,7 +686,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
     else {
       s = getProject().getProperty("locjar.warnMissingDir");
       if( s != null && !s.trim().equals( "")) {
-	ret = getProject().toBoolean(s);
+	ret = Project.toBoolean(s);
       }
     }
 
@@ -732,7 +724,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
   protected boolean shouldWriteSrcDir() {
     boolean ret = false ;
     String s = getProject().getProperty("locjar.writeSrcDir");
-    if( s != null && getProject().toBoolean(s)) {
+    if( s != null && Project.toBoolean(s)) {
       ret = true ;
     }
     return( ret) ;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/LocalizedJar.java
@@ -55,14 +55,14 @@ import org.apache.tools.ant.types.*;
  */
 public class LocalizedJar extends MatchingTask {
 
-    private List<FileSet> localeKits = new LinkedList<FileSet> ();
-    private List<LocaleOrB> locales = new LinkedList<LocaleOrB> ();
-    private List<LocaleOrB> brandings = new LinkedList<LocaleOrB> ();
+    private List<FileSet> localeKits = new LinkedList<> ();
+    private List<LocaleOrB> locales = new LinkedList<> ();
+    private List<LocaleOrB> brandings = new LinkedList<> ();
     private File jarFile;
     private File baseDir;
     private boolean doCompress = false;
     private static long emptyCrc = new CRC32 ().getValue ();
-    private List<FileSet> filesets = new LinkedList<FileSet> ();
+    private List<FileSet> filesets = new LinkedList<> ();
     private File manifest;
     private boolean checkPathLocale = true ;
     private boolean warnMissingDir = false ;
@@ -224,10 +224,10 @@ public class LocalizedJar extends MatchingTask {
 
         //System.err.println ("Stage #1");
         // First find out which files need to be archived.
-        Map<String, File> allFiles = new HashMap<String, File> (); // all files to do something with; Map<String,File> from JAR path to actual file
+        Map<String, File> allFiles = new HashMap<> (); // all files to do something with; Map<String,File> from JAR path to actual file
         // Populate it.
         {
-            List<FileScanner> scanners = new ArrayList<FileScanner> (filesets.size () + 1);
+            List<FileScanner> scanners = new ArrayList<> (filesets.size () + 1);
             if (baseDir != null) {
                 scanners.add (getDirectoryScanner (baseDir));
             }
@@ -252,7 +252,7 @@ public class LocalizedJar extends MatchingTask {
         // Now find all files which should always be put into a locale
         // kit (e.g. dir/locale/name.jar, no special locale or
         // branding, but distinguished as localizable/brandable).
-        Set<File> localeKitFiles = new HashSet<File> (); // all locale-kit files
+        Set<File> localeKitFiles = new HashSet<> (); // all locale-kit files
         // Populate this one.
         {
             for (FileSet fs: localeKits) {
@@ -267,8 +267,8 @@ public class LocalizedJar extends MatchingTask {
 
         //System.err.println ("Stage #3");
         // Compute list of supported locales and brandings.
-        List<String> locales2 = new LinkedList<String> ();
-        List<String> brandings2 = new LinkedList<String> (); // all brandings
+        List<String> locales2 = new LinkedList<> ();
+        List<String> brandings2 = new LinkedList<> (); // all brandings
         // Initialize above two.
         
         for (LocaleOrB lob: locales) {
@@ -287,10 +287,10 @@ public class LocalizedJar extends MatchingTask {
 
         //System.err.println ("Stage #4");
         // Analyze where everything goes.
-        Set<File> jars = new HashSet<File> (); //JAR files to build
-        Map<File,String> localeMarks = new HashMap<File,String> (); // JAR files to locale (or null for basic JAR, "-" for blank)
-        Map<File,String> brandingMarks = new HashMap<File,String> (); // JAR files to branding (or null for basic JAR, "-" for blank)
-        Map<File,Map<String,File>> router = new HashMap<File,Map<String,File>> (); // JAR files to map of JAR path to actual file (file may be null for dirs)
+        Set<File> jars = new HashSet<> (); //JAR files to build
+        Map<File,String> localeMarks = new HashMap<> (); // JAR files to locale (or null for basic JAR, "-" for blank)
+        Map<File,String> brandingMarks = new HashMap<> (); // JAR files to branding (or null for basic JAR, "-" for blank)
+        Map<File,Map<String,File>> router = new HashMap<> (); // JAR files to map of JAR path to actual file (file may be null for dirs)
         {
 	    String localeDir ;
             for (Map.Entry<String, File> entry: allFiles.entrySet()) {
@@ -383,7 +383,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
                     jars.add (thisjar);
                     Map<String, File> files = router.get (thisjar);
                     if (files == null) {
-                        files = new TreeMap<String, File> ();
+                        files = new TreeMap<> ();
                         router.put (thisjar, files);
                     }
                     files.put (path, file);
@@ -394,7 +394,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
         //System.err.println ("Stage #5");
         // Go through JARs one by one, and build them (if necessary).
         {
-            List<File> jars2 = new ArrayList<File> (jars);
+            List<File> jars2 = new ArrayList<> (jars);
             class FileNameComparator implements Comparator<File> {
                 public int compare (File f1, File f2) {
                     return f1.toString ().compareTo (f2.toString ());
@@ -431,7 +431,7 @@ log( "==> Examining file: " + path, Project.MSG_DEBUG) ;
                         out.setMethod (doCompress ? ZipOutputStream.DEFLATED : ZipOutputStream.STORED);
                         String localeMark = localeMarks.get (jar);
                         String brandingMark = brandingMarks.get (jar);
-                        Set<String> addedDirs = new HashSet<String> ();
+                        Set<String> addedDirs = new HashSet<> ();
                         // Add the manifest.
                         InputStream is;
                         long time;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
@@ -253,17 +253,7 @@ public class MakeJNLP extends Task {
                 Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
                 Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
                 sdaMethod.invoke(getSignTask(), "SHA1");
-            } catch (ClassNotFoundException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (NoSuchMethodException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (SecurityException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (IllegalAccessException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (IllegalArgumentException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (InvocationTargetException ex) {
+            } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
                 Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
             }
             // end of getSignTask().setDigestAlg("SHA1");
@@ -430,11 +420,7 @@ public class MakeJNLP extends Task {
                             if (n.exists() && isSigned(n) == null) {
                                 try {
                                     localeTmpFile = extendLibraryManifest(getProject(), n, t, manifestCodebase, manifestPermissions, appName, jnlp);
-                                } catch (IOException ex) {
-                                    getProject().log(
-                                            "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
-                                            Project.MSG_WARN);
-                                } catch (ManifestException ex) {
+                                } catch (IOException | ManifestException ex) {
                                     getProject().log(
                                             "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
                                             Project.MSG_WARN);
@@ -468,11 +454,7 @@ public class MakeJNLP extends Task {
                 if (jar.exists() && isSigned(jar) == null) {
                     try {
                         tmpFile = extendLibraryManifest(getProject(), jar, signed, manifestCodebase, manifestPermissions, appName, jnlp);
-                    } catch (IOException ex) {
-                        getProject().log(
-                                "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
-                                Project.MSG_WARN);
-                    } catch (ManifestException ex) {
+                    } catch (IOException | ManifestException ex) {
                         getProject().log(
                                 "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
                                 Project.MSG_WARN);
@@ -663,11 +645,7 @@ public class MakeJNLP extends Task {
         Map<String,String> fileToOwningModule = new HashMap<>();
         try {
             ModuleSelector.readUpdateTracking(getProject(), ut.toString(), fileToOwningModule);
-        } catch (IOException ex) {
-            throw new BuildException(ex);
-        } catch (ParserConfigurationException ex) {
-            throw new BuildException(ex);
-        } catch (SAXException ex) {
+        } catch (IOException | ParserConfigurationException | SAXException ex) {
             throw new BuildException(ex);
         }
         
@@ -819,11 +797,7 @@ public class MakeJNLP extends Task {
                 File tmpFile = null;
                 try {
                     tmpFile = extendLibraryManifest(getProject(), e, ext, manifestCodebase, manifestPermissions, appName, null);
-                } catch (IOException ex) {
-                    getProject().log(
-                    "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
-                    Project.MSG_WARN);
-                } catch (ManifestException ex) {
+                } catch (IOException | ManifestException ex) {
                     getProject().log(
                     "Failed to extend libraries manifests: " + ex.getMessage(), //NOI18N
                     Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
@@ -66,6 +66,7 @@ import org.apache.tools.ant.taskdefs.ManifestException;
 import org.apache.tools.ant.taskdefs.SignJar;
 import org.apache.tools.ant.taskdefs.Zip;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.ZipFileSet;
 import org.apache.tools.ant.types.resources.FileResource;
@@ -248,15 +249,7 @@ public class MakeJNLP extends Task {
                 to.getParentFile().mkdirs();
             }
             getSignTask().setSignedjar(to);
-            // use reflection for calling getSignTask().setDigestAlg("SHA1");
-            try {
-                Class sjClass = Class.forName("org.apache.tools.ant.taskdefs.SignJar");
-                Method sdaMethod = sjClass.getDeclaredMethod("setDigestAlg", String.class);
-                sdaMethod.invoke(getSignTask(), "SHA1");
-            } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                Logger.getLogger(MakeJNLP.class.getName()).log(Level.SEVERE, null, ex);
-            }
-            // end of getSignTask().setDigestAlg("SHA1");
+            getSignTask().setDigestAlg("SHA1");
             getSignTask().execute();
         } else if (to != null) {
             Copy copy = (Copy)getProject().createTask("copy");
@@ -310,7 +303,7 @@ public class MakeJNLP extends Task {
             }
         }
 
-        for (Iterator fileIt = files.iterator(); fileIt.hasNext();) {
+        for (Iterator<Resource> fileIt = files.iterator(); fileIt.hasNext();) {
             FileResource fr = (FileResource) fileIt.next();
             File jar = fr.getFile();
 
@@ -711,9 +704,9 @@ public class MakeJNLP extends Task {
             String name = removeWhat.substring(basedir + 1, removeWhat.length() - 4);
             Pattern p = Pattern.compile(base + "/locale/" + name + "(|_[a-zA-Z0-9_]+)\\.jar");
             
-            Iterator it = removeFrom.keySet().iterator();
+            Iterator<String> it = removeFrom.keySet().iterator();
             while (it.hasNext()) {
-                String s = (String)it.next();
+                String s = it.next();
                 Matcher m = p.matcher(s);
                 if (m.matches()) {
                     String locale = m.group(1).substring(1);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
@@ -276,7 +276,7 @@ public class MakeJNLP extends Task {
         }        
         if (processJarVersions) {
           if (jarDirectories == null) {
-            jarDirectories = new HashSet<File>();
+            jarDirectories = new HashSet<>();
           }
           jarDirectories.add(new File(to.getParent()));
         }
@@ -297,7 +297,7 @@ public class MakeJNLP extends Task {
     }
     
     private void generateFiles() throws IOException, BuildException {
-        Set<String> declaredLocales = new HashSet<String>();
+        Set<String> declaredLocales = new HashSet<>();
         boolean useAllLocales = false;
         if(includelocales == null || "*".equals(includelocales)) {
             useAllLocales = true;
@@ -309,7 +309,7 @@ public class MakeJNLP extends Task {
                 declaredLocales.add(tokenizer.nextToken());
             }
         }
-        Set<String> indirectFilePaths = new HashSet<String>();
+        Set<String> indirectFilePaths = new HashSet<>();
         File tmpFile = null;
         for (FileSet fs : new FileSet[] {indirectJars, indirectFiles}) {
             if (fs != null) {
@@ -527,7 +527,7 @@ public class MakeJNLP extends Task {
         cp.execute();
         boolean success = false;
         try {
-            final Map<String,String> extendedAttrs = new HashMap<String,String>();
+            final Map<String,String> extendedAttrs = new HashMap<>();
             final org.apache.tools.zip.ZipFile zf = new org.apache.tools.zip.ZipFile(sourceJar);
             try {                
                 final org.apache.tools.zip.ZipEntry manifestEntry = zf.getEntry(MANIFEST);
@@ -649,7 +649,7 @@ public class MakeJNLP extends Task {
 
     
     private Map<String,List<File>> verifyExtensions(File f, Manifest mf, String dashcnb, String codebasename, boolean verify, Set<String> indirectFilePaths) throws IOException, BuildException {
-        Map<String,List<File>> localizedFiles = new HashMap<String,List<File>>();
+        Map<String,List<File>> localizedFiles = new HashMap<>();
         
         
         File clusterRoot = f.getParentFile();
@@ -677,7 +677,7 @@ public class MakeJNLP extends Task {
             throw new BuildException("The file " + ut + " for module " + codebasename + " cannot be found");
         }
 
-        Map<String,String> fileToOwningModule = new HashMap<String,String>();
+        Map<String,String> fileToOwningModule = new HashMap<>();
         try {
             ModuleSelector.readUpdateTracking(getProject(), ut.toString(), fileToOwningModule);
         } catch (IOException ex) {
@@ -759,7 +759,7 @@ public class MakeJNLP extends Task {
                     
                     List<File> l = recordLocales.get(locale);
                     if (l == null) {
-                        l = new ArrayList<File>();
+                        l = new ArrayList<>();
                         recordLocales.put(locale, l);
                     }
                     l.add(new File(clusterRoot, s.replace('/', File.separatorChar)));
@@ -902,7 +902,7 @@ public class MakeJNLP extends Task {
             return;
         }
         DirectoryScanner scan = indirectFiles.getDirectoryScanner(getProject());
-        Map<String,File> entries = new LinkedHashMap<String,File>();
+        Map<String,File> entries = new LinkedHashMap<>();
         for (String f : scan.getIncludedFiles()) {
             entries.put(f.replace(File.separatorChar, '/'), new File(scan.getBasedir(), f));
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
@@ -422,12 +422,10 @@ public class MakeLNBM extends MatchingTask {
                             }
                         }
                         // Now pick up attributes from the bundle.
-                        Iterator it = p.entrySet().iterator();
-                        while (it.hasNext()) {
-                            Map.Entry entry = (Map.Entry)it.next();
-                            String name = (String)entry.getKey();
-                            if (! name.startsWith("OpenIDE-Module-")) continue; //NOI18N
-                            attr.putValue(name, (String)entry.getValue());
+                        for(String key: p.stringPropertyNames()) {
+                            if(key.startsWith("OpenIDE-Module-")) {
+                                attr.putValue(key, p.getProperty(key));
+                            }
                         }
                     } // else all loc attrs in main manifest, OK
                 }
@@ -628,7 +626,7 @@ public class MakeLNBM extends MatchingTask {
                 //I have to use Reflection API, because there was changed API in ANT1.5
                 try {
                     try {
-                        Class[] paramsT = {String.class};
+                        Class<?>[] paramsT = {String.class};
                         Object[] paramsV1 = {signature.keystore.getAbsolutePath()};
                         Object[] paramsV2 = {file.getAbsolutePath()};
                         signjar.getClass().getDeclaredMethod( "setKeystore", paramsT ).invoke( signjar, paramsV1 ); //NOI18N
@@ -636,7 +634,7 @@ public class MakeLNBM extends MatchingTask {
                     } catch (NoSuchMethodException ex1) {
                         //Probably ANT 1.5
                         try {
-                            Class[] paramsT = {File.class};
+                            Class<?>[] paramsT = {File.class};
                             Object[] paramsV1 = {signature.keystore};
                             Object[] paramsV2 = {file};
                             signjar.getClass().getDeclaredMethod( "setKeystore", paramsT ).invoke( signjar, paramsV1 ); //NOI18N
@@ -644,8 +642,8 @@ public class MakeLNBM extends MatchingTask {
                         } catch (NoSuchMethodException ex2) {
 			    //Probably ANT1.5.3
 			    try {
-				Class[] paramsT1 = {File.class};
-				Class[] paramsT2 = {String.class};
+				Class<?>[] paramsT1 = {File.class};
+				Class<?>[] paramsT2 = {String.class};
 				Object[] paramsV1 = {signature.keystore.getAbsolutePath()};
 				Object[] paramsV2 = {file};
 				signjar.getClass().getDeclaredMethod( "setKeystore", paramsT2 ).invoke( signjar, paramsV1 ); //NOI18N
@@ -791,16 +789,15 @@ public class MakeLNBM extends MatchingTask {
    * global property.
    */
   public boolean reqManOrMod() {
-    String s = null ;
     boolean req = true ;
 
     if( manOrModReqSet) {
       req = manOrModReq ;
     }
     else {
-      s = getProject().getProperty("makenbm.manOrModReq"); //NOI18N
+      String s = getProject().getProperty("makenbm.manOrModReq"); //NOI18N
       if( s != null && !s.equals( "")) { //NOI18N
-	req = getProject().toBoolean(s);
+	req = Project.toBoolean(s);
       }
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
@@ -369,7 +369,7 @@ public class MakeLNBM extends MatchingTask {
     public ExternalPackage createExternalPackage(){
 	ExternalPackage externalPackage = new ExternalPackage ();
 	if (externalPackages == null)
-	    externalPackages = new Vector<ExternalPackage>();
+	    externalPackages = new Vector<>();
 	externalPackages.add( externalPackage );
 	return externalPackage;
     }
@@ -522,7 +522,7 @@ public class MakeLNBM extends MatchingTask {
 		    if( attr != null) {
 		        ps.print ("  <manifest "); //NOI18N
 			boolean firstline = true;
-		        List<String> attrNames = new ArrayList<String>(attr.size());
+		        List<String> attrNames = new ArrayList<>(attr.size());
 			Iterator<Object> it = attr.keySet().iterator();
 			while (it.hasNext()) {
 			    attrNames.add(((Attributes.Name)it.next()).toString());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeLNBM.java
@@ -655,10 +655,8 @@ public class MakeLNBM extends MatchingTask {
                             }
                         }
                     }
-                } catch (IllegalAccessException ex4) {
+                } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException ex4) {
                     throw new BuildException(ex4);
-                } catch (java.lang.reflect.InvocationTargetException ex5) {
-                    throw new BuildException(ex5);
                 }
                 signjar.setStorepass (signature.storepass);
                 signjar.setAlias (signature.alias);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeListOfNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeListOfNBM.java
@@ -48,9 +48,9 @@ public class MakeListOfNBM extends Task {
 
     public MakeListOfNBM() {
         // initialize locales and brandings lists, add empty value at beginning
-        locales = new ArrayList<String>();
+        locales = new ArrayList<>();
         locales.add("");
-        brandings = new ArrayList<String>();
+        brandings = new ArrayList<>();
         brandings.add("");
     }
 
@@ -267,7 +267,7 @@ public class MakeListOfNBM extends Task {
         // update the fileset only if we have got at least one locale or one branding
         DirectoryScanner ds = fs.getDirectoryScanner();
         String[] included = ds.getIncludedFiles();
-        ArrayList<String> newIncludes = new ArrayList<String>();
+        ArrayList<String> newIncludes = new ArrayList<>();
         String dirName; String filename; String fname; String fext; String newinc;
         
         for (String include : included) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
@@ -81,31 +81,29 @@ public class MakeMasterJNLP extends Task {
                 throw new BuildException("Cannot read file: " + jar);
             }
             
-            JarFile theJar = new JarFile(jar);
-            String codenamebase = JarWithModuleAttributes.extractCodeName(theJar.getManifest().getMainAttributes());
-            if (codenamebase == null) {
-                throw new BuildException("Not a NetBeans Module: " + jar);
-            }
-            if (codenamebase.equals("org.objectweb.asm.all")
-                    && jar.getParentFile().getName().equals("core")
-                    && jar.getParentFile().getParentFile().getName().startsWith("platform")) {
-                continue;
-            }
-            {
-                int slash = codenamebase.indexOf('/');
-                if (slash >= 0) {
-                    codenamebase = codenamebase.substring(0, slash);
+            try (JarFile theJar = new JarFile(jar)) {
+                String codenamebase = JarWithModuleAttributes.extractCodeName(theJar.getManifest().getMainAttributes());
+                if (codenamebase == null) {
+                    throw new BuildException("Not a NetBeans Module: " + jar);
+                }
+                if (codenamebase.equals("org.objectweb.asm.all")
+                        && jar.getParentFile().getName().equals("core")
+                        && jar.getParentFile().getParentFile().getName().startsWith("platform")) {
+                    continue;
+                }
+                {
+                    int slash = codenamebase.indexOf('/');
+                    if (slash >= 0) {
+                        codenamebase = codenamebase.substring(0, slash);
+                    }
+                }
+                String dashcnb = codenamebase.replace('.', '-');
+                
+                File n = new File(target, dashcnb + ".ref");
+                try (FileWriter w = new FileWriter(n)) {
+                    w.write("    <extension name='" + codenamebase + "' href='" + this.masterPrefix + dashcnb + ".jnlp' />\n");
                 }
             }
-            String dashcnb = codenamebase.replace('.', '-');
-
-            File n = new File(target, dashcnb + ".ref");
-            FileWriter w = new FileWriter(n);
-            w.write("    <extension name='" + codenamebase + "' href='" + this.masterPrefix + dashcnb + ".jnlp' />\n");
-            w.close();
-                
-                
-            theJar.close();
         }
         
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeMasterJNLP.java
@@ -27,6 +27,7 @@ import java.util.jar.JarFile;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
 
@@ -73,7 +74,7 @@ public class MakeMasterJNLP extends Task {
     }
     
     private void generateFiles() throws IOException, BuildException {
-        for (Iterator fileIt = files.iterator(); fileIt.hasNext();) {
+        for (Iterator<Resource> fileIt = files.iterator(); fileIt.hasNext();) {
             FileResource fr = (FileResource) fileIt.next();
             File jar = fr.getFile();
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -313,7 +313,7 @@ public class MakeNBM extends Task {
 
     /** Try to find and create localized info.xml files */
     public void setLocales(String s) {
-        locales = new ArrayList<String>();
+        locales = new ArrayList<>();
         for (String st : s.split("[, ]+")) {
             if (! st.trim().isEmpty()) {
                 locales.add(st);
@@ -434,7 +434,7 @@ public class MakeNBM extends Task {
     public ExternalPackage createExternalPackage(){
 	ExternalPackage externalPackage = new ExternalPackage ();
 	if (externalPackages == null)
-	    externalPackages = new ArrayList<ExternalPackage>();
+	    externalPackages = new ArrayList<>();
 	externalPackages.add( externalPackage );
 	return externalPackage;
     }
@@ -577,7 +577,7 @@ public class MakeNBM extends Task {
             throw new BuildException("cannot set both manifest and module for makenbm", getLocation());
         }
         if (locales == null) {
-            locales = new ArrayList<String>();
+            locales = new ArrayList<>();
         }
 
     File nbm;
@@ -593,7 +593,7 @@ public class MakeNBM extends Task {
 	overrideLicenseIfNeeded() ;
         
         
-        moduleAttributes = new ArrayList<Attributes> ();
+        moduleAttributes = new ArrayList<> ();
         File module = new File( productDir, moduleName );
         Attributes attr = getModuleAttributesForLocale("");
         if (attr == null) {
@@ -626,7 +626,7 @@ public class MakeNBM extends Task {
             log("Most recent input: " + mostRecentInput + " file: " + nbm.lastModified(), Project.MSG_DEBUG);
         }
         
-        ArrayList<ZipFileSet> infoXMLFileSets = new ArrayList<ZipFileSet>();
+        ArrayList<ZipFileSet> infoXMLFileSets = new ArrayList<>();
         for (Attributes modAttr : moduleAttributes) {
             Document infoXmlContents = createInfoXml(modAttr);
             File infofile;
@@ -660,8 +660,8 @@ public class MakeNBM extends Task {
  	    new BuildException( "Can't get codenamebase" );
  	
  	UpdateTracking tracking = new UpdateTracking(productDir.getAbsolutePath());
- 	Set<String> _files = new LinkedHashSet<String>(Arrays.asList(tracking.getListOfNBM(codename)));
-    List<String> __files = new ArrayList<String>(_files);
+ 	Set<String> _files = new LinkedHashSet<>(Arrays.asList(tracking.getListOfNBM(codename)));
+    List<String> __files = new ArrayList<>(_files);
     for (String f : _files) {
         if (f.endsWith(".external")) { // #195041
             __files.remove(f.substring(0, f.length() - 9));
@@ -669,7 +669,7 @@ public class MakeNBM extends Task {
     }
     String[] files = __files.toArray(new String[__files.size()]);
  	ZipFileSet fs = new ZipFileSet();
-        List <String> moduleFiles = new ArrayList <String>();
+        List <String> moduleFiles = new ArrayList <>();
  	fs.setDir( productDir );
         String [] filesForPackaging = null;
         if(usePack200 && pack200excludes!=null && !pack200excludes.equals("")) {
@@ -685,7 +685,7 @@ public class MakeNBM extends Task {
             filesForPackaging = ds.getIncludedFiles();            
         }
 
-        List<File> packedFiles = new ArrayList<File>();
+        List<File> packedFiles = new ArrayList<>();
         for (int i = 0; i < files.length; i++) {
             if (usePack200) {
                 File sourceFile = new File(productDir, files[i]);
@@ -1017,7 +1017,7 @@ public class MakeNBM extends Task {
         }
         // Write manifest attributes.
         Element el = doc.createElement("manifest");
-        List<String> attrNames = new ArrayList<String>(attr.size());
+        List<String> attrNames = new ArrayList<>(attr.size());
         Iterator it = attr.keySet().iterator();
         while (it.hasNext()) {
             attrNames.add(((Attributes.Name)it.next()).toString());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -523,12 +523,9 @@ public class MakeNBM extends Task {
                             p.load(is);
                         }
                         // Now pick up attributes from the bundle.
-                        Iterator it = p.entrySet().iterator();
-                        while (it.hasNext()) {
-                            Map.Entry entry = (Map.Entry)it.next();
-                            String name = (String)entry.getKey();
+                        for(String name: p.stringPropertyNames()) {
                             if (! name.startsWith("OpenIDE-Module-")) continue;
-                            attr.putValue(name, (String)entry.getValue());
+                            attr.putValue(name, p.getProperty(name));
                         }
                     }
                 }
@@ -922,7 +919,7 @@ public class MakeNBM extends Task {
         Document doc = domimpl.createDocument(null, "module", domimpl.createDocumentType("module", pub, sys));
         String codenamebase = attr.getValue("OpenIDE-Module");
         if (codenamebase == null) {
-            Iterator it = attr.keySet().iterator();
+            Iterator<Object> it = attr.keySet().iterator();
             Name key; String val;
             while (it.hasNext()) {
                 key = (Name) it.next();
@@ -1000,14 +997,11 @@ public class MakeNBM extends Task {
         // Write manifest attributes.
         Element el = doc.createElement("manifest");
         List<String> attrNames = new ArrayList<>(attr.size());
-        Iterator it = attr.keySet().iterator();
-        while (it.hasNext()) {
-            attrNames.add(((Attributes.Name)it.next()).toString());
+        for(Object key: attr.keySet()) {
+            attrNames.add(((Attributes.Name)key).toString());
         }
         Collections.sort(attrNames);
-        it = attrNames.iterator();
-        while (it.hasNext()) {
-            String name = (String) it.next();
+        for(String name: attrNames) {
             if (name.matches("OpenIDE-Module(|-(Name|(Specification|Implementation)-Version|(Module|Package|Java|IDE)-Dependencies|" +
                     "(Short|Long)-Description|Display-Category|Provides|Requires|Recommends|Needs|Fragment-Host))|AutoUpdate-(Show-In-Client|Essential-Module)")) {
                 el.setAttribute(name, attr.getValue(name));

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -103,8 +103,7 @@ public class MakeNBM extends Task {
 		if (lmod > mostRecentInput) mostRecentInput = lmod;
 		addSeparator ();
 		try {
-		    InputStream is = new FileInputStream (file);
-		    try {
+		    try (InputStream is = new FileInputStream (file)) {
 			BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                         String line;
                         while ((line = r.readLine()) != null) {
@@ -128,8 +127,6 @@ public class MakeNBM extends Task {
                             text.append(line);
                             text.append('\n');
                         }
-		    } finally {
-			is.close ();
 		    }
 		} catch (IOException ioe) {
                     throw new BuildException ("Exception reading blurb from " + file, ioe, getLocation ());
@@ -497,8 +494,7 @@ public class MakeNBM extends Task {
             }
         }
         try {
-            JarFile mjar = new JarFile(mfile);
-            try {
+            try (JarFile mjar = new JarFile(mfile)) {
                 if (mjar.getManifest().getMainAttributes().getValue("Bundle-SymbolicName") != null) {
                     // #181025: treat bundles specially.
                     return null;
@@ -523,11 +519,8 @@ public class MakeNBM extends Task {
                     Properties p = new Properties();
                     ZipEntry bundleentry = mjar.getEntry(bundlename);
                     if (bundleentry != null) {
-                        InputStream is = mjar.getInputStream(bundleentry);
-                        try {
+                        try (InputStream is = mjar.getInputStream(bundleentry)) {
                             p.load(is);
-                        } finally {
-                            is.close();
                         }
                         // Now pick up attributes from the bundle.
                         Iterator it = p.entrySet().iterator();
@@ -539,8 +532,6 @@ public class MakeNBM extends Task {
                         }
                     }
                 }
-            } finally {
-                mjar.close();
             }
         } catch (IOException ioe) {
             throw new BuildException("exception while reading " + mfile.getName(), ioe, getLocation());
@@ -635,11 +626,8 @@ public class MakeNBM extends Task {
                 throw new BuildException("Found attributes without assigned locale code", getLocation());
             try {
                 infofile = File.createTempFile("info_"+loc,".xml");
-                OutputStream infoStream = new FileOutputStream (infofile);
-                try {
+                try (OutputStream infoStream = new FileOutputStream (infofile)) {
                     XMLUtil.write(infoXmlContents, infoStream);
-                } finally {
-                    infoStream.close ();
                 }
             } catch (IOException e) {
                 throw new BuildException("exception when creating Info/info.xml for locale '"+loc+"'", e, getLocation());
@@ -776,11 +764,8 @@ public class MakeNBM extends Task {
                     }
                 try {
                     executablesFile = File.createTempFile("executables",".list");
-                    OutputStream infoStream = new FileOutputStream (executablesFile);
-                    try {
+                    try (OutputStream infoStream = new FileOutputStream (executablesFile)) {
                         infoStream.write(sb.toString().getBytes("UTF-8"));
-                    } finally {
-                        infoStream.close ();
                     }
                 } catch (IOException e) {
                     throw new BuildException("exception when creating Info/executables.list", e, getLocation());
@@ -879,8 +864,7 @@ public class MakeNBM extends Task {
     }
 
     private boolean pack200(final File sourceFile, final File targetFile) throws IOException {
-        JarFile jarFile = new JarFile(sourceFile);
-        try {
+        try (JarFile jarFile = new JarFile(sourceFile)) {
             if (isSigned(jarFile)) {
                 return false;
             }
@@ -902,8 +886,6 @@ public class MakeNBM extends Task {
                     targetFile.setLastModified(sourceFile.lastModified());
                 }
             }
-        } finally {
-            jarFile.close();
         }
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
@@ -90,7 +90,7 @@ import org.xml.sax.InputSource;
 public class MakeOSGi extends Task {
 
     private File destdir;
-    private List<ResourceCollection> modules = new ArrayList<ResourceCollection>();
+    private List<ResourceCollection> modules = new ArrayList<>();
     
     /**
      * Mandatory destination directory. Bundles will be created here.
@@ -111,19 +111,19 @@ public class MakeOSGi extends Task {
     }
 
     static class Info {
-        final Set<String> importedPackages = new TreeSet<String>();
-        final Set<String> exportedPackages = new TreeSet<String>();
-        final Set<String> hiddenPackages = new TreeSet<String>();
-        final Set<String> hiddenSubpackages = new TreeSet<String>();
+        final Set<String> importedPackages = new TreeSet<>();
+        final Set<String> exportedPackages = new TreeSet<>();
+        final Set<String> hiddenPackages = new TreeSet<>();
+        final Set<String> hiddenSubpackages = new TreeSet<>();
     }
 
     public @Override void execute() throws BuildException {
         if (destdir == null) {
             throw new BuildException("missing destdir");
         }
-        List<File> jars = new ArrayList<File>();
-        List<File> fragments = new ArrayList<File>();
-        Map<String,Info> infos = new HashMap<String,Info>();
+        List<File> jars = new ArrayList<>();
+        List<File> fragments = new ArrayList<>();
+        Map<String,Info> infos = new HashMap<>();
         log("Prescanning JARs...");
         for (ResourceCollection rc : modules) {
             Iterator<?> it = rc.iterator();
@@ -184,7 +184,7 @@ public class MakeOSGi extends Task {
             // Otherwise get e.g. CCE: org.netbeans.core.osgi.Activator cannot be cast to org.osgi.framework.BundleActivator
             return cnb;
         }
-        Set<String> availablePackages = new TreeSet<String>();
+        Set<String> availablePackages = new TreeSet<>();
         scanClasses(module, info.importedPackages, availablePackages, task);
         File antlib = new File(module.getName().replaceFirst("([/\\\\])modules([/\\\\][^/\\\\]+)", "$1ant$1nblib$2"));
         if (antlib.isFile()) {
@@ -192,10 +192,10 @@ public class MakeOSGi extends Task {
             // AntBridge.MainClassLoader.findClass will refuse to load these,
             // since it is expected that the module loader, thus also AuxClassLoader, can load them.
             // So we need to DynamicImport-Package these packages so that will be true.
-            Set<String> antlibPackages = new HashSet<String>();
+            Set<String> antlibPackages = new HashSet<>();
             JarFile antlibJF = new JarFile(antlib);
             try {
-                scanClasses(antlibJF, antlibPackages, new HashSet<String>(), task);
+                scanClasses(antlibJF, antlibPackages, new HashSet<>(), task);
             } finally {
                 antlibJF.close();
             }
@@ -370,7 +370,7 @@ public class MakeOSGi extends Task {
             OutputStream bundle = new FileOutputStream(bundleFile);
             try {
                 ZipOutputStream zos = new JarOutputStream(bundle, osgi);
-                Set<String> parents = new HashSet<String>();
+                Set<String> parents = new HashSet<>();
                 Enumeration<? extends ZipEntry> entries = jar.entries();
                 while (entries.hasMoreElements()) {
                     ZipEntry entry = entries.nextElement();
@@ -460,7 +460,7 @@ public class MakeOSGi extends Task {
             // do not need to import any API, just need it to be started:
             requireBundles.append("org.netbeans.core.osgi");
         }
-        Set<String> imports = new TreeSet<String>(myInfo.importedPackages);
+        Set<String> imports = new TreeSet<>(myInfo.importedPackages);
         hideImports(imports, myInfo);
         String dependencies = netbeans.getValue("OpenIDE-Module-Module-Dependencies");
         if (dependencies != null) {
@@ -641,7 +641,7 @@ public class MakeOSGi extends Task {
     }
 
     private Map<String,File> findBundledFiles(File module, String cnb) throws Exception {
-        Map<String,File> result = new HashMap<String,File>();
+        Map<String,File> result = new HashMap<>();
         if (module.getParentFile().getName().matches("modules|core|lib")) {
             File cluster = module.getParentFile().getParentFile();
             File updateTracking = new File(new File(cluster, "update_tracking"), cnb.replace('.', '-') + ".xml");
@@ -673,8 +673,8 @@ public class MakeOSGi extends Task {
     }
 
     private static void scanClasses(JarFile module, Set<String> importedPackages, Set<String> availablePackages, Task task) throws Exception {
-        Map<String, byte[]> classfiles = new TreeMap<String, byte[]>();
-        VerifyClassLinkage.read(module, classfiles, new HashSet<File>(Collections.singleton(new File(module.getName()))), task, null);
+        Map<String, byte[]> classfiles = new TreeMap<>();
+        VerifyClassLinkage.read(module, classfiles, new HashSet<>(Collections.singleton(new File(module.getName()))), task, null);
         for (Map.Entry<String,byte[]> entry : classfiles.entrySet()) {
             String available = entry.getKey();
             int idx = available.lastIndexOf('.');
@@ -717,7 +717,7 @@ public class MakeOSGi extends Task {
             OutputStream bundle = new FileOutputStream(bundleFile);
             try {
                 ZipOutputStream zos = new JarOutputStream(bundle, mf);
-                Set<String> parents = new HashSet<String>();
+                Set<String> parents = new HashSet<>();
                 Enumeration<? extends ZipEntry> entries = jar.entries();
                 while (entries.hasMoreElements()) {
                     ZipEntry entry = entries.nextElement();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
@@ -405,9 +405,9 @@ public class MakeUpdateDesc extends MatchingTask {
                                 license.setAttribute("url", path);
                                 String licenseText = license.getTextContent();
                                 license.setTextContent("");
-                                FileOutputStream fos = new FileOutputStream(new File(desc.getParentFile(), relativePath));
-                                fos.write(licenseText.getBytes("UTF-8"));
-                                fos.close();
+                                try (FileOutputStream fos = new FileOutputStream(new File(desc.getParentFile(), relativePath))) {
+                                    fos.write(licenseText.getBytes("UTF-8"));
+                                }
                             }
                             // XXX ideally would compare the license texts to make sure they actually match up
                             licenses.put(license.getAttribute("name"), license);
@@ -556,8 +556,7 @@ public class MakeUpdateDesc extends MatchingTask {
                 for (String file : ds.getIncludedFiles()) {
                     File n_file = new File(fs.getDir(getProject()), file);
                     try {
-                        JarFile jar = new JarFile(n_file);
-                        try {
+                        try (JarFile jar = new JarFile(n_file)) {
                             Module m = new Module();
                             m.nbm = n_file;
                             m.relativePath = file.replace(File.separatorChar, '/');
@@ -627,17 +626,12 @@ public class MakeUpdateDesc extends MatchingTask {
                             while (en.hasMoreElements()) {
                                 JarEntry e = en.nextElement();
                                 if (e.getName().endsWith(".external")) {
-                                    InputStream eStream = jar.getInputStream(e);
-                                    try {
+                                    try (InputStream eStream = jar.getInputStream(e)) {
                                         m.externalDownloadSize += externalSize(eStream);
-                                    } finally {
-                                        eStream.close();
                                     }
                                 }
                             }
                             moduleCollection.add(m);
-                        } finally {
-                            jar.close();
                         }
                     } catch (BuildException x) {
                         throw x;
@@ -675,11 +669,8 @@ public class MakeUpdateDesc extends MatchingTask {
         Properties localized = new Properties();
         String bundleLocalization = attr.getValue("Bundle-Localization");
         if (bundleLocalization != null) {
-            InputStream is = jar.getInputStream(jar.getEntry(bundleLocalization + ".properties"));
-            try {
+            try (InputStream is = jar.getInputStream(jar.getEntry(bundleLocalization + ".properties"))) {
                 localized.load(is);
-            } finally {
-                is.close();
             }
         }
         return fakeOSGiInfoXml(attr, localized, whereFrom);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
@@ -75,7 +75,7 @@ public class MakeUpdateDesc extends MatchingTask {
 
     /** Set of NBMs presented as a folder in the Update Center. */
     public /*static*/ class Group {
-        public List<FileSet> filesets = new ArrayList<FileSet>();
+        public List<FileSet> filesets = new ArrayList<>();
 	public String name;
 
         /** Displayed name of the group. */
@@ -100,9 +100,9 @@ public class MakeUpdateDesc extends MatchingTask {
 	}
     }
 
-    private List<Entityinclude> entityincludes = new ArrayList<Entityinclude>();
-    private List<Group> groups = new ArrayList<Group>();
-    private List<FileSet> filesets = new ArrayList<FileSet>();
+    private List<Entityinclude> entityincludes = new ArrayList<>();
+    private List<Group> groups = new ArrayList<>();
+    private List<FileSet> filesets = new ArrayList<>();
 
     private File desc;
 
@@ -346,7 +346,7 @@ public class MakeUpdateDesc extends MatchingTask {
                 pw.println ();
                 writeContentDescription(pw);
                 pw.println ();
-		Map<String,Element> licenses = new HashMap<String,Element>();
+		Map<String,Element> licenses = new HashMap<>();
                 String prefix = null;
                 if (dist_base != null) {
                     // fix/enforce distribution URL base
@@ -526,9 +526,9 @@ public class MakeUpdateDesc extends MatchingTask {
         };
         Map<String,Collection<Module>> r = automaticGrouping ?
             // generally will be creating groups on the fly, so sort them:
-            new TreeMap<String,Collection<Module>>(groupNameComparator) :
+            new TreeMap<>(groupNameComparator) :
             // preserve explicit order of <group>s:
-            new LinkedHashMap<String,Collection<Module>>();
+            new LinkedHashMap<>();
         // sort modules by display name (where available):
         Comparator<Module> moduleDisplayNameComparator = new Comparator<Module>() {
             public int compare(Module m1, Module m2) {
@@ -548,7 +548,7 @@ public class MakeUpdateDesc extends MatchingTask {
         for (Group g : groups) {
             Collection<Module> modules = r.get(g.name);
             if (modules == null) {
-                modules = new TreeSet<Module>(moduleDisplayNameComparator);
+                modules = new TreeSet<>(moduleDisplayNameComparator);
                 r.put(g.name, modules);
             }
             for (FileSet fs : g.filesets) {
@@ -586,7 +586,7 @@ public class MakeUpdateDesc extends MatchingTask {
                                 if (categ.length() > 0) {
                                     moduleCollection = r.get(categ);
                                     if (moduleCollection == null) {
-                                        moduleCollection = new TreeSet<Module>(moduleDisplayNameComparator);
+                                        moduleCollection = new TreeSet<>(moduleDisplayNameComparator);
                                         r.put(categ, moduleCollection);
                                     }
                                 }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
@@ -617,7 +617,7 @@ public class ModuleDependencies extends Task {
 
     private boolean dependsOnTransitively(String kit1, String kit2, 
         TreeMap<String, TreeSet<String>> dependingKits) {
-        TreeSet kits = dependingKits.get(kit1);
+        TreeSet<String> kits = dependingKits.get(kit1);
         if (kits == null) {
             return false;
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleDependencies.java
@@ -59,8 +59,8 @@ import org.apache.tools.ant.types.FileSet;
  * http://openide.netbeans.org/proposals/arch/clusters.html#verify-solution
  */
 public class ModuleDependencies extends Task {
-    private List<Input> inputs = new ArrayList<Input>();
-    private List<Output> outputs = new ArrayList<Output>();
+    private List<Input> inputs = new ArrayList<>();
+    private List<Output> outputs = new ArrayList<>();
     private Set<ModuleInfo> modules;
     private Pattern regexp;
     
@@ -137,7 +137,7 @@ public class ModuleDependencies extends Task {
     }
     
     private void readModuleInfo () throws IOException {
-        modules = new TreeSet<ModuleInfo>();
+        modules = new TreeSet<>();
         
         if (inputs.isEmpty()) {
             throw new BuildException ("At least one <input> tag is needed");
@@ -208,8 +208,8 @@ public class ModuleDependencies extends Task {
 
                 m.implementationVersion = file.getManifest ().getMainAttributes ().getValue ("OpenIDE-Module-Implementation-Version");
 
-                TreeSet<Dependency> depends = new TreeSet<Dependency>();
-                TreeSet<Dependency> provides = new TreeSet<Dependency>();
+                TreeSet<Dependency> depends = new TreeSet<>();
+                TreeSet<Dependency> provides = new TreeSet<>();
                 addDependencies (depends, file.getManifest (), Dependency.Type.REQUIRES, "OpenIDE-Module-Requires");
                 addDependencies (depends, file.getManifest (), Dependency.Type.REQUIRES, "OpenIDE-Module-Needs");
                 addDependencies (depends, file.getManifest (), Dependency.Type.RECOMMENDS, "OpenIDE-Module-Recommends");
@@ -228,14 +228,14 @@ public class ModuleDependencies extends Task {
                  org.openide.loaders,org.openide.src > 1.0
                  */
                 m.depends = depends;
-                m.provides = new HashSet<String>();
+                m.provides = new HashSet<>();
                 for (Dependency d : provides) {
                     m.provides.add(d.getName());
                 }
                 {
                     String friends = file.getManifest ().getMainAttributes ().getValue ("OpenIDE-Module-Friends"); 
                     if (friends != null) {
-			TreeSet<String> set = new TreeSet<String>();
+			TreeSet<String> set = new TreeSet<>();
                         StringTokenizer tok = new StringTokenizer(friends, ", ");
 			while (tok.hasMoreElements()) {
 			    set.add(tok.nextToken());
@@ -285,8 +285,8 @@ public class ModuleDependencies extends Task {
     
 
     private void generatePublicPackages(File output, boolean justPublic, boolean justInterCluster) throws BuildException, IOException {
-        TreeSet<String> packages = new TreeSet<String>();
-        TreeMap<ModuleInfo,TreeSet<String>> friendExports = new TreeMap<ModuleInfo,TreeSet<String>>();
+        TreeSet<String> packages = new TreeSet<>();
+        TreeMap<ModuleInfo,TreeSet<String>> friendExports = new TreeMap<>();
         
         {
             for (ModuleInfo m : modules) {
@@ -302,7 +302,7 @@ public class ModuleDependencies extends Task {
                 String s = m.publicPackages;
                 Map<String,Boolean> pkgs = null;
                 if (s != null) {
-                    pkgs = new HashMap<String,Boolean>();
+                    pkgs = new HashMap<>();
                     StringTokenizer tok = new StringTokenizer(s, ",");
                     while (tok.hasMoreElements()) {
                         String p = tok.nextToken().trim();
@@ -328,7 +328,7 @@ public class ModuleDependencies extends Task {
                         throw new BuildException("Not enough packages found. The declared packages are: " + s + " but only " + packages + " were found in " + m.file);
                     }
                 } else {
-                    TreeSet<String> modulePkgs = new TreeSet<String>();
+                    TreeSet<String> modulePkgs = new TreeSet<>();
                     iterateThruPackages(m.file, pkgs, modulePkgs);
                     friendExports.put(m, modulePkgs);
                 }
@@ -467,9 +467,9 @@ public class ModuleDependencies extends Task {
     }
 
     private void generateListOfDisabledAutoloads(File output) throws BuildException, IOException {
-        Map<String,Set<String>> depsAll = new TreeMap<String,Set<String>>();
-        Map<String,ModuleInfo> considered = new TreeMap<String,ModuleInfo>();
-        Set<String> regular = new HashSet<String>();
+        Map<String,Set<String>> depsAll = new TreeMap<>();
+        Map<String,ModuleInfo> considered = new TreeMap<>();
+        Set<String> regular = new HashSet<>();
         for (ModuleInfo m : modules) {
             if (regexp != null && !regexp.matcher(m.group).matches()) {
                 continue;
@@ -479,7 +479,7 @@ public class ModuleDependencies extends Task {
             } else if (!m.isEager) {
                 regular.add(m.codebasename);
             }
-            Set<String> deps = new TreeSet<String>();
+            Set<String> deps = new TreeSet<>();
             depsAll.put(m.codebasename, deps);
             for (Dependency d : m.depends) {
                 for (ModuleInfo m2 : findModuleInfo(d, m)) {
@@ -488,7 +488,7 @@ public class ModuleDependencies extends Task {
             }
         }
         transitiveClosure(depsAll);
-        Map<String,Set<ModuleInfo>> disabled = new TreeMap<String,Set<ModuleInfo>>();
+        Map<String,Set<ModuleInfo>> disabled = new TreeMap<>();
         for (Map.Entry<String, Set<String>> entry : depsAll.entrySet()) {
             if (!regular.contains(entry.getKey())) {
                 continue;
@@ -500,7 +500,7 @@ public class ModuleDependencies extends Task {
         for (ModuleInfo m : considered.values()) {
             Set<ModuleInfo> group = disabled.get(m.group);
             if (group == null) {
-                group = new TreeSet<ModuleInfo>();
+                group = new TreeSet<>();
                 disabled.put(m.group, group);
             }
             group.add(m);
@@ -523,7 +523,7 @@ public class ModuleDependencies extends Task {
         // calculate transitive closure of modules
         TreeMap<String, TreeSet<String>> allModuleDeps = transitiveClosureOfModules();
         // create a map of <module, kits that depend on it>
-        TreeMap<ModuleInfo, Set<String>> dependingKits = new TreeMap<ModuleInfo, Set<String>>();
+        TreeMap<ModuleInfo, Set<String>> dependingKits = new TreeMap<>();
         for (ModuleInfo m : modules) {
             if (regexp != null && !regexp.matcher(m.group).matches()) {
                 continue;
@@ -544,7 +544,7 @@ public class ModuleDependencies extends Task {
                         // regular module, not a kit
                         Set<String> kits = dependingKits.get(theModuleOneIsDependingOn);
                         if (kits == null) {
-                            kits = new TreeSet<String>();
+                            kits = new TreeSet<>();
                             dependingKits.put(theModuleOneIsDependingOn, kits);
                         }
                         kits.add(m.getName(false));
@@ -556,7 +556,7 @@ public class ModuleDependencies extends Task {
         }
         // now check that there is one canonical kit that "contains" the module
         // at the same time create a map of <kit, set of <module>>
-        TreeMap<String, TreeSet<String>> allKits = new TreeMap<String, TreeSet<String>>();
+        TreeMap<String, TreeSet<String>> allKits = new TreeMap<>();
         for (ModuleInfo module : dependingKits.keySet()) {
             Set<String> kits = dependingKits.get(module);
             // candidate for the lowest kit
@@ -634,17 +634,17 @@ public class ModuleDependencies extends Task {
     private static void registerModuleInKit(ModuleInfo module, String kit, TreeMap<String, TreeSet<String>> allKits) {
         TreeSet<String> modules = allKits.get(kit);
         if (modules == null) {
-            modules = new TreeSet<String>();
+            modules = new TreeSet<>();
             allKits.put(kit, modules);
         }
         modules.add(module.getName(false));
     }
 
     private TreeMap<String, TreeSet<String>> transitiveClosureOfModules() {
-        TreeMap<String, TreeSet<String>> moduleDepsAll = new TreeMap<String, TreeSet<String>>();
+        TreeMap<String, TreeSet<String>> moduleDepsAll = new TreeMap<>();
         // populate with modules first
         for (ModuleInfo m : modules) {
-            TreeSet<String> deps = new TreeSet<String>();
+            TreeSet<String> deps = new TreeSet<>();
             moduleDepsAll.put(m.codebasename, deps);
             for (Dependency d : m.depends) {
                 for (ModuleInfo theModuleOneIsDependingOn : findModuleInfo(d, m)) {
@@ -658,11 +658,11 @@ public class ModuleDependencies extends Task {
     
     
     private TreeMap<String, TreeSet<String>> transitiveClosureOfKits() {
-        TreeMap<String, TreeSet<String>> kitDepsAll = new TreeMap<String, TreeSet<String>>();
+        TreeMap<String, TreeSet<String>> kitDepsAll = new TreeMap<>();
         // populate with kits first
         for (ModuleInfo m : modules) {
             if (m.showInAutoupdate) {
-                TreeSet<String> deps = new TreeSet<String>();
+                TreeSet<String> deps = new TreeSet<>();
                 kitDepsAll.put(m.getName(false), deps);
                 for (Dependency d : m.depends) {
                     for (ModuleInfo theModuleOneIsDependingOn : findModuleInfo(d, m)) {
@@ -687,7 +687,7 @@ public class ModuleDependencies extends Task {
             needAnotherIteration = false;
             for (Map.Entry<T,? extends Set<T>> entry : allDeps.entrySet()) {
                 Set<T> deps = entry.getValue();
-                for (T d : new TreeSet<T>(deps)) {
+                for (T d : new TreeSet<>(deps)) {
                     for (T d2: allDeps.get(d)) {
                         if (deps.add(d2)) {
                             log("transitive closure: need to add " + d2 + " to " + entry.getKey(), Project.MSG_DEBUG);
@@ -726,7 +726,7 @@ public class ModuleDependencies extends Task {
     }
 
     private void generatePlugins(File output) throws BuildException, IOException {
-        Set<String> standardClusters = new HashSet<String>();
+        Set<String> standardClusters = new HashSet<>();
         String standardClustersS = getProject().getProperty("clusters.config.full.list");
         if (standardClustersS != null) {
             for (String clusterProp : standardClustersS.split(",")) {
@@ -739,7 +739,7 @@ public class ModuleDependencies extends Task {
         FileWriter fw = new FileWriter(output);
         try {
             PrintWriter w = new PrintWriter(fw);
-            SortedMap<String,String> lines = new TreeMap<String,String>(Collator.getInstance());
+            SortedMap<String,String> lines = new TreeMap<>(Collator.getInstance());
             lines.put("A", "||Code Name Base||Display Name||Display Category||Standard Cluster");
             lines.put("C", "");
             lines.put("D", "||Code Name Base||Display Name||Display Category||Extra Cluster");
@@ -773,7 +773,7 @@ public class ModuleDependencies extends Task {
                 if (clusterDeps == null) {
                     throw new BuildException("no property ${nb.cluster." + m.group + ".depends} defined");
                 }
-                Set<String> allowed = new HashSet<String>();
+                Set<String> allowed = new HashSet<>();
                 allowed.add(m.group);
                 for (String piece : clusterDeps.split(",")) {
                     allowed.add(piece.replaceFirst("^nb[.]cluster[.]", ""));
@@ -799,15 +799,15 @@ public class ModuleDependencies extends Task {
     }
 
     private void generateSharedPackages (File output) throws BuildException, IOException {
-        TreeMap<String,List<ModuleInfo>> packages = new TreeMap<String,List<ModuleInfo>>();
+        TreeMap<String,List<ModuleInfo>> packages = new TreeMap<>();
         
         for (ModuleInfo m : modules) {
-            HashSet<String> pkgs = new HashSet<String>();
+            HashSet<String> pkgs = new HashSet<>();
             iterateSharedPackages(m.file, pkgs);
             for (String s : pkgs) {
                 List<ModuleInfo> l = packages.get(s);
                 if (l == null) {
-                    l = new ArrayList<ModuleInfo>();
+                    l = new ArrayList<>();
                     packages.put(s, l);
                 }
                 l.add(m);
@@ -822,7 +822,7 @@ public class ModuleDependencies extends Task {
             }
             List<ModuleInfo> cnt = entry.getValue();
             if (cnt.size() > 1) {
-                SortedSet<String> cnbs = new TreeSet<String>();
+                SortedSet<String> cnbs = new TreeSet<>();
                 for (ModuleInfo m : cnt) {
                     if (regexp == null || regexp.matcher(m.group).matches()) {
                         cnbs.add(m.codebasename);
@@ -878,7 +878,7 @@ public class ModuleDependencies extends Task {
         PrintWriter w = new PrintWriter (new FileWriter (output));
         for (ModuleInfo m : modules) {
             boolean first = true;
-            Set<ModuleInfo> written = new HashSet<ModuleInfo>(); // XXX needed for other uses of findModuleInfo too
+            Set<ModuleInfo> written = new HashSet<>(); // XXX needed for other uses of findModuleInfo too
             for (Dependency d : m.depends) {
                 if (d.getName().startsWith("org.openide.modules.ModuleFormat")) {
                     continue; // just clutter
@@ -919,19 +919,19 @@ public class ModuleDependencies extends Task {
     private void generateGroupDependencies (File output, boolean implementationOnly) throws BuildException, IOException {
         PrintWriter w = new PrintWriter (new FileWriter (output));
 
-        Map<Dependency,Set<ModuleInfo>> referrers = new HashMap<Dependency,Set<ModuleInfo>>();
+        Map<Dependency,Set<ModuleInfo>> referrers = new HashMap<>();
         
-        TreeMap<String, Set<Dependency>> groups = new TreeMap<String, Set<Dependency>>();
+        TreeMap<String, Set<Dependency>> groups = new TreeMap<>();
         for (ModuleInfo m : modules) {
             if (regexp != null && !regexp.matcher(m.group).matches()) {
                 continue;
             }
             Set<Dependency> l = groups.get(m.group);
             if (l == null) {
-                l = new TreeSet<Dependency>();
+                l = new TreeSet<>();
                 groups.put(m.group, l);
             }
-            Set<Dependency> deps = new HashSet<Dependency>();
+            Set<Dependency> deps = new HashSet<>();
             for (Dependency d : m.depends) {
                 if (implementationOnly && (!d.exact || d.compare == null)) {
                     continue;
@@ -946,7 +946,7 @@ public class ModuleDependencies extends Task {
             for (Dependency d : deps) {
                 Set<ModuleInfo> r = referrers.get(d);
                 if (r == null) {
-                    r = new HashSet<ModuleInfo>();
+                    r = new HashSet<>();
                     referrers.put(d, r);
                 }
                 r.add(m);
@@ -987,7 +987,7 @@ public class ModuleDependencies extends Task {
         if (dep.isSpecial()) {
             return Collections.emptySet();
         }
-        Set<ModuleInfo> result = new LinkedHashSet<ModuleInfo>();
+        Set<ModuleInfo> result = new LinkedHashSet<>();
         for (ModuleInfo info : modules) {
             if (dep.isDependingOn (info)) {
                 result.add(info);
@@ -1058,7 +1058,7 @@ public class ModuleDependencies extends Task {
             this.dir = dir;
         }
         Collection<Input> inputs() {
-            List<Input> inputs = new ArrayList<Input>();
+            List<Input> inputs = new ArrayList<>();
             for (File cluster : dir.listFiles()) {
                 if (!new File(cluster, "update_tracking").isDirectory()) {
                     continue;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
@@ -140,8 +140,7 @@ final class ModuleListParser {
                     project.log("Loading module list from " + scanCache);
                 }
                 try {
-                    InputStream is = new FileInputStream(scanCache);
-                    try {
+                    try (InputStream is = new FileInputStream(scanCache)) {
                         ObjectInput oi = new ObjectInputStream(new BufferedInputStream(is));
                         @SuppressWarnings("unchecked") Map<File,Long[]> timestampsAndSizes = (Map) oi.readObject();
                         boolean matches = true;
@@ -178,8 +177,6 @@ final class ModuleListParser {
                                 project.log("Loaded modules: " + entries.keySet(), Project.MSG_DEBUG);
                             }
                         }
-                    } finally {
-                        is.close();
                     }
                 } catch (Exception x) {
                     if (project != null) {
@@ -228,8 +225,7 @@ final class ModuleListParser {
                     project.log("Cache depends on files: " + timestampsAndSizes.keySet(), Project.MSG_DEBUG);
                 }
                 scanCache.getParentFile().mkdirs();
-                OutputStream os = new FileOutputStream(scanCache);
-                try {
+                try (OutputStream os = new FileOutputStream(scanCache)) {
                     ObjectOutput oo = new ObjectOutputStream(os);
                     oo.writeObject(timestampsAndSizes);
                     if (doFastScan) {
@@ -237,8 +233,6 @@ final class ModuleListParser {
                     }
                     oo.writeObject(entries);
                     oo.flush();
-                } finally {
-                    os.close();
                 }
             }
             SOURCE_SCAN_CACHE.put(root, entries);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
@@ -290,9 +290,8 @@ final class ModuleListParser {
         Project fakeproj = new Project();
         if (project != null) {
             // Try to debug any problems in the following definitions (cf. #59849).
-            Iterator it = project.getBuildListeners().iterator();
-            while (it.hasNext()) {
-                fakeproj.addBuildListener((BuildListener) it.next());
+            for(BuildListener bl: project.getBuildListeners()) {
+                fakeproj.addBuildListener(bl);
             }
         }
         fakeproj.setBaseDir(dir); // in case ${basedir} is used somewhere

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleListParser.java
@@ -96,7 +96,7 @@ final class ModuleListParser {
         Map<String,Entry> entries = SOURCE_SCAN_CACHE.get(root);
         if (entries == null) {
             // Similar to #62221: if just invoked from a module in standard clusters, only scan those clusters (faster):
-            Set<String> standardModules = new HashSet<String>();
+            Set<String> standardModules = new HashSet<>();
             boolean doFastScan = false;
             String basedir = (String) properties.get("basedir");
             if (basedir != null) {
@@ -158,9 +158,9 @@ final class ModuleListParser {
                         if (doFastScan) {
                             @SuppressWarnings("unchecked") Set<String> storedStandardModules = (Set) oi.readObject();
                             if (!standardModules.equals(storedStandardModules)) {
-                                Set<String> added = new TreeSet<String>(standardModules);
+                                Set<String> added = new TreeSet<>(standardModules);
                                 added.removeAll(storedStandardModules);
-                                Set<String> removed = new TreeSet<String>(storedStandardModules);
+                                Set<String> removed = new TreeSet<>(storedStandardModules);
                                 removed.removeAll(standardModules);
                                 project.log("Cache ignored due to changes in modules among standard clusters: + " + added + " - " + removed);
                                 matches = false;
@@ -188,8 +188,8 @@ final class ModuleListParser {
                 }
             }
             if (entries == null) {
-                entries = new HashMap<String,Entry>();
-                Map<File,Long[]> timestampsAndSizes = new HashMap<File,Long[]>();
+                entries = new HashMap<>();
+                Map<File,Long[]> timestampsAndSizes = new HashMap<>();
                 registerTimestampAndSize(new File(root, "nbbuild" + File.separatorChar + "cluster.properties"), timestampsAndSizes);
                 registerTimestampAndSize(new File(root, "nbbuild" + File.separatorChar + "build.properties"), timestampsAndSizes);
                 registerTimestampAndSize(new File(root, "nbbuild" + File.separatorChar + "user.build.properties"), timestampsAndSizes);
@@ -408,7 +408,7 @@ final class ModuleListParser {
             assert false : moduleType;
         }
         File jar = fakeproj.resolveFile(fakeproj.replaceProperties("${cluster}/${module.jar}"));
-        List<File> exts = new ArrayList<File>();
+        List<File> exts = new ArrayList<>();
         for (Element ext : XMLUtil.findSubElements(dataEl)) {
             if (!ext.getLocalName().equals("class-path-extension")) {
                 continue;
@@ -450,22 +450,22 @@ final class ModuleListParser {
                 exts.add(resultBin);
             }
         }
-        List<String> prereqs = new ArrayList<String>();
-        List<String> rundeps = new ArrayList<String>();
+        List<String> prereqs = new ArrayList<>();
+        List<String> rundeps = new ArrayList<>();
         Element depsEl = ParseProjectXml.findNBMElement(dataEl, "module-dependencies");
         if (depsEl == null) {
             throw new IOException("Malformed project file " + projectxml);
         }
         Element testDepsEl = ParseProjectXml.findNBMElement(dataEl,"test-dependencies");
          //compileDeps = Collections.emptyList();
-        Map<String,String[]> compileTestDeps = new HashMap<String,String[]>();
+        Map<String,String[]> compileTestDeps = new HashMap<>();
         if (testDepsEl != null) {
             for (Element depssEl : XMLUtil.findSubElements(testDepsEl)) {
                 String testtype = ParseProjectXml.findTextOrNull(depssEl,"name") ;
                 if (testtype == null) {
                     throw new IOException("Must declare <name>unit</name> (e.g.) in <test-type> in " + projectxml);
                 }
-                List<String> compileDepsList = new ArrayList<String>();
+                List<String> compileDepsList = new ArrayList<>();
                 for (Element dep : XMLUtil.findSubElements(depssEl)) {
                     if (dep.getTagName().equals("test-dependency")) {
                         if (ParseProjectXml.findNBMElement(dep,"test") != null)  {
@@ -537,7 +537,7 @@ final class ModuleListParser {
      * Find all modules in a binary build, possibly from cache.
      */
     private static Map<String,Entry> scanBinaries(Project project, File[] clusters) throws IOException {
-        Map<String,Entry> allEntries = new HashMap<String,Entry>();
+        Map<String,Entry> allEntries = new HashMap<>();
 
         for (File cluster : clusters) {
             Map<String, Entry> entries = BINARY_SCAN_CACHE.get(cluster);
@@ -545,7 +545,7 @@ final class ModuleListParser {
                 if (project != null) {
                     project.log("Scanning for modules in " + cluster);
                 }
-                entries = new HashMap<String, Entry>();
+                entries = new HashMap<>();
                 doScanBinaries(cluster, entries);
                 if (project != null) {
                     project.log("Found modules: " + entries.keySet(), Project.MSG_VERBOSE);
@@ -646,7 +646,7 @@ final class ModuleListParser {
             if (project != null) {
                 project.log("Scanning for modules in suite " + suite);
             }
-            entries = new HashMap<String,Entry>();
+            entries = new HashMap<>();
             doScanSuite(entries, suite, properties, project);
             if (project != null) {
                 project.log("Found modules: " + entries.keySet(), Project.MSG_VERBOSE);
@@ -686,7 +686,7 @@ final class ModuleListParser {
         File basedir = new File((String) properties.get("project"));
         Entry entry = STANDALONE_SCAN_CACHE.get(basedir);
         if (entry == null) {
-            Map<String,Entry> entries = new HashMap<String,Entry>();
+            Map<String,Entry> entries = new HashMap<>();
             if (!scanPossibleProject(basedir, entries, properties, null, ModuleType.STANDALONE, project, null)) {
                 throw new IOException("No valid module found in " + basedir);
             }
@@ -807,7 +807,7 @@ final class ModuleListParser {
      * @return a set of all known entries
      */
     public Set<Entry> findAll() {
-        return new HashSet<Entry>(entries.values());
+        return new HashSet<>(entries.values());
     }
     
     /**
@@ -827,7 +827,7 @@ final class ModuleListParser {
         if (moduleDependencies == null) {
             return new String[0];
         }
-        List<String> cnds = new ArrayList<String>();
+        List<String> cnds = new ArrayList<>();
         StringTokenizer toks = new StringTokenizer(moduleDependencies,",");
         while (toks.hasMoreTokens()) {
             String token = toks.nextToken().trim();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
@@ -79,8 +79,7 @@ public final class ModuleSelector extends BaseExtendSelector {
         
         String module = null;
         if (file.getName().endsWith(".jar")) {
-            try {
-                JarFile jar = new JarFile(file);
+            try (JarFile jar = new JarFile(file)) {
                 Manifest m = jar.getManifest();
                 if (m != null) {
                     module = m.getMainAttributes().getValue("OpenIDE-Module"); // NOI18N
@@ -92,7 +91,6 @@ public final class ModuleSelector extends BaseExtendSelector {
                         }
                     }
                 }
-                jar.close();
             } catch (IOException ex) {
                 throw new BuildException("Problem with " + file + ": " + ex, ex, getLocation());
             }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
@@ -196,11 +196,7 @@ public final class ModuleSelector extends BaseExtendSelector {
                 fileToOwningModule = new HashMap<>();
                 try {
                     readUpdateTracking(getProject(), p.getValue(), fileToOwningModule);
-                } catch (IOException ex) {
-                    throw new BuildException(ex);
-                } catch (ParserConfigurationException ex) {
-                    throw new BuildException(ex);
-                } catch (SAXException ex) {
+                } catch (IOException | ParserConfigurationException | SAXException ex) {
                     throw new BuildException(ex);
                 }
                 log("Will accept these files: " + fileToOwningModule.keySet(), Project.MSG_VERBOSE);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
@@ -164,9 +164,9 @@ public final class ModuleSelector extends BaseExtendSelector {
             return;
         }
         
-        includeClusters = new HashSet<String>();
-        excludeClusters = new HashSet<String>();
-        excludeModules = new HashSet<String>();
+        includeClusters = new HashSet<>();
+        excludeClusters = new HashSet<>();
+        excludeModules = new HashSet<>();
         
         Parameter[] arr = getParameters();
         if (arr == null) {
@@ -195,7 +195,7 @@ public final class ModuleSelector extends BaseExtendSelector {
                 continue;
             }
             if ("updateTrackingFiles".equals(p.getName())) {
-                fileToOwningModule = new HashMap<String,String>();
+                fileToOwningModule = new HashMap<>();
                 try {
                     readUpdateTracking(getProject(), p.getValue(), fileToOwningModule);
                 } catch (IOException ex) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleStateSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleStateSelector.java
@@ -80,11 +80,7 @@ public final class ModuleStateSelector extends BaseExtendSelector {
         }
         try {
             return readConfig(getProject(), module, file);
-        } catch (SAXException ex) {
-            throw new BuildException(ex);
-        } catch (IOException ex) {
-            throw new BuildException(ex);
-        } catch (ParserConfigurationException ex) {
+        } catch (SAXException | IOException | ParserConfigurationException ex) {
             throw new BuildException(ex);
         }
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleTestDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleTestDependencies.java
@@ -67,8 +67,8 @@ public class ModuleTestDependencies extends Task {
         try {
             Hashtable<String,Object> props = getProject().getProperties();
             ModuleListParser mlp = new ModuleListParser(props, ModuleType.NB_ORG, getProject());
-            SortedMap<String,SortedSet<String>> deps = new TreeMap<String,SortedSet<String>>();
-            SortedMap<String,SortedSet<String>> reverseDeps = reverseOutput != null ? new TreeMap<String,SortedSet<String>>() : null;
+            SortedMap<String,SortedSet<String>> deps = new TreeMap<>();
+            SortedMap<String,SortedSet<String>> reverseDeps = reverseOutput != null ? new TreeMap<>() : null;
             File nball = new File((String) props.get("nb_all"));
             for (ModuleListParser.Entry entry : mlp.findAll()) {
                 String myCnb = entry.getCnb();
@@ -86,7 +86,7 @@ public class ModuleTestDependencies extends Task {
                     if (clusterDeps == null) {
                         throw new BuildException("no property ${nb.cluster." + myCluster + ".depends} defined");
                     }
-                    Set<String> allowed = new HashSet<String>();
+                    Set<String> allowed = new HashSet<>();
                     allowed.add(myCluster);
                     allowed.add("harness");
                     for (String piece : clusterDeps.split(",")) {
@@ -105,7 +105,7 @@ public class ModuleTestDependencies extends Task {
                             if (ParseProjectXml.TestDeps.UNIT.equals(testType) && ParseProjectXml.findNBMElement(dep, "test") != null && ParseProjectXml.findNBMElement(dep, "compile-dependency") != null) {
                                 SortedSet<String> depsForMe = deps.get(myCnbAndCluster);
                                 if (depsForMe == null) {
-                                    depsForMe = new TreeSet<String>();
+                                    depsForMe = new TreeSet<>();
                                     deps.put(myCnbAndCluster, depsForMe);
                                 }
                                 depsForMe.add(targetCnbAndCluster);
@@ -113,7 +113,7 @@ public class ModuleTestDependencies extends Task {
                             if (reverseDeps != null && !targetCnb.equals("org.netbeans.libs.junit4") && !allowed.contains(targetCluster)) {
                                 SortedSet<String> depsForMe = reverseDeps.get(myCnbAndCluster);
                                 if (depsForMe == null) {
-                                    depsForMe = new TreeSet<String>();
+                                    depsForMe = new TreeSet<>();
                                     reverseDeps.put(myCnbAndCluster, depsForMe);
                                 }
                                 depsForMe.add(targetCnbAndCluster);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
@@ -39,17 +39,17 @@ import org.apache.tools.ant.Task;
 public class NbMerge extends Task {
     
     private File dest;
-    private Vector<String> modules = new Vector<String> (); // list of modules defined by build.xml
-    private Vector<String> buildmodules = new Vector<String> (); // list of modules which will be built
-    private Vector<String> fixedmodules = new Vector<String> (); // list of fixed modules defined in build.xml
-    private Vector<String> buildfixedmodules = new Vector<String> (); // List of fixed modules which will be built
-    private Vector<String> failedmodules = new Vector<String> (); // List of failed modules
-    private Vector<String> builtmodules = new Vector<String> (); // list of successfully built modules
-    private Vector<String> mergemodules = new Vector<String> (); // list of successfully built modules
-    private Vector<String> builttargets = new Vector<String> (); // list of successfully built targets
+    private Vector<String> modules = new Vector<> (); // list of modules defined by build.xml
+    private Vector<String> buildmodules = new Vector<> (); // list of modules which will be built
+    private Vector<String> fixedmodules = new Vector<> (); // list of fixed modules defined in build.xml
+    private Vector<String> buildfixedmodules = new Vector<> (); // List of fixed modules which will be built
+    private Vector<String> failedmodules = new Vector<> (); // List of failed modules
+    private Vector<String> builtmodules = new Vector<> (); // list of successfully built modules
+    private Vector<String> mergemodules = new Vector<> (); // list of successfully built modules
+    private Vector<String> builttargets = new Vector<> (); // list of successfully built targets
     private String targetprefix = "all-";    
-    private List<File> topdirs = new ArrayList<File> ();
-    private List<Suppress> suppress = new LinkedList<Suppress> ();
+    private List<File> topdirs = new ArrayList<> ();
+    private List<Suppress> suppress = new LinkedList<> ();
     private boolean failonerror = true; // false = enable build success granularity
     private boolean mergedependentmodules = false; // merge also dependent modules
     private String dummyName;
@@ -83,7 +83,7 @@ public class NbMerge extends Task {
     /** Comma-separated list of fixed modules to include. */
     public void setFixedModules (String s) {
         StringTokenizer tok = new StringTokenizer (s, ", ");
-        fixedmodules = new Vector<String> ();
+        fixedmodules = new Vector<> ();
         while (tok.hasMoreTokens ())
             fixedmodules.addElement (tok.nextToken ());
     }
@@ -91,7 +91,7 @@ public class NbMerge extends Task {
     /** Comma-separated list of modules to include. */
     public void setModules (String s) {
         StringTokenizer tok = new StringTokenizer (s, ", ");
-        modules = new Vector<String> ();
+        modules = new Vector<> ();
         while (tok.hasMoreTokens ())
             modules.addElement (tok.nextToken ());
     }
@@ -181,7 +181,7 @@ public class NbMerge extends Task {
         Vector<Target> fullList = getProject().topoSort(dummyName, targets);
         // Now remove earlier ones: already done.
         Vector doneList = getProject().topoSort(getOwningTarget().getName(), targets);
-        List<Target> todo = new ArrayList<Target>(fullList.subList(0, fullList.indexOf(dummy)));
+        List<Target> todo = new ArrayList<>(fullList.subList(0, fullList.indexOf(dummy)));
         todo.removeAll(doneList.subList(0, doneList.indexOf(getOwningTarget())));
         log("Going to execute targets " + todo);
         for (Target nexttargit: todo) {
@@ -221,7 +221,7 @@ public class NbMerge extends Task {
                 // Now remove earlier ones: already done.
                 @SuppressWarnings("unchecked")
                 Vector<Target> doneList = getProject().topoSort(getOwningTarget().getName(), targets);
-                List<Target> todo = new ArrayList<Target>(fullList.subList(0, fullList.indexOf(dummy)));
+                List<Target> todo = new ArrayList<>(fullList.subList(0, fullList.indexOf(dummy)));
                 todo.removeAll(doneList.subList(0, doneList.indexOf(getOwningTarget())));
                 
                 Iterator<Target> targit = todo.iterator();
@@ -290,7 +290,7 @@ public class NbMerge extends Task {
             
             if ( mergemodules.size() > 0 ) {
                 if ( builtmodulesproperty.length() > 0 ) {
-                    Vector<String> setmodules = new Vector<String>();
+                    Vector<String> setmodules = new Vector<>();
                     // add all successfuly built modules
                     setmodules.addAll(mergemodules);
                     // remove all fixed modules (don't put fixed modules to modules list)
@@ -315,7 +315,7 @@ public class NbMerge extends Task {
 
     /** Do final data merge */
     private void dataMerge() throws BuildException {
-        List<String> suppressedlocales = new LinkedList<String> ();
+        List<String> suppressedlocales = new LinkedList<> ();
         Iterator it = suppress.iterator ();
         while (it.hasNext ()) {
             Suppress s = (Suppress) it.next ();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/NbMerge.java
@@ -180,7 +180,7 @@ public class NbMerge extends Task {
         @SuppressWarnings("unchecked")
         Vector<Target> fullList = getProject().topoSort(dummyName, targets);
         // Now remove earlier ones: already done.
-        Vector doneList = getProject().topoSort(getOwningTarget().getName(), targets);
+        Vector<Target> doneList = getProject().topoSort(getOwningTarget().getName(), targets);
         List<Target> todo = new ArrayList<>(fullList.subList(0, fullList.indexOf(dummy)));
         todo.removeAll(doneList.subList(0, doneList.indexOf(getOwningTarget())));
         log("Going to execute targets " + todo);
@@ -316,9 +316,7 @@ public class NbMerge extends Task {
     /** Do final data merge */
     private void dataMerge() throws BuildException {
         List<String> suppressedlocales = new LinkedList<> ();
-        Iterator it = suppress.iterator ();
-        while (it.hasNext ()) {
-            Suppress s = (Suppress) it.next ();
+        for (Suppress s: suppress) {
             if (s.iftest != null && getProject().getProperty(s.iftest) == null) {
                 continue;
             } else if (s.unlesstest != null && getProject().getProperty(s.unlesstest) != null) {
@@ -326,12 +324,11 @@ public class NbMerge extends Task {
             }
             log ("Suppressing locale: " + s.locale);
             suppressedlocales.add (s.locale);
-        }        
+        }
 
         UpdateTracking tr = new UpdateTracking( dest.getAbsolutePath() );
         log ( dest.getAbsolutePath() );
-        while (it.hasNext ()) {
-          String locale = (String) it.next ();
+        for(String locale: suppressedlocales) {
           tr.removeLocalized(locale);
         }
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseManifest.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseManifest.java
@@ -72,15 +72,12 @@ public class ParseManifest extends Task {
             throw new BuildException("Must specify parameter 'attribute'.");
         }
         try {
-            BufferedInputStream is = new BufferedInputStream(new FileInputStream(manifest));
-            try {
+            try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(manifest))) {
                 Manifest mf = new Manifest(is);
                 String attr = mf.getMainAttributes().getValue(attribute);
                 if (attr == null)
                     return;
                 getProject().setProperty(property, attr);
-            } finally {
-                is.close();
             }
         } catch (Exception x) {
             throw new BuildException("Reading manifest " + manifest + ": " + x, x, getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
@@ -480,8 +480,7 @@ public final class ParseProjectXml extends Task {
                 StringBuilder aliases = null;
                 File hgmail = new File(getProject().getProperty("nb_all"), ".hgmail");
                 if (hgmail.canRead()) {
-                    Reader r = new FileReader(hgmail);
-                    try {
+                    try (Reader r = new FileReader(hgmail)) {
                         BufferedReader br = new BufferedReader(r);
                         String line;
                         while ((line = br.readLine()) != null) {
@@ -500,8 +499,6 @@ public final class ParseProjectXml extends Task {
                                 }
                             }
                         }
-                    } finally {
-                        r.close();
                     }
                 } else {
                     log("Cannot find " + hgmail + " to read addresses from", Project.MSG_VERBOSE);
@@ -695,11 +692,8 @@ public final class ParseProjectXml extends Task {
         private String implementationVersionOf(ModuleListParser modules, String cnb) throws BuildException {
             File jar = computeClasspathModuleLocation(modules, cnb, null, null, false);
             try {
-                JarFile jarFile = new JarFile(jar, false);
-                try {
+                try (JarFile jarFile = new JarFile(jar, false)) {
                     return jarFile.getManifest().getMainAttributes().getValue("OpenIDE-Module-Implementation-Version");
-                } finally {
-                    jarFile.close();
                 }
             } catch (IOException e) {
                 throw new BuildException(e, getLocation());
@@ -976,11 +970,8 @@ public final class ParseProjectXml extends Task {
             if (depJar.isFile()) { // might be false for m.run.cp if DO_NOT_RECURSE and have a runtime-only dep
                 Attributes attr;
                 try {
-                    JarFile jarFile = new JarFile(depJar, false);
-                    try {
+                    try (JarFile jarFile = new JarFile(depJar, false)) {
                         attr = jarFile.getManifest().getMainAttributes();
-                    } finally {
-                        jarFile.close();
                     }
                 } catch (ZipException x) {
                     throw new BuildException("Could not open " + depJar + ": " + x, x, getLocation());
@@ -1479,8 +1470,7 @@ public final class ParseProjectXml extends Task {
         Pattern p = Pattern.compile("(" + corePattern + ")[^/]+[.].+");
         boolean foundAtLeastOneEntry = false;
         // E.g.: (org/netbeans/api/foo/|org/netbeans/spi/foo/)[^/]+[.].+
-        OutputStream os = new FileOutputStream(ppjar);
-        try {
+        try (OutputStream os = new FileOutputStream(ppjar)) {
             ZipOutputStream zos = new ZipOutputStream(os);
             Set<String> addedPaths = new HashSet<>();
             for (File jar : jars) {
@@ -1488,8 +1478,7 @@ public final class ParseProjectXml extends Task {
                     log("Classpath entry " + jar + " does not exist; skipping", Project.MSG_WARN);
                     continue;
                 }
-                InputStream is = new FileInputStream(jar);
-                try {
+                try (InputStream is = new FileInputStream(jar)) {
                     ZipInputStream zis = new ZipInputStream(is);
                     ZipEntry inEntry;
                     while ((inEntry = zis.getNextEntry()) != null) {
@@ -1518,13 +1507,9 @@ public final class ParseProjectXml extends Task {
                         zos.putNextEntry(outEntry);
                         zos.write(data);
                     }
-                } finally {
-                    is.close();
                 }
             }
             zos.close();
-        } finally {
-            os.close();
         }
         if (!foundAtLeastOneEntry) {
             ppjar.delete();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
@@ -278,7 +278,7 @@ public final class ParseProjectXml extends Task {
             this.compileDep = compileDep;
         }
      }
-      List<TestType> testTypes = new LinkedList<TestType>();
+      List<TestType> testTypes = new LinkedList<>();
       
       public void addTestType(TestType testType) {
           testTypes.add(testType);
@@ -320,7 +320,7 @@ public final class ParseProjectXml extends Task {
                 // Ensure project.xml is valid according to schema.
                 File nball = new File(getProject().getProperty("nb_all"));
                 SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-                List<Source> sources = new ArrayList<Source>();
+                List<Source> sources = new ArrayList<>();
                 String[] xsds = {
                     "project.ant/src/org/netbeans/modules/project/ant/project.xsd",
                     "apisupport.project/src/org/netbeans/modules/apisupport/project/resources/nb-module-project2.xsd",
@@ -591,7 +591,7 @@ public final class ParseProjectXml extends Task {
         if (pp == null) {
             throw new BuildException("No <public-packages>", getLocation());
         }
-        List<PublicPackage> pkgs = new ArrayList<PublicPackage>();
+        List<PublicPackage> pkgs = new ArrayList<>();
         for (Element p : XMLUtil.findSubElements(pp)) {
             boolean sub = false;
             if ("friend".equals(p.getNodeName())) {
@@ -619,7 +619,7 @@ public final class ParseProjectXml extends Task {
         if (pp == null) {
             return null;
         }
-        List<String> friends = new ArrayList<String>();
+        List<String> friends = new ArrayList<>();
         boolean other = false;
         for (Element p : XMLUtil.findSubElements(pp)) {
             if ("friend".equals(p.getNodeName())) {
@@ -785,8 +785,8 @@ public final class ParseProjectXml extends Task {
         if (md == null) {
             throw new BuildException("No <module-dependencies>", getLocation());
         }
-        List<Dep> deps = new ArrayList<Dep>();
-        List<URL> moduleAutoDeps = new ArrayList<URL>();
+        List<Dep> deps = new ArrayList<>();
+        List<URL> moduleAutoDeps = new ArrayList<>();
         for (Element dep : XMLUtil.findSubElements(md)) {
             Element cnb = findNBMElement(dep, "code-name-base");
             if (cnb == null) {
@@ -842,7 +842,7 @@ public final class ParseProjectXml extends Task {
         if (moduleAutoDeps.isEmpty()) {
             return;
         }
-        Set<String> depsS = new HashSet<String>();
+        Set<String> depsS = new HashSet<>();
         String result;
         AntClassLoader loader = new AntClassLoader();
         try {
@@ -894,7 +894,7 @@ public final class ParseProjectXml extends Task {
             return;
         }
         log("warning: " + result, Project.MSG_WARN);
-        Set<String> noCompileDeps = new HashSet<String>();
+        Set<String> noCompileDeps = new HashSet<>();
         Iterator<Dep> it = deps.iterator();
         while (it.hasNext()) {
             Dep d = it.next();
@@ -944,7 +944,7 @@ public final class ParseProjectXml extends Task {
         Path clusterPathS = (Path) getProject().getReference("cluster.path.id");
         Set<File> clusterPath = null;
         if (clusterPathS != null) {
-            clusterPath = new HashSet<File>();
+            clusterPath = new HashSet<>();
             for (Iterator<?> it = clusterPathS.iterator(); it.hasNext();) {
                 File oneCluster = ((FileResource) it.next()).getFile();
                 clusterPath.add(oneCluster);
@@ -952,7 +952,7 @@ public final class ParseProjectXml extends Task {
         }
         String excludedModulesProp = getProject().getProperty("disabled.modules");
         Set<String> excludedModules = excludedModulesProp != null ?
-            new HashSet<String>(Arrays.asList(excludedModulesProp.split(" *, *"))) :
+            new HashSet<>(Arrays.asList(excludedModulesProp.split(" *, *"))) :
             null;
         for (Dep dep : deps) {
             if (!runtime && !dep.compile) {
@@ -961,10 +961,10 @@ public final class ParseProjectXml extends Task {
             String cnb = dep.codenamebase;
             File depJar = computeClasspathModuleLocation(modules, cnb, clusterPath, excludedModules, runtime);
 
-            List<File> additions = new ArrayList<File>();
+            List<File> additions = new ArrayList<>();
             additions.add(depJar);
             if (recursive) {
-                addRecursiveDeps(additions, modules, cnb, clusterPath, excludedModules, new HashSet<String>(), runtime);
+                addRecursiveDeps(additions, modules, cnb, clusterPath, excludedModules, new HashSet<>(), runtime);
             }
             
             // #52354: look for <class-path-extension>s in dependent modules.
@@ -1132,7 +1132,7 @@ public final class ParseProjectXml extends Task {
       // unit, qa-functional, performance
       final String testtype;
       // all dependecies for the testtype
-      final  List<TestDep> dependencies = new ArrayList<TestDep>();
+      final  List<TestDep> dependencies = new ArrayList<>();
       // code name base of tested module
       final String cnb;
       final ModuleListParser modulesParser;
@@ -1154,7 +1154,7 @@ public final class ParseProjectXml extends Task {
        }
       
       public List<String> getFiles(boolean compile) {
-          List<String> files = new ArrayList<String>();
+          List<String> files = new ArrayList<>();
           for (TestDep d : dependencies) {
               files.addAll(d.getFiles(compile));
           }
@@ -1189,7 +1189,7 @@ public final class ParseProjectXml extends Task {
         }
         private String getPath(List<String> files) {
             StringBuffer path = new StringBuffer();
-            Set<String> filesSet = new HashSet<String>();
+            Set<String> filesSet = new HashSet<>();
             for (String filePath : files) {
                 if (!filesSet.contains(filePath)) {
                     if (path.length() > 0) {
@@ -1211,7 +1211,7 @@ public final class ParseProjectXml extends Task {
      * @return relative project folder paths separated by comma
      */
     public  String getTestCompileDep() {
-        Set<String> cnbs = new HashSet<String>();
+        Set<String> cnbs = new HashSet<>();
         StringBuilder builder = new StringBuilder();
         computeCompileDep(cnb,cnbs,builder);
         return (builder.length() > 0) ? builder.toString() : null;
@@ -1254,7 +1254,7 @@ public final class ParseProjectXml extends Task {
     
    private void addMissingEntry(String cnb) {
         if (missingEntries == null) {
-            missingEntries = new HashSet<String>();
+            missingEntries = new HashSet<>();
         }
         missingEntries.add(cnb);
     }
@@ -1313,9 +1313,9 @@ public final class ParseProjectXml extends Task {
        /* get modules dependecies
         */
        List<ModuleListParser.Entry> getModules() {
-           List<ModuleListParser.Entry> entries = new ArrayList<ModuleListParser.Entry>();
+           List<ModuleListParser.Entry> entries = new ArrayList<>();
            if (recursive ) {
-               Map<String,ModuleListParser.Entry> entriesMap = new HashMap<String,ModuleListParser.Entry>();
+               Map<String,ModuleListParser.Entry> entriesMap = new HashMap<>();
                addRecursiveModules(cnb,entriesMap);
                entries.addAll(entriesMap.values());
            } else {
@@ -1351,7 +1351,7 @@ public final class ParseProjectXml extends Task {
            }
        }
        List<String> getFiles(boolean compile) {
-           List<String> files = new ArrayList<String>();
+           List<String> files = new ArrayList<>();
            if (!compile ||  ( compile && this.compile)) {
                List<ModuleListParser.Entry> modules = getModules();
                for (ModuleListParser.Entry entry : getModules()) {
@@ -1482,7 +1482,7 @@ public final class ParseProjectXml extends Task {
         OutputStream os = new FileOutputStream(ppjar);
         try {
             ZipOutputStream zos = new ZipOutputStream(os);
-            Set<String> addedPaths = new HashSet<String>();
+            Set<String> addedPaths = new HashSet<>();
             for (File jar : jars) {
                 if (!jar.isFile()) {
                     log("Classpath entry " + jar + " does not exist; skipping", Project.MSG_WARN);
@@ -1552,7 +1552,7 @@ public final class ParseProjectXml extends Task {
     private TestDeps[] getTestDeps(Document pDoc,ModuleListParser modules,String testCnb) {
         assert modules != null;
         Element cfg = getConfig(pDoc);
-        List<TestDeps> testDepsList = new ArrayList<TestDeps>();
+        List<TestDeps> testDepsList = new ArrayList<>();
         Element pp = findNBMElement(cfg, "test-dependencies");
         boolean existsUnitTests = false;
         boolean existsQaFunctionalTests = false;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PathFileSet.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PathFileSet.java
@@ -82,7 +82,7 @@ public class PathFileSet extends DataType implements ResourceCollection, Selecto
         this.include = include;
     }
 
-    private List<Path> paths = new ArrayList<Path>();
+    private List<Path> paths = new ArrayList<>();
 
     /**
      * Adds path in classpath notation. Searched in addition
@@ -218,7 +218,7 @@ public class PathFileSet extends DataType implements ResourceCollection, Selecto
     private void initFiles() throws BuildException {
         if (files != null) return;
         try {
-            files = new ArrayList<Resource>();
+            files = new ArrayList<>();
             log("ClusterPathSet: scanning " + paths.size() + " paths.", Project.MSG_VERBOSE);
             DirectoryScanner scanner = new DirectoryScanner();
             if (paths.size() == 0) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
@@ -205,12 +205,9 @@ public class PrintIcon extends Task {
                         _hash += (rgb >> 2);
                     }
                 }
-            } catch (IOException e) {
+            } catch (IOException | IndexOutOfBoundsException e) {
                 p.log("Broken icon at " + from, Project.MSG_WARN);
                 _hash = hash(e);
-            } catch (IndexOutOfBoundsException ex) {
-                p.log("Broken icon at " + from, Project.MSG_WARN);
-                _hash = hash(ex);
             }
             
             this.hash = _hash;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
@@ -109,48 +109,48 @@ public class PrintIcon extends Task {
                 Set<IconInfo> both = new TreeSet<>(firstSet);
                 both.addAll(sndSet);
                 
-                BufferedWriter os = new BufferedWriter(new FileWriter(duplicates));
-                IconInfo prev = null;
-                boolean prevPrinted = false;
-                for (IconInfo info : both) {
-                    IconInfo p = prev;
-                    prev = info;
-                    if (p == null || p.hash != info.hash) {
-                        prevPrinted = false;
-                        continue;
-                    }
-                    
-                    if (!prevPrinted) {
-                        os.write(p.toString());
+                try (BufferedWriter os = new BufferedWriter(new FileWriter(duplicates))) {
+                    IconInfo prev = null;
+                    boolean prevPrinted = false;
+                    for (IconInfo info : both) {
+                        IconInfo p = prev;
+                        prev = info;
+                        if (p == null || p.hash != info.hash) {
+                            prevPrinted = false;
+                            continue;
+                        }
+                        
+                        if (!prevPrinted) {
+                            os.write(p.toString());
+                            os.newLine();
+                            prevPrinted = true;
+                        }
+                        
+                        os.write(info.toString());
                         os.newLine();
-                        prevPrinted = true;
                     }
-                    
-                    os.write(info.toString());
-                    os.newLine();
                 }
-                os.close();
             }
             if (difference != null) {
                 SortedSet<IconInfo> union = new TreeSet<>(firstSet);
                 union.addAll(sndSet);
                 
-                BufferedWriter os = new BufferedWriter(new FileWriter(difference));
-                for (IconInfo info : union) {
-                    if (!contains(firstSet, info.hash)) {
-                        os.write('+');
-                        os.write(info.toString());
-                        os.newLine();
-                        continue;
-                    }
-                    if (!contains(sndSet, info.hash)) {
-                        os.write('-');
-                        os.write(info.toString());
-                        os.newLine();
-                        continue;
+                try (BufferedWriter os = new BufferedWriter(new FileWriter(difference))) {
+                    for (IconInfo info : union) {
+                        if (!contains(firstSet, info.hash)) {
+                            os.write('+');
+                            os.write(info.toString());
+                            os.newLine();
+                            continue;
+                        }
+                        if (!contains(sndSet, info.hash)) {
+                            os.write('-');
+                            os.write(info.toString());
+                            os.newLine();
+                            continue;
+                        }
                     }
                 }
-                os.close();
             }
             
         } catch (IOException ex) {
@@ -192,9 +192,9 @@ public class PrintIcon extends Task {
             BufferedImage image;
             int _hash;
             try {
-                InputStream is = from.openStream();
-                image = ImageIO.read(is);
-                is.close();
+                try (InputStream is = from.openStream()) {
+                    image = ImageIO.read(is);
+                }
                 int w = image.getWidth();
                 int h = image.getHeight();
                 _hash = w * 3 + h * 7;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/PrintIcon.java
@@ -89,14 +89,14 @@ public class PrintIcon extends Task {
         
         try {
             
-            SortedSet<IconInfo> firstSet = new TreeSet<IconInfo>();
+            SortedSet<IconInfo> firstSet = new TreeSet<>();
             for (String f : first.getDirectoryScanner(getProject()).getIncludedFiles()) {
                 File baseDir = first.getDir(getProject());
                 File file = new File(baseDir, f);
                 firstSet.add(new IconInfo(file.toURI().toURL(), getProject()));
             }
 
-            SortedSet<IconInfo> sndSet = new TreeSet<IconInfo>();
+            SortedSet<IconInfo> sndSet = new TreeSet<>();
             if (second != null) {
                 for (String f : second.getDirectoryScanner(getProject()).getIncludedFiles()) {
                     File baseDir = second.getDir(getProject());
@@ -106,7 +106,7 @@ public class PrintIcon extends Task {
             }
             
             if (duplicates != null) {
-                Set<IconInfo> both = new TreeSet<IconInfo>(firstSet);
+                Set<IconInfo> both = new TreeSet<>(firstSet);
                 both.addAll(sndSet);
                 
                 BufferedWriter os = new BufferedWriter(new FileWriter(duplicates));
@@ -132,7 +132,7 @@ public class PrintIcon extends Task {
                 os.close();
             }
             if (difference != null) {
-                SortedSet<IconInfo> union = new TreeSet<IconInfo>(firstSet);
+                SortedSet<IconInfo> union = new TreeSet<>(firstSet);
                 union.addAll(sndSet);
                 
                 BufferedWriter os = new BufferedWriter(new FileWriter(difference));

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
@@ -133,11 +133,8 @@ public final class ProcessJsAnnotationsTask extends Task {
         }
         
         byte[] arr = new byte[(int)f.length()];
-        FileInputStream is = new FileInputStream(f);
-        try {
+        try (FileInputStream is = new FileInputStream(f)) {
             readArr(arr, is);
-        } finally {
-            is.close();
         }
 
         byte[] newArr = null;
@@ -159,11 +156,8 @@ public final class ProcessJsAnnotationsTask extends Task {
     }
 
     private void writeArr(File f, byte[] newArr) throws IOException, FileNotFoundException {
-        FileOutputStream os = new FileOutputStream(f);
-        try {
+        try (FileOutputStream os = new FileOutputStream(f)) {
             os.write(newArr);
-        } finally {
-            os.close();
         }
     }
 
@@ -186,32 +180,32 @@ public final class ProcessJsAnnotationsTask extends Task {
             className = className.substring(0, className.length() - 6);
         }
         
-        BufferedReader r = new BufferedReader(new FileReader(f));
         List<String> arr = new ArrayList<>();
         boolean modified = false;
-        for (;;) {
-            String line = r.readLine();
-            if (line == null) {
-                break;
+        try (BufferedReader r = new BufferedReader(new FileReader(f))) {
+            for (;;) {
+                String line = r.readLine();
+                if (line == null) {
+                    break;
+                }
+                if (line.endsWith(className)) {
+                    modified = true;
+                    continue;
+                }
+                arr.add(line);
             }
-            if (line.endsWith(className)) {
-                modified = true;
-                continue;
-            }
-            arr.add(line);
         }
-        r.close();
         
         if (modified) {
             if (arr.isEmpty()) {
                 f.delete();
             } else {
-                FileWriter w = new FileWriter(f);
-                for (String l : arr) {
-                    w.write(l);
-                    w.write("\n");
+                try (FileWriter w = new FileWriter(f)) {
+                    for (String l : arr) {
+                        w.write(l);
+                        w.write("\n");
+                    }
                 }
-                w.close();
             }
         }
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ProcessJsAnnotationsTask.java
@@ -75,7 +75,7 @@ public final class ProcessJsAnnotationsTask extends Task {
             return;
         }
         
-        LinkedList<URL> arr = new LinkedList<URL>();
+        LinkedList<URL> arr = new LinkedList<>();
         boolean foundAsm = false;
         for (String s : cp.list()) {
             final File f = FileUtils.getFileUtils().resolveFile(getProject().getBaseDir(), s);
@@ -187,7 +187,7 @@ public final class ProcessJsAnnotationsTask extends Task {
         }
         
         BufferedReader r = new BufferedReader(new FileReader(f));
-        List<String> arr = new ArrayList<String>();
+        List<String> arr = new ArrayList<>();
         boolean modified = false;
         for (;;) {
             String line = r.readLine();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RatReportTask.java
@@ -147,7 +147,7 @@ public class RatReportTask extends Task {
                 modulebycluster.get(clusterName).add(amo);
             }
         }
-        modulebycluster.put(OTHERS_AREA, new HashSet<String>());
+        modulebycluster.put(OTHERS_AREA, new HashSet<>());
         for (String k : moduleDB) {
             modulebycluster.get(OTHERS_AREA).add(k);
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
@@ -160,11 +160,8 @@ public final class RefreshDependencyVersions extends Task {
 
             Document nbprj = null;
             try {
-                InputStream is = new FileInputStream(projectFile);
-                try {
+                try (InputStream is = new FileInputStream(projectFile)) {
                     nbprj = XMLUtil.parse(new InputSource(is), false, true, null, null);
-                } finally {
-                    is.close();
                 }
             } catch (Exception ioe) {
                 throw new BuildException("Can't parse " + projectFile, ioe, getLocation());
@@ -242,11 +239,8 @@ public final class RefreshDependencyVersions extends Task {
             if (updated) {
                 try {
                     if (!dryRun) {
-                        OutputStream os = new FileOutputStream(projectFile);
-                        try {
+                        try (OutputStream os = new FileOutputStream(projectFile)) {
                             XMLUtil.write(nbprj, os);
-                        } finally {
-                            os.close();
                         }
                     } else {
                         if (!projectFile.canWrite()) {
@@ -427,8 +421,7 @@ public final class RefreshDependencyVersions extends Task {
     }
     
     private static String[] gulp(File file, String enc) throws IOException {
-        InputStream is = new FileInputStream(file);
-        try {
+        try (InputStream is = new FileInputStream(file)) {
             BufferedReader r = new BufferedReader(new InputStreamReader(is, enc));
             List<String> l = new ArrayList<>();
             String line;
@@ -436,8 +429,6 @@ public final class RefreshDependencyVersions extends Task {
                 l.add(line);
             }
             return l.toArray(new String[l.size()]);
-        } finally {
-            is.close();
         }
     }
     

--- a/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/RefreshDependencyVersions.java
@@ -56,7 +56,7 @@ public final class RefreshDependencyVersions extends Task {
     private String specification;
     
     private boolean dryRun = false;
-    private final Set<Dep> injectDeps = new HashSet<Dep>();
+    private final Set<Dep> injectDeps = new HashSet<>();
     
     public RefreshDependencyVersions() {}
     
@@ -430,7 +430,7 @@ public final class RefreshDependencyVersions extends Task {
         InputStream is = new FileInputStream(file);
         try {
             BufferedReader r = new BufferedReader(new InputStreamReader(is, enc));
-            List<String> l = new ArrayList<String>();
+            List<String> l = new ArrayList<>();
             String line;
             while ((line = r.readLine()) != null) {
                 l.add(line);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Repeat.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Repeat.java
@@ -45,7 +45,7 @@ public class Repeat extends Task {
     //
     
     public Repeat() {
-        values = new ArrayList<String>();
+        values = new ArrayList<>();
         target    = null;
     }
 
@@ -65,7 +65,7 @@ public class Repeat extends Task {
         log ("SET values = " + s, Project.MSG_DEBUG);
 
         StringTokenizer tok = new StringTokenizer (s, ", ");
-        values = new ArrayList<String>();
+        values = new ArrayList<>();
         while ( tok.hasMoreTokens() ) {
             values.add (tok.nextToken().trim());
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ResolveList.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ResolveList.java
@@ -40,7 +40,7 @@ public class ResolveList extends Task {
     /** Comma-separated list of properties to expand */
     public void setList (String s) {
         StringTokenizer tok = new StringTokenizer (s, ", ");
-        properties = new ArrayList<String>();
+        properties = new ArrayList<>();
         while (tok.hasMoreTokens ())
             properties.add(tok.nextToken ());
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SetCluster.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SetCluster.java
@@ -78,7 +78,7 @@ public class SetCluster extends Task {
             throw new BuildException("The name of current module have to be set", getLocation());
         }
 
-        Map<String,String> clusterByModule = new HashMap<String,String>(); // e.g. "serverplugins/jboss4" => "j2ee"
+        Map<String,String> clusterByModule = new HashMap<>(); // e.g. "serverplugins/jboss4" => "j2ee"
         for (Object key : getProject().getProperties().keySet()) {
             String property = (String) key;
             String clusterDir = getProject().getProperty(property + ".dir");
@@ -87,7 +87,7 @@ public class SetCluster extends Task {
             }
             String list = this.getProject().getProperty( property );
             assert list != null : property;
-            Set<String> modules = new HashSet<String>();
+            Set<String> modules = new HashSet<>();
             StringTokenizer modTokens = new StringTokenizer(list," \t\n\f\r,");
             while (modTokens.hasMoreTokens()) {
                 String module = modTokens.nextToken();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
@@ -67,7 +67,7 @@ public class ShorterPaths extends Task {
             return dir + (excluded != null ? " - " + excluded : "") + " => ${" + name + "}";
         }
     }
-    private List<Replacement> replacements = new LinkedList<Replacement>(); // List<Nestme>
+    private List<Replacement> replacements = new LinkedList<>(); // List<Nestme>
 
     public Replacement createReplacement() {
         Replacement r = new Replacement();
@@ -334,7 +334,7 @@ public class ShorterPaths extends Task {
      * @return a tokenization of that path into components
      */
     public static String[] tokenizePath(String path) {
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         StringTokenizer tok = new StringTokenizer(path, ":;", true); // NOI18N
         char dosHack = '\0';
         char lastDelim = '\0';

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ShorterPaths.java
@@ -154,32 +154,31 @@ public class ShorterPaths extends Task {
 
             if (testProperties != null) {
                 // create properties file
-                PrintWriter pw = new PrintWriter(testProperties);
-
-                // copy extra unit.test.properties
-                Map<String,Object> properties = getProject().getProperties();
-                StringBuffer outProp = new StringBuffer();
-                for (String name : properties.keySet()) {
-                    if (name.matches("test-(unit|qa-functional)-sys-prop\\..+")) {
-                        if (name.equals("test-unit-sys-prop.xtest.data")) {
-                            // ignore overring xtest.data.dir, data.zip placed to standard location
-                            continue;
+                try (PrintWriter pw = new PrintWriter(testProperties)) {
+                    // copy extra unit.test.properties
+                    Map<String,Object> properties = getProject().getProperties();
+                    StringBuffer outProp = new StringBuffer();
+                    for (String name : properties.keySet()) {
+                        if (name.matches("test-(unit|qa-functional)-sys-prop\\..+")) {
+                            if (name.equals("test-unit-sys-prop.xtest.data")) {
+                                // ignore overring xtest.data.dir, data.zip placed to standard location
+                                continue;
+                            }
+                            //
+                            outProp.setLength(0);
+                            for (String path : tokenizePath(properties.get(name).toString())) {
+                                replacePath(path, outProp);
+                            }
+                            pw.println(name.replaceFirst("^test-(unit|qa-functional)-sys-prop\\.", "test-sys-prop.") + "=" + outProp);
+                        } else if (name.startsWith("test.config")) {
+                            pw.println(name + "=" + properties.get(name));
+                        } else if ("requires.nb.javac".equals(name)) {
+                            pw.println(name + "=" + properties.get(name));
                         }
-                        //  
-                        outProp.setLength(0);
-                        for (String path : tokenizePath(properties.get(name).toString())) {
-                            replacePath(path, outProp);
-                        }
-                        pw.println(name.replaceFirst("^test-(unit|qa-functional)-sys-prop\\.", "test-sys-prop.") + "=" + outProp);
-                    } else if (name.startsWith("test.config")) {
-                        pw.println(name + "=" + properties.get(name));
-                    } else if ("requires.nb.javac".equals(name)) {
-                        pw.println(name + "=" + properties.get(name));
                     }
+                    pw.println("extra.test.libs=" + externalLibBuf.toString());
+                    pw.println("test.run.cp=" + nbLibBuff.toString());
                 }
-                pw.println("extra.test.libs=" + externalLibBuf.toString());
-                pw.println("test.run.cp=" + nbLibBuff.toString());
-                pw.close();
             }
         } catch (IOException ex) {
             throw new BuildException(ex);
@@ -283,12 +282,9 @@ public class ShorterPaths extends Task {
         if (wasCopied && file.getName().endsWith(".jar")) {
             String cp;
             try {
-                JarFile jf = new JarFile(file);
-                try {
+                try (JarFile jf = new JarFile(file)) {
                     Manifest manifest = jf.getManifest();
                     cp = manifest != null ? manifest.getMainAttributes().getValue(Name.CLASS_PATH) : null;
-                } finally {
-                    jf.close();
                 }
             } catch (IOException x) {
                 log("Could not parse " + file + " for Class-Path", Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
@@ -195,11 +195,11 @@ public class Sigtest extends Task {
             String email = getProject().getProperty("sigtest.mail");
             if (email != null) {
                 try {
-                    FileWriter w = new FileWriter(outputFile);
-                    w.write("email: ");
-                    w.write(email);
-                    w.write("\n");
-                    w.close();
+                    try (FileWriter w = new FileWriter(outputFile)) {
+                        w.write("email: ");
+                        w.write(email);
+                        w.write("\n");
+                    }
                 } catch (IOException ex) {
                     throw new BuildException(ex);
                 }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Sigtest.java
@@ -261,7 +261,7 @@ public class Sigtest extends Task {
     private void apitest() throws Exception {
         URLClassLoader url = new URLClassLoader(new URL[] { sigtestJar.toURI().toURL() }, Sigtest.class.getClassLoader());
         Class<?> clazz = url.loadClass("org.netbeans.apitest.Sigtest");
-        Task task = (Task)clazz.newInstance();
+        Task task = (Task) clazz.getConstructor().newInstance();
         
         task.setProject(getProject());
         task.setTaskName(getTaskName());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
@@ -21,19 +21,14 @@ package org.netbeans.nbbuild;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
 import java.util.TreeMap;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -143,11 +138,8 @@ public class SortSuiteModules extends Task {
                 Element testDepsEl = ParseProjectXml.findNBMElement(data,"test-dependencies");
                 if (testDepsEl != null) {
                     // <test-type>
-                    Iterator itTType = XMLUtil.findSubElements(testDepsEl).iterator();
-                    while (itTType.hasNext()) {
-                        Iterator itt = XMLUtil.findSubElements((Element)itTType.next()).iterator();
-                        while (itt.hasNext()) {
-                            Element dep = (Element) itt.next();
+                    for(Element testDep: XMLUtil.findSubElements(testDepsEl)) {
+                        for(Element dep: XMLUtil.findSubElements(testDep)) {
                             if (ParseProjectXml.findNBMElement(dep, "test") == null) {
                                 continue;
                             }
@@ -182,7 +174,7 @@ public class SortSuiteModules extends Task {
         } catch (TopologicalSortException x) {
             throw new BuildException(x.getMessage(), x, getLocation());
         }
-        StringBuffer path = new StringBuffer();
+        StringBuilder path = new StringBuilder();
         for (String cnb: cnbs) {
             assert basedirsByCNB.containsKey(cnb);
             if (path.length() > 0) {
@@ -206,7 +198,7 @@ public class SortSuiteModules extends Task {
             List<T> cycle = visit(it.next(), edges, finished, r);
 
             if (cycle != null) {
-                throw new TopologicalSortException(cRev, edges);
+                throw new TopologicalSortException("Cycle detected: " + cycle.toString());
             }
         }
 
@@ -227,7 +219,7 @@ public class SortSuiteModules extends Task {
 
         //System.err.println("node=" + node + " color=" + b);
         if (b != null) {
-            if (b.booleanValue()) {
+            if (b) {
                 return null;
             }
 
@@ -279,350 +271,22 @@ public class SortSuiteModules extends Task {
 
         return null;
     }
+
     private static final class TopologicalSortException extends Exception {
-        /** all vertexes */
 
-        private Collection vertexes;
-
-        /** map with edges */
-        private Map<?,? extends Collection<?>> edges;
-
-        /** result if called twice */
-        private Set[] result;
-
-        /** counter to number the vertexes */
-        private int counter;
-
-        /** vertexes sorted by increasing value of y */
-        private Stack<Vertex> dualGraph = new Stack<>();
-
-        TopologicalSortException(Collection vertexes, Map<?,? extends Collection<?>> edges) {
-            this.vertexes = vertexes;
-            this.edges = edges;
+        public TopologicalSortException() {
         }
 
-        /** Because the full sort was not possible, this methods
-     * returns the best possible substitute for it that is available.
-     *
-     * @return list of partially sorted objects, the list can be freely modified
-     */
-        public final List partialSort() {
-            Set[] all = topologicalSets();
-
-            ArrayList<Object> res = new ArrayList<>(vertexes.size());
-
-            for (int i = 0; i < all.length; i++) {
-                for (Object e : all[i]) {
-                    res.add(e);
-                }
-            }
-
-            return res;
+        public TopologicalSortException(String message) {
+            super(message);
         }
 
-        /** The topological sort could not be finished as there
-     * are some objects that are mutually refering to each other.
-     * This methods finds such objects and partition them into
-     * separate sets. All objects in one set (transitively) refer to
-     * each other and thus prevent the sort from succeding. As
-     * there can be more of such "unsortable sets" an array
-     * of them is returned.
-     *
-     * @return array of sets that contain some of the original objects, result
-     *   shall not be modified
-     */
-        public final Set[] unsortableSets() {
-            Set[] all = topologicalSets();
-
-            ArrayList<Set> unsort = new ArrayList<>();
-
-            for (int i = 0; i < all.length; i++) {
-                if ((all[i].size() > 1) || !(all[i] instanceof HashSet)) {
-                    unsort.add(all[i]);
-                }
-            }
-
-            return unsort.toArray(new Set[0]);
+        public TopologicalSortException(String message, Throwable cause) {
+            super(message, cause);
         }
 
-        @Override
-    public String getMessage() {
-            StringWriter w = new StringWriter();
-            try (PrintWriter pw = new PrintWriter(w)) {
-                printDebug(pw);
-            }
-            return w.toString();
-        }
-
-        @Override
-    public String toString() {
-            String s = getClass().getName();
-            return s;
-        }
-
-        private void printDebug(java.io.PrintWriter w) {
-            Set<Object> relevantVertices = new HashSet<>();
-            Set<?>[] bad = unsortableSets();
-            for (Set<?> s : bad) {
-                relevantVertices.addAll(s);
-            }
-            Map<Object,Collection<?>> relevantEdges = new HashMap<>();
-            for (Map.Entry<?,? extends Collection<?>> entry : edges.entrySet()) {
-                Set<Object> relevant = new HashSet<>(entry.getValue());
-                relevant.add(entry.getKey());
-                relevant.retainAll(relevantVertices);
-                if (!relevant.isEmpty()) {
-                    relevantEdges.put(entry.getKey(), entry.getValue());
-                }
-            }
-            w.print("TopologicalSortException - Collection with relevant edges "); // NOI18N
-            w.print(relevantEdges);
-            w.println(" cannot be sorted"); // NOI18N
-
-            for (int i = 0; i < bad.length; i++) {
-                w.print(" Conflict #"); // NOI18N
-                w.print(i);
-                w.print(": "); // NOI18N
-                w.println(bad[i]);
-            }
-        }
-
-        /** Adds description why the graph cannot be sorted.
-     * @param w writer to write to
-     */
-        public @Override final void printStackTrace(java.io.PrintWriter w) {
-            printDebug(w);
-            super.printStackTrace(w);
-        }
-
-        /** Adds description why the graph cannot be sorted.
-     * @param s stream to write to
-     */
-        public @Override final void printStackTrace(java.io.PrintStream s) {
-            java.io.PrintWriter w = new java.io.PrintWriter(s);
-            this.printStackTrace(w);
-            w.flush();
-        }
-
-        /** As the full topological sort cannot be finished due to cycles
-     * in the graph this methods performs a partition topological sort.
-     * <P>
-     * First of all it identifies unsortable parts of the graph and
-     * partitions the graph into sets of original objects. Each set contains
-     * objects that are mutually unsortable (there is a cycle between them).
-     * Then the topological sort is performed again on those sets, this
-     * sort succeeds because the graph of sets is DAG (all problematic edges
-     * were only between objects now grouped inside the sets) and the
-     * result forms the return value of this method.
-     *
-     * @return array of sorted sets that contain the original objects, each
-     *   object from the original collection is exactly in one set, result
-     *   shall not be modified
-     */
-        public final Set[] topologicalSets() {
-            if (result != null) {
-                return result;
-            }
-
-            HashMap<Object, Vertex> vertexInfo = new HashMap<>();
-
-            // computes value X and Y for each vertex
-            counter = 0;
-
-            Iterator it = vertexes.iterator();
-
-            while (it.hasNext()) {
-                constructDualGraph(counter, it.next(), vertexInfo);
-            }
-
-            // now connect vertexes that cannot be sorted into own
-        // sets
-        // map from the original objects to 
-            Map<Object, Set> objectsToSets = new HashMap<>();
-
-            ArrayList<Set> sets = new ArrayList<>();
-
-            while (!dualGraph.isEmpty()) {
-                Vertex v = dualGraph.pop();
-
-                if (!v.visited) {
-                    Set<Object> set = new HashSet<>();
-                    visitDualGraph(v, set);
-
-                    if ((set.size() == 1) && v.edgesFrom.contains(v)) {
-                        // mark if there is a self reference and the
-                    // set is only one element big, it means that there
-                    // is a self cycle
-                    //
-                    // do not use HashSet but Collections.singleton
-                    // to recognize such cycles
-                        set = Collections.singleton(v.object);
-                    }
-
-                    sets.add(set);
-
-                    // fill the objectsToSets mapping
-                    it = set.iterator();
-
-                    while (it.hasNext()) {
-                        objectsToSets.put(it.next(), set);
-                    }
-                }
-            }
-
-            // now topologically sort the sets
-        // 1. prepare the map
-            HashMap<Set, Collection<Set>> edgesBetweenSets = new HashMap<>();
-            it = edges.entrySet().iterator();
-
-            while (it.hasNext()) {
-                Map.Entry entry = (Map.Entry) it.next();
-                Collection leadsTo = (Collection) entry.getValue();
-
-                if ((leadsTo == null) || leadsTo.isEmpty()) {
-                    continue;
-                }
-
-                Set from = objectsToSets.get(entry.getKey());
-
-                Collection<Set> setsTo = edgesBetweenSets.get(from);
-
-                if (setsTo == null) {
-                    setsTo = new ArrayList<>();
-                    edgesBetweenSets.put(from, setsTo);
-                }
-
-                Iterator convert = leadsTo.iterator();
-
-                while (convert.hasNext()) {
-                    Set to = objectsToSets.get(convert.next());
-
-                    if (from != to) {
-                        // avoid self cycles
-                        setsTo.add(to);
-                    }
-                }
-            }
-
-            // 2. do the sort
-            try {
-                List<Set> listResult = topologicalSort(sets, edgesBetweenSets);
-                result = listResult.toArray(new Set[0]);
-            } catch (TopologicalSortException ex) {
-                throw new IllegalStateException("Cannot happen"); // NOI18N
-            }
-
-            return result;
-        }
-
-        /** Traverses the tree
-     * @param counter current value
-     * @param vertex current vertex
-     * @param vertexInfo the info
-     */
-        private Vertex constructDualGraph(int counter, Object vertex, HashMap<Object, Vertex> vertexInfo) {
-            Vertex info = vertexInfo.get(vertex);
-
-            if (info == null) {
-                info = new Vertex(vertex, counter++);
-                vertexInfo.put(vertex, info);
-            } else {
-                // already (being) processed
-                return info;
-            }
-
-            // process children
-            Collection c = (Collection) edges.get(vertex);
-
-            if (c != null) {
-                Iterator it = c.iterator();
-
-                while (it.hasNext()) {
-                    Vertex next = constructDualGraph(counter, it.next(), vertexInfo);
-                    next.edgesFrom.add(info);
-                }
-            }
-
-            // leaving the vertex
-            info.y = counter++;
-
-            dualGraph.push(info);
-
-            return info;
-        }
-
-        /** Visit dual graph. Decreasing value of Y gives the order.
-     * Number
-     *
-     * @param vertex vertex to start from
-     * @param visited list of all objects that we've been to
-     */
-        private void visitDualGraph(Vertex vertex, Collection<Object> visited) {
-            if (vertex.visited) {
-                return;
-            }
-
-            visited.add(vertex.object);
-            vertex.visited = true;
-
-            Iterator it = vertex.edges();
-
-            while (it.hasNext()) {
-                Vertex v = (Vertex) it.next();
-                visitDualGraph(v, visited);
-            }
-        }
-
-        /** Represents info about a vertex in the graph. Vertexes are
-     * comparable by the value of Y, but only after the value is set,
-     * so the sort has to be done latelly.
-     */
-        private static final class Vertex implements Comparable<Vertex> {
-            /** the found object */
-
-            public Object object;
-
-            /** list of vertexes that point to this one */
-            public List<Vertex> edgesFrom = new ArrayList<>();
-
-            /** the counter state when we entered the vertex */
-            public final int x;
-
-            /** the counter when we exited the vertex */
-            public int y;
-
-            /** already sorted, true if the edges has been sorted */
-            public boolean sorted;
-
-            /** true if visited in dual graph */
-            public boolean visited;
-
-            public Vertex(Object obj, int x) {
-                this.x = x;
-                this.object = obj;
-            }
-
-            /** Iterator over edges
-         * @return iterator of Vertex items
-         */
-            public Iterator edges() {
-                if (!sorted) {
-                    Collections.sort(edgesFrom);
-                    sorted = true;
-                }
-
-                return edgesFrom.iterator();
-            }
-
-            /** Comparing based on value of Y.
-         *
-         * @param   o the Object to be compared.
-         * @return  a negative integer, zero, or a positive integer as this object
-         *                 is less than, equal to, or greater than the specified object.
-         */
-            public int compareTo(Vertex o) {
-                return o.y - y;
-            }
+        public TopologicalSortException(Throwable cause) {
+            super(cause);
         }
 
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
@@ -350,9 +350,9 @@ public class SortSuiteModules extends Task {
         @Override
     public String getMessage() {
             StringWriter w = new StringWriter();
-            PrintWriter pw = new PrintWriter(w);
-            printDebug(pw);
-            pw.close();
+            try (PrintWriter pw = new PrintWriter(w)) {
+                printDebug(pw);
+            }
             return w.toString();
         }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
@@ -88,8 +88,8 @@ public class SortSuiteModules extends Task {
         if (sortedModulesProperty == null) {
             throw new BuildException("Must set sortedModulesProperty");
         }
-        Map<String,File> basedirsByCNB = new TreeMap<String,File>();
-        Map<String,List<String>> buildDeps = new HashMap<String,List<String>>();
+        Map<String,File> basedirsByCNB = new TreeMap<>();
+        Map<String,List<String>> buildDeps = new HashMap<>();
         for (String piece : unsortedModules.list()) {
             File d = new File(piece);
             File projectXml = new File(d, "nbproject" + File.separatorChar + "project.xml");
@@ -119,7 +119,7 @@ public class SortSuiteModules extends Task {
             }
             String cnb = XMLUtil.findText(cnbEl);
             basedirsByCNB.put(cnb, d);
-            List<String> deps = new LinkedList<String>();
+            List<String> deps = new LinkedList<>();
             Element depsEl = ParseProjectXml.findNBMElement(data, "module-dependencies");
             if (depsEl == null) {
                 throw new BuildException("Malformed project file " + projectXml, getLocation());
@@ -167,13 +167,13 @@ public class SortSuiteModules extends Task {
         for (List<String> deps: buildDeps.values()) {
             deps.retainAll(basedirsByCNB.keySet());
         }
-        Map<String,List<String>> reversedDeps = new HashMap<String,List<String>>();
+        Map<String,List<String>> reversedDeps = new HashMap<>();
         for (Map.Entry<String,List<String>> entry : buildDeps.entrySet()) {
             for (String from : entry.getValue()) {
                 String to = entry.getKey();
                 List<String> tos = reversedDeps.get(from);
                 if (tos == null) {
-                    reversedDeps.put(from, tos = new ArrayList<String>());
+                    reversedDeps.put(from, tos = new ArrayList<>());
                 }
                 tos.add(to);
             }
@@ -197,9 +197,9 @@ public class SortSuiteModules extends Task {
     // Stolen from org.openide.util.Utilities:
     private static <T> List<T> topologicalSort(Collection<T> c, Map<? super T, ? extends Collection<? extends T>> edges)
     throws TopologicalSortException {
-        Map<T,Boolean> finished = new HashMap<T,Boolean>();
-        List<T> r = new ArrayList<T>(Math.max(c.size(), 1));
-        List<T> cRev = new ArrayList<T>(c);
+        Map<T,Boolean> finished = new HashMap<>();
+        List<T> r = new ArrayList<>(Math.max(c.size(), 1));
+        List<T> cRev = new ArrayList<>(c);
         Collections.reverse(cRev);
 
         Iterator<T> it = cRev.iterator();
@@ -233,7 +233,7 @@ public class SortSuiteModules extends Task {
                 return null;
             }
 
-            ArrayList<T> cycle = new ArrayList<T>();
+            ArrayList<T> cycle = new ArrayList<>();
             cycle.add(node);
             finished.put(node, null);
 
@@ -296,7 +296,7 @@ public class SortSuiteModules extends Task {
         private int counter;
 
         /** vertexes sorted by increasing value of y */
-        private Stack<Vertex> dualGraph = new Stack<Vertex>();
+        private Stack<Vertex> dualGraph = new Stack<>();
 
         TopologicalSortException(Collection vertexes, Map<?,? extends Collection<?>> edges) {
             this.vertexes = vertexes;
@@ -311,7 +311,7 @@ public class SortSuiteModules extends Task {
         public final List partialSort() {
             Set[] all = topologicalSets();
 
-            ArrayList<Object> res = new ArrayList<Object>(vertexes.size());
+            ArrayList<Object> res = new ArrayList<>(vertexes.size());
 
             for (int i = 0; i < all.length; i++) {
                 for (Object e : all[i]) {
@@ -336,7 +336,7 @@ public class SortSuiteModules extends Task {
         public final Set[] unsortableSets() {
             Set[] all = topologicalSets();
 
-            ArrayList<Set> unsort = new ArrayList<Set>();
+            ArrayList<Set> unsort = new ArrayList<>();
 
             for (int i = 0; i < all.length; i++) {
                 if ((all[i].size() > 1) || !(all[i] instanceof HashSet)) {
@@ -363,14 +363,14 @@ public class SortSuiteModules extends Task {
         }
 
         private void printDebug(java.io.PrintWriter w) {
-            Set<Object> relevantVertices = new HashSet<Object>();
+            Set<Object> relevantVertices = new HashSet<>();
             Set<?>[] bad = unsortableSets();
             for (Set<?> s : bad) {
                 relevantVertices.addAll(s);
             }
-            Map<Object,Collection<?>> relevantEdges = new HashMap<Object,Collection<?>>();
+            Map<Object,Collection<?>> relevantEdges = new HashMap<>();
             for (Map.Entry<?,? extends Collection<?>> entry : edges.entrySet()) {
-                Set<Object> relevant = new HashSet<Object>(entry.getValue());
+                Set<Object> relevant = new HashSet<>(entry.getValue());
                 relevant.add(entry.getKey());
                 relevant.retainAll(relevantVertices);
                 if (!relevant.isEmpty()) {
@@ -426,7 +426,7 @@ public class SortSuiteModules extends Task {
                 return result;
             }
 
-            HashMap<Object, Vertex> vertexInfo = new HashMap<Object, Vertex>();
+            HashMap<Object, Vertex> vertexInfo = new HashMap<>();
 
             // computes value X and Y for each vertex
             counter = 0;
@@ -440,15 +440,15 @@ public class SortSuiteModules extends Task {
             // now connect vertexes that cannot be sorted into own
         // sets
         // map from the original objects to 
-            Map<Object, Set> objectsToSets = new HashMap<Object, Set>();
+            Map<Object, Set> objectsToSets = new HashMap<>();
 
-            ArrayList<Set> sets = new ArrayList<Set>();
+            ArrayList<Set> sets = new ArrayList<>();
 
             while (!dualGraph.isEmpty()) {
                 Vertex v = dualGraph.pop();
 
                 if (!v.visited) {
-                    Set<Object> set = new HashSet<Object>();
+                    Set<Object> set = new HashSet<>();
                     visitDualGraph(v, set);
 
                     if ((set.size() == 1) && v.edgesFrom.contains(v)) {
@@ -474,7 +474,7 @@ public class SortSuiteModules extends Task {
 
             // now topologically sort the sets
         // 1. prepare the map
-            HashMap<Set, Collection<Set>> edgesBetweenSets = new HashMap<Set, Collection<Set>>();
+            HashMap<Set, Collection<Set>> edgesBetweenSets = new HashMap<>();
             it = edges.entrySet().iterator();
 
             while (it.hasNext()) {
@@ -490,7 +490,7 @@ public class SortSuiteModules extends Task {
                 Collection<Set> setsTo = edgesBetweenSets.get(from);
 
                 if (setsTo == null) {
-                    setsTo = new ArrayList<Set>();
+                    setsTo = new ArrayList<>();
                     edgesBetweenSets.put(from, setsTo);
                 }
 
@@ -585,7 +585,7 @@ public class SortSuiteModules extends Task {
             public Object object;
 
             /** list of vertexes that point to this one */
-            public List<Vertex> edgesFrom = new ArrayList<Vertex>();
+            public List<Vertex> edgesFrom = new ArrayList<>();
 
             /** the counter state when we entered the vertex */
             public final int x;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SortSuiteModules.java
@@ -99,9 +99,7 @@ public class SortSuiteModules extends Task {
             Document doc;
             try {
                 doc = XMLUtil.parse(new InputSource(projectXml.toURI().toString()), false, true, null, null);
-            } catch (IOException e) {
-                throw new BuildException("Error parsing " + projectXml + ": " + e, e, getLocation());
-            } catch (SAXException e) {
+            } catch (IOException | SAXException e) {
                 throw new BuildException("Error parsing " + projectXml + ": " + e, e, getLocation());
             }
             Element config = XMLUtil.findElement(doc.getDocumentElement(), "configuration", ParseProjectXml.PROJECT_NS);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SubAntJUnitReport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SubAntJUnitReport.java
@@ -92,7 +92,7 @@ public class SubAntJUnitReport extends Task {
     }
 
     public @Override void execute() throws BuildException {
-        Map<String,String> pseudoTests = new HashMap<String,String>();
+        Map<String,String> pseudoTests = new HashMap<>();
         for (String path : buildPath.list()) {
             log("Entering: " + path);
             File dir = new File(path);
@@ -159,7 +159,7 @@ public class SubAntJUnitReport extends Task {
                 prefix = prefix.substring(0, prefix.length() - 1);
             }
         }
-        Map<String,T> m2 = new HashMap<String,T>();
+        Map<String,T> m2 = new HashMap<>();
         for (Map.Entry<String,T> entry : m.entrySet()) {
             m2.put(entry.getKey().substring(prefix.length()), entry.getValue());
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
@@ -60,8 +60,7 @@ public class SummarizeHgmail extends Task {
 
     public @Override void execute() throws BuildException {
         try {
-            PrintWriter w = new PrintWriter(output);
-            try {
+            try (PrintWriter w = new PrintWriter(output)) {
                 DirectoryScanner scanner = hgmails.getDirectoryScanner(getProject());
                 scanner.scan();
                 for (String hgmailS : new TreeSet<String>(Arrays.asList(scanner.getIncludedFiles()))) {
@@ -78,8 +77,7 @@ public class SummarizeHgmail extends Task {
                     }
                     // module dir such as java.source or contrib/autosave or file such as .hgtags, to list of addressees such as core-commits@platform.netbeans.org
                     Map<String,List<String>> notifications = new TreeMap<>();
-                    Reader r = new FileReader(hgmail);
-                    try {
+                    try (Reader r = new FileReader(hgmail)) {
                         BufferedReader br = new BufferedReader(r);
                         String line;
                         while ((line = br.readLine()) != null) {
@@ -128,8 +126,6 @@ public class SummarizeHgmail extends Task {
                                 }
                             }
                         }
-                    } finally {
-                        r.close();
                     }
                     // Now find unmentioned modules:
                     for (File kid : kids) {
@@ -161,8 +157,6 @@ public class SummarizeHgmail extends Task {
                     w.println();
                 }
                 w.flush();
-            } finally {
-                w.close();
             }
             log(output + ": hgmail summary written");
         } catch (IOException x) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/SummarizeHgmail.java
@@ -77,7 +77,7 @@ public class SummarizeHgmail extends Task {
                         throw new BuildException(dir.getPath(), getLocation());
                     }
                     // module dir such as java.source or contrib/autosave or file such as .hgtags, to list of addressees such as core-commits@platform.netbeans.org
-                    Map<String,List<String>> notifications = new TreeMap<String,List<String>>();
+                    Map<String,List<String>> notifications = new TreeMap<>();
                     Reader r = new FileReader(hgmail);
                     try {
                         BufferedReader br = new BufferedReader(r);
@@ -99,7 +99,7 @@ public class SummarizeHgmail extends Task {
                                 if (patt.contains("/")) {
                                     throw new BuildException("Notifications of subdirs not yet supported: " + line, getLocation());
                                 }
-                                List<String> modules = new ArrayList<String>();
+                                List<String> modules = new ArrayList<>();
                                 if (patt.contains("*")) {
                                     // Pattern, have to search for matches.
                                     Pattern wild = Pattern.compile("\\Q" + patt.replace("*", "\\E.*\\Q") + "\\E");
@@ -121,7 +121,7 @@ public class SummarizeHgmail extends Task {
                                 for (String module : modules) {
                                     List<String> addressees = notifications.get(module);
                                     if (addressees == null) {
-                                        addressees = new ArrayList<String>();
+                                        addressees = new ArrayList<>();
                                         notifications.put(module, addressees);
                                     }
                                     addressees.add(addr);
@@ -135,7 +135,7 @@ public class SummarizeHgmail extends Task {
                     for (File kid : kids) {
                         String name = kid.getName();
                         if (!notifications.containsKey(name)) {
-                            notifications.put(name, new ArrayList<String>());
+                            notifications.put(name, new ArrayList<>());
                         }
                     }
                     // Report:
@@ -149,7 +149,7 @@ public class SummarizeHgmail extends Task {
                         if (addressees.isEmpty()) {
                             w.println("  UNNOTIFIED");
                         } else {
-                            if (new HashSet<String>(addressees).size() < addressees.size()) {
+                            if (new HashSet<>(addressees).size() < addressees.size()) {
                                 w.println("  DUPLICATES");
                             }
                             Collections.sort(addressees);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
@@ -371,7 +371,7 @@ class UpdateTracking {
         private String codename;
         
         /** Holds value of property versions. */
-        private List<Version> versions = new ArrayList<Version>();
+        private List<Version> versions = new ArrayList<>();
         
         /** Getter for property codenamebase.
          * @return Value of property codenamebase.
@@ -413,12 +413,12 @@ class UpdateTracking {
         }
         
         void addVersion( Version version ) {
-            versions = new ArrayList<Version>();
+            versions = new ArrayList<>();
             versions.add( version );
         }
 
         void setVersion( Version version ) {
-            versions = new ArrayList<Version>();
+            versions = new ArrayList<>();
             versions.add( version );
         }
         
@@ -446,7 +446,7 @@ class UpdateTracking {
         private long install_time = 0;
         
         /** Holds value of property files. */
-        private List<ModuleFile> files = new ArrayList<ModuleFile>();
+        private List<ModuleFile> files = new ArrayList<>();
         
         /** Getter for property version.
          * @return Value of property version.
@@ -530,7 +530,7 @@ class UpdateTracking {
         }
         
         public void removeLocalized( String locale ) {
-            List<ModuleFile> newFiles = new ArrayList<ModuleFile>();
+            List<ModuleFile> newFiles = new ArrayList<>();
             for (ModuleFile file : files) {
                 if (file.getName().indexOf("_" + locale + ".") == -1 // NOI18N
                         && file.getName().indexOf("_" + locale + "/") == -1 // NOI18N

--- a/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
@@ -353,16 +353,16 @@ class UpdateTracking {
     }
 
     static CRC32 crcForFile(File inFile) throws FileNotFoundException, IOException {
-        FileInputStream inFileStream = new FileInputStream(inFile);
-        byte[] array = new byte[(int) inFile.length()];
-        CRC32 crc = new CRC32();
-        int len = inFileStream.read(array);
-        if (len != array.length) {
-            throw new BuildException("Cannot fully read " + inFile);
+        try (FileInputStream inFileStream = new FileInputStream(inFile)) {
+            byte[] array = new byte[(int) inFile.length()];
+            CRC32 crc = new CRC32();
+            int len = inFileStream.read(array);
+            if (len != array.length) {
+                throw new BuildException("Cannot fully read " + inFile);
+            }
+            crc.update(array);
+            return crc;
         }
-        inFileStream.close();
-        crc.update(array);
-        return crc;
     }
     
     class Module extends Object {        

--- a/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/UpdateTracking.java
@@ -423,9 +423,7 @@ class UpdateTracking {
         }
         
         void removeLocalized( String locale ) {
-            Iterator it = versions.iterator();
-            while (it.hasNext()) {
-                Version ver = (Version) it.next();
+            for(Version ver: versions) {
                 ver.removeLocalized( locale );
             }
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ValidateHgConfiguration.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ValidateHgConfiguration.java
@@ -49,7 +49,7 @@ public class ValidateHgConfiguration extends Task {
         }
         List<String> hgExecutable = HgExec.hgExecutable();
         try {
-            List<String> commandAndArgs = new ArrayList<String>(hgExecutable);
+            List<String> commandAndArgs = new ArrayList<>(hgExecutable);
             commandAndArgs.add("--config");
             commandAndArgs.add("extensions.churn="); // added to hgext right before 1.0 release
             commandAndArgs.add("showconfig");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
@@ -139,11 +139,8 @@ public class VerifyClassLinkage extends Task {
             // Map from class name (foo/Bar format) to true (found), false (not found), null (as yet unknown):
             Map<String,Boolean> loadable = new HashMap<>();
             Map<String,byte[]> classfiles = new TreeMap<>();
-            JarFile jf = new JarFile(jar);
-            try {
+            try (JarFile jf = new JarFile(jar)) {
                 read(jf, classfiles, new HashSet<>(Collections.singleton(jar)), this, ignores);
-            } finally {
-                jf.close();
             }
             for (String clazz: classfiles.keySet()) {
                 // All classes we define are obviously loadable:
@@ -185,15 +182,12 @@ public class VerifyClassLinkage extends Task {
                     continue;
                 }
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max((int) entry.getSize(), 0));
-                InputStream is = jf.getInputStream(entry);
-                try {
+                try (InputStream is = jf.getInputStream(entry)) {
                     byte[] buf = new byte[4096];
                     int read;
                     while ((read = is.read(buf)) != -1) {
                         baos.write(buf, 0, read);
                     }
-                } finally {
-                    is.close();
                 }
                 classfiles.put(clazz, baos.toByteArray());
             }
@@ -225,11 +219,8 @@ public class VerifyClassLinkage extends Task {
                         }
                         if (alreadyRead.add(otherJar)) {
                             if (otherJar.isFile()) {
-                                JarFile otherJF = new JarFile(otherJar);
-                                try {
+                                try (JarFile otherJF = new JarFile(otherJar)) {
                                     read(otherJF, classfiles, alreadyRead, task, ignores);
-                                } finally {
-                                    otherJF.close();
                                 }
                             }
                         } else {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyClassLinkage.java
@@ -137,11 +137,11 @@ public class VerifyClassLinkage extends Task {
         }
         try {
             // Map from class name (foo/Bar format) to true (found), false (not found), null (as yet unknown):
-            Map<String,Boolean> loadable = new HashMap<String,Boolean>();
-            Map<String,byte[]> classfiles = new TreeMap<String,byte[]>();
+            Map<String,Boolean> loadable = new HashMap<>();
+            Map<String,byte[]> classfiles = new TreeMap<>();
             JarFile jf = new JarFile(jar);
             try {
-                read(jf, classfiles, new HashSet<File>(Collections.singleton(jar)), this, ignores);
+                read(jf, classfiles, new HashSet<>(Collections.singleton(jar)), this, ignores);
             } finally {
                 jf.close();
             }
@@ -274,7 +274,7 @@ public class VerifyClassLinkage extends Task {
         }
     }
     static Set<String> dependencies(byte[] data) throws IOException {
-        Set<String> result = new TreeSet<String>();
+        Set<String> result = new TreeSet<>();
         DataInput input = new DataInputStream(new ByteArrayInputStream(data));
         skip(input, 8); // magic, minor_version, major_version
         int size = input.readUnsignedShort() - 1; // constantPoolCount

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
@@ -60,7 +60,7 @@ import org.xml.sax.SAXParseException;
  */
 public class VerifyJNLP extends Task {
 
-    private List<FileSet> filesets = new ArrayList<FileSet>();
+    private List<FileSet> filesets = new ArrayList<>();
     /**
      * Add one or more JNLP files to validate.
      * Use &lt;fileset file="..."/> if you have just one.
@@ -87,7 +87,7 @@ public class VerifyJNLP extends Task {
     }
 
     public @Override void execute() throws BuildException {
-        Map<String,String> results = new LinkedHashMap<String,String>();
+        Map<String,String> results = new LinkedHashMap<>();
         for (FileSet fs : filesets) {
             DirectoryScanner s = fs.getDirectoryScanner(getProject());
             File basedir = s.getBasedir();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
@@ -185,9 +185,8 @@ public class VerifyJNLP extends Task {
                         validate(f, results);
                     } else if (el.getTagName().equals("jar") && f.exists()) {
                         try {
-                            JarFile jf = new JarFile(f, true);
                             // Try to find signers.
-                            try {
+                            try (JarFile jf = new JarFile(f, true)) {
                                 Enumeration<JarEntry> entries = jf.entries();
                                 while (entries.hasMoreElements()) {
                                     JarEntry entry = entries.nextElement();
@@ -217,8 +216,6 @@ public class VerifyJNLP extends Task {
                                     existingSignedJar = f;
                                     break; // just check one representative file
                                 }
-                            } finally {
-                                jf.close();
                             }
                         } catch (IOException x) {
                             error(jnlp, results, "Signatures", "error examining signatures in " + f + ": " + x);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyUpdateCenter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyUpdateCenter.java
@@ -100,24 +100,24 @@ public final class VerifyUpdateCenter extends Task {
         if (updates == null) {
             throw new BuildException("you must specify updates");
         }
-        Map<String,String> pseudoTests = new LinkedHashMap<String,String>();
+        Map<String,String> pseudoTests = new LinkedHashMap<>();
         ClassLoader loader = new AntClassLoader(getProject(), classpath);
         Set<Manifest> manifests = loadManifests(updates);
         checkForProblems(findInconsistencies(manifests, loader), "Inconsistency(ies) in " + updates, "synchronicConsistency", pseudoTests);
         if (pseudoTests.get("synchronicConsistency") == null) {
             log(updates + " is internally consistent", Project.MSG_INFO);
             if (oldUpdates != null) {
-                Map<String,Manifest> updated = new HashMap<String,Manifest>();
+                Map<String,Manifest> updated = new HashMap<>();
                 for (Manifest m : loadManifests(oldUpdates)) {
                     updated.put(findCNB(m), m);
                 }
-                if (!findInconsistencies(new HashSet<Manifest>(updated.values()), loader).isEmpty()) {
+                if (!findInconsistencies(new HashSet<>(updated.values()), loader).isEmpty()) {
                     log(oldUpdates + " is already inconsistent, skipping update check", Project.MSG_WARN);
                     JUnitReportWriter.writeReport(this, null, reportFile, pseudoTests);
                     return;
                 }
-                SortedSet<String> updatedCNBs = new TreeSet<String>();
-                Set<String> newCNBs = new HashSet<String>();
+                SortedSet<String> updatedCNBs = new TreeSet<>();
+                Set<String> newCNBs = new HashSet<>();
                 for (Manifest m : manifests) {
                     String cnb = findCNB(m);
                     newCNBs.add(cnb);
@@ -133,7 +133,7 @@ public final class VerifyUpdateCenter extends Task {
                         updatedCNBs.add(cnb);
                     }
                 }
-                SortedMap<String,SortedSet<String>> updateProblems = findInconsistencies(new HashSet<Manifest>(updated.values()), loader);
+                SortedMap<String,SortedSet<String>> updateProblems = findInconsistencies(new HashSet<>(updated.values()), loader);
                 updateProblems.keySet().retainAll(newCNBs); // ignore problems in now-deleted modules
                 checkForProblems(updateProblems, "Inconsistency(ies) in " + updates + " relative to " + oldUpdates, "diachronicConsistency", pseudoTests);
                 if (pseudoTests.get("diachronicConsistency") == null) {
@@ -157,7 +157,7 @@ public final class VerifyUpdateCenter extends Task {
     private Set<Manifest> loadManifests(URI u) throws BuildException {
         try {
             Document doc = XMLUtil.parse(new InputSource(u.toString()), false, false, XMLUtil.rethrowHandler(), XMLUtil.nullResolver());
-            Set<Manifest> manifests = new HashSet<Manifest>();
+            Set<Manifest> manifests = new HashSet<>();
             boolean foundJUnit = false;
             NodeList nl = doc.getElementsByTagName("manifest");
             for (int i = 0; i < nl.getLength(); i++) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
@@ -166,9 +166,7 @@ public final class XMLUtil extends Object {
             Source source = new DOMSource(doc);
             Result result = new StreamResult(out);
             t.transform(source, result);
-        } catch (Exception e) {
-            throw new IOException(e);
-        } catch (TransformerFactoryConfigurationError e) {
+        } catch (Exception | TransformerFactoryConfigurationError e) {
             throw new IOException(e);
         }
     }
@@ -182,9 +180,7 @@ public final class XMLUtil extends Object {
             Source source = new DOMSource(el);
             Result result = new StreamResult(out);
             t.transform(source, result);
-        } catch (Exception e) {
-            throw new IOException(e);
-        } catch (TransformerFactoryConfigurationError e) {
+        } catch (Exception | TransformerFactoryConfigurationError e) {
             throw new IOException(e);
         }
     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
@@ -63,7 +63,7 @@ public final class XMLUtil extends Object {
     private static final ThreadLocal<DocumentBuilder>[] builderTL = (ThreadLocal<DocumentBuilder>[]) new ThreadLocal<?>[4];
     static {
         for (int i = 0; i < 4; i++) {
-            builderTL[i] = new ThreadLocal<DocumentBuilder>();
+            builderTL[i] = new ThreadLocal<>();
         }
     }
 
@@ -248,7 +248,7 @@ public final class XMLUtil extends Object {
      */
     static List<Element> findSubElements(Element parent) throws IllegalArgumentException {
         NodeList l = parent.getChildNodes();
-        List<Element> elements = new ArrayList<Element>(l.getLength());
+        List<Element> elements = new ArrayList<>(l.getLength());
         for (int i = 0; i < l.getLength(); i++) {
             Node n = l.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateDependencies.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateDependencies.java
@@ -71,8 +71,7 @@ public class CreateDependencies extends Task {
             try (InputStream in = new FileInputStream(new File(getProject().getProperty("nb_all"), "nbbuild/licenses/names.properties"))) {
                 licenseNames.load(in);
             }
-            OutputStream os = new FileOutputStream(dependencies);
-            try {
+            try (OutputStream os = new FileOutputStream(dependencies)) {
                 PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
                 pw.println("This project's dependencies");
                 pw.println();
@@ -133,8 +132,6 @@ public class CreateDependencies extends Task {
                 }
                 pw.flush();
                 pw.close();
-            } finally {
-                os.close();
             }
             log(dependencies + ": written");
         } catch (IOException x) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -100,13 +100,13 @@ public class CreateLicenseSummary extends Task {
 
     public @Override
     void execute() throws BuildException {
-        pseudoTests = new LinkedHashMap<String, String>();
+        pseudoTests = new LinkedHashMap<>();
         try {
             Map<Long, Map<String, String>> crc2License = findCrc2LicenseHeaderMapping();
-            Map<String, Map<String, String>> binaries2LicenseHeaders = new TreeMap<String, Map<String, String>>();
+            Map<String, Map<String, String>> binaries2LicenseHeaders = new TreeMap<>();
             StringBuilder testBinariesAreUnique = new StringBuilder();
             List<String> ignoredPatterns = VerifyLibsAndLicenses.loadPatterns("ignored-binary-overlaps");
-            findBinaries(build, binaries2LicenseHeaders, crc2License, new HashMap<Long, String>(), "", testBinariesAreUnique, ignoredPatterns);
+            findBinaries(build, binaries2LicenseHeaders, crc2License, new HashMap<>(), "", testBinariesAreUnique, ignoredPatterns);
             pseudoTests.put("testBinariesAreUnique", testBinariesAreUnique.length() > 0 ? "Some binaries are duplicated (edit nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-binary-overlaps as needed)" + testBinariesAreUnique : null);
             try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(license), "UTF-8"));
                     PrintWriter nw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(notice), "UTF-8"))) {
@@ -131,7 +131,7 @@ public class CreateLicenseSummary extends Task {
                     }
                 }
 
-                Set<String> licenseNames = new TreeSet<String>();
+                Set<String> licenseNames = new TreeSet<>();
                 pw.printf("%-72s %s\n", "THIRD-PARTY COMPONENT FILE", "LICENSE");
                 pw.printf("%-44s %s\n", "(path in the installation)", "(see license text reproduced below)");
                 pw.println("--------------------------------------------------------------------------------");
@@ -223,7 +223,7 @@ public class CreateLicenseSummary extends Task {
     }
 
     private Map<Long, Map<String, String>> findCrc2LicenseHeaderMapping() throws IOException {
-        Map<Long, Map<String, String>> crc2LicenseHeaders = new HashMap<Long, Map<String, String>>();
+        Map<Long, Map<String, String>> crc2LicenseHeaders = new HashMap<>();
         for (String cluster : getProject().getProperty("nb.clusters.list").split("[, ]+")) {
             for (String module : getProject().getProperty(cluster).split("[, ]+")) {
                 File d = new File(new File(nball, module), "external");
@@ -307,12 +307,12 @@ public class CreateLicenseSummary extends Task {
     }
 
     static Map<String, Map<String, String>> findBinary2LicenseHeaderMapping(Set<String> cvsFiles, File d) throws IOException {
-        Map<String, Map<String, String>> binary2LicenseHeaders = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> binary2LicenseHeaders = new HashMap<>();
         for (String n : cvsFiles) {
             if (!n.endsWith("-license.txt")) {
                 continue;
             }
-            Map<String, String> headers = new HashMap<String, String>();
+            Map<String, String> headers = new HashMap<>();
             InputStream is = new FileInputStream(new File(d, n));
             try {
                 BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -192,20 +192,16 @@ public class CreateLicenseSummary extends Task {
                     pw.println("======");
                     pw.println("========================= " + licenseName + " =========================");
                     pw.println();
-                    InputStream is = new FileInputStream(license);
-                    try {
+                    try (InputStream is = new FileInputStream(license)) {
                         BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                         String line;
                         while ((line = r.readLine()) != null) {
                             pw.println(line);
                         }
                         r.close();
-                    } finally {
-                        is.close();
                     }
                 }
                 pw.flush();
-                pw.close();
             }
             log(license + ": written");
         } catch (IOException x) {
@@ -313,8 +309,7 @@ public class CreateLicenseSummary extends Task {
                 continue;
             }
             Map<String, String> headers = new HashMap<>();
-            InputStream is = new FileInputStream(new File(d, n));
-            try {
+            try (InputStream is = new FileInputStream(new File(d, n))) {
                 BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                 String line;
                 while ((line = r.readLine()) != null && line.length() > 0) {
@@ -324,8 +319,6 @@ public class CreateLicenseSummary extends Task {
                     }
                 }
                 r.close();
-            } finally {
-                is.close();
             }
             String files = headers.remove("Files");
             if (files != null) {
@@ -369,8 +362,7 @@ public class CreateLicenseSummary extends Task {
             if (f.isDirectory()) {
                 findBinaries(f, binaries2LicenseHeaders, crc2LicenseHeaders, crc2Binary, prefix + n + "/", testBinariesAreUnique, ignoredPatterns);
             } else if (n.endsWith(".jar") || n.endsWith(".zip") || n.endsWith(".xml") || n.endsWith(".js") || n.endsWith(".dylib")) {
-                InputStream is = new FileInputStream(f);
-                try {
+                try (InputStream is = new FileInputStream(f)) {
                     long crc = computeCRC32(is);
                     Map<String, String> headers = crc2LicenseHeaders.get(crc);
                     if (headers != null) {
@@ -396,8 +388,6 @@ public class CreateLicenseSummary extends Task {
                             }
                         }
                     }
-                } finally {
-                    is.close();
                 }
             }
         }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DeregisterExternalHook.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DeregisterExternalHook.java
@@ -58,15 +58,12 @@ public class DeregisterExternalHook extends Task {
                 File hgrc = new File(dotHg, "hgrc");
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 if (hgrc.isFile()) {
-                    InputStream is = new FileInputStream(hgrc);
-                    try {
+                    try (InputStream is = new FileInputStream(hgrc)) {
                         byte[] buf = new byte[4096];
                         int read;
                         while ((read = is.read(buf)) != -1) {
                             baos.write(buf, 0, read);
                         }
-                    } finally {
-                        is.close();
                     }
                 }
                 String config = baos.toString();
@@ -77,11 +74,8 @@ public class DeregisterExternalHook extends Task {
                         replaceAll("(^|\r?\n)(\r?\n)*(\\[(extensions|encode|decode)\\](\r?\n)+)+(?=\\[|$)", "$1");
                 if (!newConfig.equals(config)) {
                     log("Unregistering external hook from " + hgrc);
-                    OutputStream os = new FileOutputStream(hgrc);
-                    try {
+                    try (OutputStream os = new FileOutputStream(hgrc)) {
                         os.write(newConfig.getBytes());
-                    } finally {
-                        os.close();
                     }
                 }
             } catch (IOException x) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -134,8 +134,7 @@ public class DownloadBinaries extends Task {
                 File manifest = new File(basedir, include);
                 log("Scanning: " + manifest, Project.MSG_VERBOSE);
                 try {
-                    InputStream is = new FileInputStream(manifest);
-                    try {
+                    try (InputStream is = new FileInputStream(manifest)) {
                         BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                         String line;
                         while ((line = r.readLine()) != null) {
@@ -157,8 +156,6 @@ public class DownloadBinaries extends Task {
                                 fillInFile(hashAndFile[0], hashAndFile[1], manifest, () -> legacyDownload(hashAndFile[0] + "-" + hashAndFile[1]));
                             }
                         }
-                    } finally {
-                        is.close();
                     }
                 } catch (IOException x) {
                     throw new BuildException("Could not open " + manifest + ": " + x, x, getLocation());
@@ -278,8 +275,7 @@ public class DownloadBinaries extends Task {
             throw new IOException("Skipping download from " + url + " due to response code " + code);
         }
         try {
-            InputStream is = conn.getInputStream();
-            try {
+            try (InputStream is = conn.getInputStream()) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 byte[] buf = new byte[4096];
                 int read;
@@ -287,8 +283,6 @@ public class DownloadBinaries extends Task {
                     baos.write(buf, 0, read);
                 }
                 return baos.toByteArray();
-            } finally {
-                is.close();
             }
         } catch (IOException ex) {
             throw new IOException("Cannot download: " + url + " due to: " + ex, ex);
@@ -367,11 +361,8 @@ public class DownloadBinaries extends Task {
 
     private String hash(File f) {
         try {
-            FileInputStream is = new FileInputStream(f);
-            try {
+            try (FileInputStream is = new FileInputStream(f)) {
                 return hash(is);
-            } finally {
-                is.close();
             }
         } catch (IOException x) {
             throw new BuildException("Could not get hash for " + f + ": " + x, x, getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -309,9 +309,7 @@ public class DownloadBinaries extends Task {
                         test.connect();
                         conn[0] = test;
                         connected.countDown();
-                    } catch (IOException ex) {
-                        log(ex, Project.MSG_ERR);
-                    } catch (URISyntaxException ex) {
+                    } catch (IOException | URISyntaxException ex) {
                         log(ex, Project.MSG_ERR);
                     }
                 }
@@ -329,9 +327,7 @@ public class DownloadBinaries extends Task {
                         test.connect();
                         conn[0] = test;
                         connected.countDown();
-                    } catch (IOException ex) {
-                        log(ex, Project.MSG_ERR);
-                    } catch (URISyntaxException ex) {
+                    } catch (IOException | URISyntaxException ex) {
                         log(ex, Project.MSG_ERR);
                     }
                 }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -88,7 +88,7 @@ public class DownloadBinaries extends Task {
         this.server = server;
     }
 
-    private final List<FileSet> manifests = new ArrayList<FileSet>();
+    private final List<FileSet> manifests = new ArrayList<>();
     /**
      * Add one or more manifests of files to download.
      * Each manifest is a text file; lines beginning with # are ignored.

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/PatchFile.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/PatchFile.java
@@ -244,7 +244,7 @@ public class PatchFile extends Task {
             patch.targetFile = computeTargetFile(patch);
             if (patch.sourceFile != null && patch.sourceFile.exists()) {
                 if (patch.binary) {
-                    target = new ArrayList<String>();
+                    target = new ArrayList<>();
                 } else {
                     target = readFile(patch.sourceFile);
                     if (patchCreatesNewFileThatAlreadyExists(patch, target)) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesCopy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesCopy.java
@@ -70,8 +70,7 @@ public class ReleaseFilesCopy extends Task {
                     File zip = getProject().resolveFile(fromString.substring(0, bangSlash));
                     if (zip.isFile()) {
                         try {
-                            ZipFile zf = new ZipFile(zip);
-                            try {
+                            try (ZipFile zf = new ZipFile(zip)) {
                                 String path = fromString.substring(bangSlash + 2);
                                 log("Copying " + path + " in " + zip + " to " + to);
                                 ZipEntry ze = zf.getEntry(path);
@@ -90,8 +89,6 @@ public class ReleaseFilesCopy extends Task {
                                 } finally {
                                     os.close();
                                 }
-                            } finally {
-                                zf.close();
                             }
                         } catch (IOException x) {
                             throw new BuildException("Could not extract " + zip + ": " + x, x, getLocation());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
@@ -67,8 +67,7 @@ public class ReleaseFilesLicense extends Task {
 
     public @Override void execute() throws BuildException {
         try {
-            OutputStream os = new FileOutputStream(license);
-            try {
+            try (OutputStream os = new FileOutputStream(license)) {
                 PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
                 pw.println("License for NetBeans module:");
                 pw.println();
@@ -84,16 +83,13 @@ public class ReleaseFilesLicense extends Task {
                     pw.println("==================================================");
                     pw.println("Additional license (" + f.getName() + "):");
                     pw.println();
-                    InputStream is = new FileInputStream(f);
-                    try {
+                    try (InputStream is = new FileInputStream(f)) {
                         BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                         String line;
                         while ((line = r.readLine()) != null && line.length() > 0) {}
                         while ((line = r.readLine()) != null) {
                             pw.println(line);
                         }
-                    } finally {
-                        is.close();
                     }
                 }
                 Map<File,Set<String>> inferredLicenses = new TreeMap<>();
@@ -107,8 +103,7 @@ public class ReleaseFilesLicense extends Task {
                             if (!possibleLicense.getName().endsWith("-license.txt")) {
                                 continue;
                             }
-                            InputStream is = new FileInputStream(possibleLicense);
-                            try {
+                            try (InputStream is = new FileInputStream(possibleLicense)) {
                                 BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                                 String files = possibleLicense.getName().replaceFirst("-license\\.txt$", ".jar") +
                                         " " + possibleLicense.getName().replaceFirst("-license\\.txt$", ".zip");
@@ -129,8 +124,6 @@ public class ReleaseFilesLicense extends Task {
                                     binaries.add((String) entry.getValue());
                                     continue RELEASE_FILE;
                                 }
-                            } finally {
-                                is.close();
                             }
                         }
                     }
@@ -144,21 +137,16 @@ public class ReleaseFilesLicense extends Task {
                         pw.println(binary);
                     }
                     pw.println();
-                    InputStream is = new FileInputStream(entry.getKey());
-                    try {
+                    try (InputStream is = new FileInputStream(entry.getKey())) {
                         BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                         String line;
                         while ((line = r.readLine()) != null && line.length() > 0) {}
                         while ((line = r.readLine()) != null) {
                             pw.println(line);
                         }
-                    } finally {
-                        is.close();
                     }
                 }
                 pw.flush();
-            } finally {
-                os.close();
             }
         } catch (IOException x) {
             throw new BuildException(x, getLocation());
@@ -166,15 +154,12 @@ public class ReleaseFilesLicense extends Task {
     }
 
     private void append(PrintWriter pw, File f) throws IOException {
-        InputStream is = new FileInputStream(f);
-        try {
+        try (InputStream is = new FileInputStream(f)) {
             BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String line;
             while ((line = r.readLine()) != null) {
                 pw.println(line);
             }
-        } finally {
-            is.close();
         }
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ReleaseFilesLicense.java
@@ -96,7 +96,7 @@ public class ReleaseFilesLicense extends Task {
                         is.close();
                     }
                 }
-                Map<File,Set<String>> inferredLicenses = new TreeMap<File,Set<String>>();
+                Map<File,Set<String>> inferredLicenses = new TreeMap<>();
                 RELEASE_FILE: for (Map.Entry<String,Object> entry : ((Map<String,Object>) getProject().getProperties()).entrySet()) {
                     String k = entry.getKey();
                     // XXX this does not work for release.../external/*; need to maybe match ^release\.(.+/)?external/
@@ -123,7 +123,7 @@ public class ReleaseFilesLicense extends Task {
                                 if (Arrays.asList(files.split("[, ]+")).contains(binary)) {
                                     Set<String> binaries = inferredLicenses.get(possibleLicense);
                                     if (binaries == null) {
-                                        binaries = new TreeSet<String>();
+                                        binaries = new TreeSet<>();
                                         inferredLicenses.put(possibleLicense, binaries);
                                     }
                                     binaries.add((String) entry.getValue());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -443,8 +443,7 @@ public class VerifyLibsAndLicenses extends Task {
 
     static List<String> loadPatterns(String resource) throws IOException {
         List<String> patterns = new ArrayList<>();
-        InputStream is = VerifyLibsAndLicenses.class.getResourceAsStream(resource);
-        try {
+        try (InputStream is = VerifyLibsAndLicenses.class.getResourceAsStream(resource)) {
             BufferedReader r = new BufferedReader(new InputStreamReader(is));
             String line;
             while ((line = r.readLine()) != null) {
@@ -453,8 +452,6 @@ public class VerifyLibsAndLicenses extends Task {
                     patterns.add(line.replaceAll("/(?=( |$))", "/**"));
                 }
             }
-        } finally {
-            is.close();
         }
         return patterns;
     }
@@ -531,8 +528,7 @@ public class VerifyLibsAndLicenses extends Task {
                 ignoredPatterns = hgignores.get(root);
             } else {
                 ignoredPatterns = new ArrayList<>();
-                Reader r = new FileReader(hgignore);
-                try {
+                try (Reader r = new FileReader(hgignore)) {
                     BufferedReader br = new BufferedReader(r);
                     String line;
                     while ((line = br.readLine()) != null) {
@@ -546,8 +542,6 @@ public class VerifyLibsAndLicenses extends Task {
                         line += "($|/)";
                         ignoredPatterns.add(Pattern.compile(line));
                     }
-                } finally {
-                    r.close();
                 }
                 hgignores.put(root, ignoredPatterns);
             }
@@ -572,8 +566,7 @@ public class VerifyLibsAndLicenses extends Task {
         }
         File list = new File(dir, "binaries-list");
         if (list.isFile()) {
-            Reader r = new FileReader(list);
-            try {
+            try (Reader r = new FileReader(list)) {
                 BufferedReader br = new BufferedReader(r);
                 String line;
                 while ((line = br.readLine()) != null) {
@@ -595,8 +588,6 @@ public class VerifyLibsAndLicenses extends Task {
                         files.add(hashAndFile[1]);
                     }
                 }
-            } finally {
-                r.close();
             }
         }
         return files;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -82,8 +82,8 @@ public class VerifyLibsAndLicenses extends Task {
 
     public @Override void execute() throws BuildException {
         try { // XXX workaround for http://issues.apache.org/bugzilla/show_bug.cgi?id=43398
-        pseudoTests = new LinkedHashMap<String,String>();
-        modules = new TreeSet<String>();
+        pseudoTests = new LinkedHashMap<>();
+        modules = new TreeSet<>();
         for (String cluster : getProject().getProperty("nb.clusters.list").split("[, ]+")) {
             modules.addAll(Arrays.asList(getProject().getProperty(cluster).split("[, ]+")));
         }
@@ -107,7 +107,7 @@ public class VerifyLibsAndLicenses extends Task {
     private void testBinaryUniqueness() throws IOException {
         List<String> ignoredPatterns = loadPatterns("ignored-overlaps");
         StringBuffer msg = new StringBuffer();
-        Map<Long,String> binaries = new HashMap<Long,String>();
+        Map<Long,String> binaries = new HashMap<>();
         for (String module : modules) {
             File d = new File(new File(nball, module), "external");
             Set<String> hgFiles = findHgControlledFiles(d);
@@ -239,20 +239,20 @@ public class VerifyLibsAndLicenses extends Task {
 
     private void testLicenses() throws IOException {
         File licenses = new File(new File(nball, "nbbuild"), "licenses");
-        Set<String> requiredHeaders = new TreeSet<String>(Arrays.asList("Name", "Version", "Description", "License", "Origin"));
-        Set<String> optionalHeaders = new HashSet<String>(Arrays.asList("Files", "Source", "Comment", "Type", "URL", /*for transition period:*/"OSR"));
+        Set<String> requiredHeaders = new TreeSet<>(Arrays.asList("Name", "Version", "Description", "License", "Origin"));
+        Set<String> optionalHeaders = new HashSet<>(Arrays.asList("Files", "Source", "Comment", "Type", "URL", /*for transition period:*/"OSR"));
         StringBuffer msg = new StringBuffer();
         for (String module : modules) {
             File d = new File(new File(nball, module), "external");
             Set<String> hgFiles = findHgControlledFiles(d);
-            Set<String> referencedBinaries = new HashSet<String>();
+            Set<String> referencedBinaries = new HashSet<>();
             for (String n : hgFiles) {
                 if (!n.endsWith("-license.txt")) {
                     continue;
                 }
                 File f = new File(d, n);
                 String path = module + "/external/" + n;
-                Map<String,String> headers = new HashMap<String,String>();
+                Map<String,String> headers = new HashMap<>();
                 InputStream is = new FileInputStream(f);
                 StringBuffer body = new StringBuffer();
                 try {
@@ -442,7 +442,7 @@ public class VerifyLibsAndLicenses extends Task {
     }
 
     static List<String> loadPatterns(String resource) throws IOException {
-        List<String> patterns = new ArrayList<String>();
+        List<String> patterns = new ArrayList<>();
         InputStream is = VerifyLibsAndLicenses.class.getResourceAsStream(resource);
         try {
             BufferedReader r = new BufferedReader(new InputStreamReader(is));
@@ -461,7 +461,7 @@ public class VerifyLibsAndLicenses extends Task {
 
     private void testNoStrayThirdPartyBinaries() throws IOException {
         List<String> ignoredPatterns = loadPatterns("ignored-binaries");
-        Set<String> violations = new TreeSet<String>();
+        Set<String> violations = new TreeSet<>();
         findStrayThirdPartyBinaries(nball, "", violations, ignoredPatterns);
         if (violations.isEmpty()) {
             pseudoTests.put("testNoStrayThirdPartyBinaries", null);
@@ -530,7 +530,7 @@ public class VerifyLibsAndLicenses extends Task {
             } else if (hgignores.containsKey(root)) {
                 ignoredPatterns = hgignores.get(root);
             } else {
-                ignoredPatterns = new ArrayList<Pattern>();
+                ignoredPatterns = new ArrayList<>();
                 Reader r = new FileReader(hgignore);
                 try {
                     BufferedReader br = new BufferedReader(r);
@@ -552,7 +552,7 @@ public class VerifyLibsAndLicenses extends Task {
                 hgignores.put(root, ignoredPatterns);
             }
         }
-        Set<String> files = new TreeSet<String>();
+        Set<String> files = new TreeSet<>();
         FILES: for (File f : kids) {
             String n = f.getName();
             if (n.equals(".git")) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
@@ -189,8 +189,7 @@ public class TestDistFilter extends Task {
        if (pfile.exists()) {
            Properties props = new Properties();
             try {
-                FileInputStream fis = new FileInputStream(pfile);
-                try { 
+                try (FileInputStream fis = new FileInputStream(pfile)) { 
                   props.load(fis);
                   
                   String runCp = props.getProperty("test.unit.run.cp");
@@ -211,8 +210,6 @@ public class TestDistFilter extends Task {
                           }
                       }
                   }
-                } finally {
-                  fis.close();  
                 }
             } catch(IOException ioe){
                 throw new BuildException(ioe);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
@@ -97,9 +97,8 @@ public class TestDistFilter extends Task {
     /** get path with test dirs separated by :
      */
     private String getTestList() {
-        StringBuffer path = new StringBuffer();
-        for (Iterator it = possibleTests.iterator() ; it.hasNext() ; ) {
-            TestConf tc = (TestConf)it.next();
+        StringBuilder path = new StringBuilder();
+        for (TestConf tc: possibleTests) {
             if (!matchRequiredModule(tc.getModuleDir())) {
                 continue;
             }
@@ -195,8 +194,8 @@ public class TestDistFilter extends Task {
                   String runCp = props.getProperty("test.unit.run.cp");
                   if (runCp != null) {
                       String paths[] = runCp.split(":");
-                      Set reqModules = getRequiredModulesSet();
-                      if (reqModules.size() == 0) {
+                      Set<String> reqModules = getRequiredModulesSet();
+                      if (reqModules.isEmpty()) {
                           return true;
                       }
                       for (int i = 0 ; i < paths.length ; i++) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/testdist/TestDistFilter.java
@@ -52,7 +52,7 @@ import org.apache.tools.ant.Task;
  */
 public class TestDistFilter extends Task {
     private File testDistDir;
-    Set<TestConf> possibleTests = new HashSet<TestConf>();
+    Set<TestConf> possibleTests = new HashSet<>();
     private String testtype;
     private String testListProperty;
     private String requiredModules;
@@ -144,7 +144,7 @@ public class TestDistFilter extends Task {
 
     private List<TestConf> getTestList(String testtype) {
         File root = new File (getTestDistDir(),testtype);
-        List <TestConf> testList = new ArrayList<TestConf>();
+        List <TestConf> testList = new ArrayList<>();
         if (!root.exists()) {
             return Collections.emptyList();
         }
@@ -223,6 +223,6 @@ public class TestDistFilter extends Task {
 
     private Set<String> getRequiredModulesSet() {
         String names[] = getRequiredModules().split(",");
-        return new HashSet<String>(Arrays.asList(names));
+        return new HashSet<>(Arrays.asList(names));
     }
 }

--- a/nbbuild/default-properties.xml
+++ b/nbbuild/default-properties.xml
@@ -73,4 +73,11 @@
     <property file="${nb_all}/nbbuild/build.properties"/>
   </target>
 
+  <xmlcatalog id="nbantextcatalog" classpath="${nbantext.jar}">
+    <dtd publicId="-//W3C//DTD XHTML 1.0 Strict//EN" location="org/netbeans/nbbuild/xhtml1-strict.dtd" />
+    <dtd publicId="-//W3C//ENTITIES Latin 1 for XHTML//EN" location="org/netbeans/nbbuild/xhtml-lat1.ent" />
+    <dtd publicId="-//W3C//ENTITIES Symbols for XHTML//EN" location="org/netbeans/nbbuild/xhtml-symbol.ent" />
+    <dtd publicId="-//W3C//ENTITIES Special for XHTML//EN" location="org/netbeans/nbbuild/xhtml-special.ent" />
+    <dtd publicId="-//NetBeans//DTD Arch Answers//EN" location="org/netbeans/nbbuild/Arch.dtd" />
+  </xmlcatalog>
 </project>

--- a/nbbuild/javadoctools/all-arch.xml
+++ b/nbbuild/javadoctools/all-arch.xml
@@ -26,8 +26,11 @@
         Tools for working with all available architecture description documents.
     </description>
 
+    <import file="../default.xml"/>
+
     <target name="validate">
         <xmlvalidate warn="true" failonerror="false">
+            <xmlcatalog refid="nbantextcatalog" />
             <fileset dir="../..">
                 <include name="*/arch/arch-*.xml"/>
                 <include name="*/arch.xml"/>
@@ -36,5 +39,4 @@
             </fileset>
         </xmlvalidate>
     </target>
-
 </project>

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -29,6 +29,8 @@
 
 <project name="template" default="die" basedir=".">
 
+    <import file="../default-properties.xml"/>
+
     <description><![CDATA[
 Templated targets:
 
@@ -318,23 +320,29 @@ cause it to fail.
 
     <target name="javadoc-stage-apichanges" depends="javadoc-init,javadoc-check-timestamps,javadoc-stage-export-apichanges" unless="javadoc.up.to.date">
         <xslt in="${javadoc.apichanges}" out="${javadoc.out.dir}/apichanges.html" style="apichanges.xsl">
+            <xmlcatalog refid="nbantextcatalog" />
             <param name="javadoc-url-base" expression="."/>
         </xslt>
     </target>
+
     <target name="javadoc-stage-export-apichanges" depends="javadoc-init,javadoc-check-timestamps,javadoc-stage-init-apichanges" unless="javadoc.apichanges.should.not.be.generated">
         <fail message="Need to specify the date of branching of previous.release.year: ${previous.release.year}" unless="previous.release.year" />
         <fail message="Need to specify the date of branching of previous.release.month: ${previous.release.month}" unless="previous.release.month" />
         <fail message="Need to specify the date of branching of previous.release.day: ${previous.release.day}" unless="previous.release.day" />
-    
+
         <xslt in="${javadoc.apichanges}" out="${export.apichanges}/${javadoc.name}" style="export-apichanges.xsl">
+            <xmlcatalog refid="nbantextcatalog" />
             <param name="changes-since-url" expression="${javadoc.name}/apichanges.html"/>
             <param name="changes-since-year" expression="${previous.release.year}"/>
             <param name="changes-since-day" expression="${previous.release.day}"/>
             <param name="changes-since-month" expression="${previous.release.month}"/>
         </xslt>
     </target>
+
     <target name="javadoc-stage-init-apichanges" depends="javadoc-init,javadoc-check-timestamps" unless="javadoc.up.to.date">
-        <xmlvalidate file="${javadoc.apichanges}" failonerror="true"/>
+        <xmlvalidate file="${javadoc.apichanges}" failonerror="true">
+            <xmlcatalog refid="nbantextcatalog" />
+        </xmlvalidate>
     </target>
 
     <target name="javadoc-stage-arch" depends="javadoc-init,javadoc-check-timestamps" unless="javadoc.up.to.date">

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -345,17 +345,11 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
     </target>
 
     <target name="-verify-apichanges" if="javadoc.apichanges" depends="basic-init">
-        <xmlcatalog id="xhtmlcatalog" classpath="${nbantext.jar}">
-            <dtd publicId="-//W3C//DTD XHTML 1.0 Strict//EN" location="org/netbeans/nbbuild/xhtml1-strict.dtd" />
-            <dtd publicId="-//W3C//ENTITIES Latin 1 for XHTML//EN" location="org/netbeans/nbbuild/xhtml-lat1.ent" />
-            <dtd publicId="-//W3C//ENTITIES Symbols for XHTML//EN" location="org/netbeans/nbbuild/xhtml-symbol.ent" />
-            <dtd publicId="-//W3C//ENTITIES Special for XHTML//EN" location="org/netbeans/nbbuild/xhtml-special.ent" />
-        </xmlcatalog>
         <xmlvalidate file="${javadoc.apichanges}" failonerror="true">
-            <xmlcatalog refid="xhtmlcatalog" />
+            <xmlcatalog refid="nbantextcatalog" />
         </xmlvalidate>
         <xslt in="${javadoc.apichanges}" out="${build.dir}/apichanges.html" style="${nb_all}/nbbuild/javadoctools/apichanges.xsl">
-            <xmlcatalog refid="xhtmlcatalog" />
+            <xmlcatalog refid="nbantextcatalog" />
             <param name="javadoc-url-base" expression="."/>
         </xslt>
         <!-- XXX could perhaps validate arch.xml too, if it exists -->

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ArchQuestionsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ArchQuestionsTest.java
@@ -37,7 +37,7 @@ import org.xml.sax.SAXException;
  */
 public class ArchQuestionsTest extends TestBase implements EntityResolver {
     /** debug messages to show if necessary */
-    private List<String> msg = new ArrayList<String>();
+    private List<String> msg = new ArrayList<>();
     
     public ArchQuestionsTest (String name) {
         super (name);

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
@@ -433,9 +433,9 @@ public class AutoUpdateTest extends TestBase {
 "</module>\n";
 
 
-        FileOutputStream osx = new FileOutputStream(x);
-        osx.write(txtx.getBytes());
-        osx.close();
+        try (FileOutputStream osx = new FileOutputStream(x)) {
+            osx.write(txtx.getBytes());
+        }
 
 
         execute(
@@ -500,9 +500,9 @@ public class AutoUpdateTest extends TestBase {
 "</module>\n";
 
 
-        FileOutputStream osx = new FileOutputStream(x);
-        osx.write(txtx.getBytes());
-        osx.close();
+        try (FileOutputStream osx = new FileOutputStream(x)) {
+            osx.write(txtx.getBytes());
+        }
 
 
         execute(
@@ -569,9 +569,9 @@ public class AutoUpdateTest extends TestBase {
 "</module>\n";
 
 
-        FileOutputStream osx = new FileOutputStream(x);
-        osx.write(txtx.getBytes());
-        osx.close();
+        try (FileOutputStream osx = new FileOutputStream(x)) {
+            osx.write(txtx.getBytes());
+        }
 
         File lastM = new File(new File(target, "platform"), ".lastModified");
         lastM.createNewFile();
@@ -653,9 +653,9 @@ public class AutoUpdateTest extends TestBase {
 "</module>\n";
 
 
-        FileOutputStream osx = new FileOutputStream(x);
-        osx.write(txtx.getBytes());
-        osx.close();
+        try (FileOutputStream osx = new FileOutputStream(x)) {
+            osx.write(txtx.getBytes());
+        }
 
         File lastM = new File(new File(target, "platform"), ".lastModified");
         lastM.createNewFile();
@@ -709,29 +709,29 @@ public class AutoUpdateTest extends TestBase {
     public File generateNBMContent (String name, String... filesAndContent) throws IOException {
         File f = new File (getWorkDir (), name);
 
-        ZipOutputStream os = new ZipOutputStream (new FileOutputStream (f));
-        for (int i = 0; i < filesAndContent.length; i += 2) {
-            os.putNextEntry(new ZipEntry(filesAndContent[i]));
-            os.write(filesAndContent[i + 1].getBytes());
+        try (ZipOutputStream os = new ZipOutputStream (new FileOutputStream (f))) {
+            for (int i = 0; i < filesAndContent.length; i += 2) {
+                os.putNextEntry(new ZipEntry(filesAndContent[i]));
+                os.write(filesAndContent[i + 1].getBytes());
+                os.closeEntry();
+            }
+            os.putNextEntry(new ZipEntry("Info/info.xml"));
+            String codeName = name.replaceAll("\\.nbm$", "").replace('-', '.');
+            os.write(("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                    "<!DOCTYPE module_updates PUBLIC \"-//NetBeans//DTD Autoupdate Info 2.5//EN\" \"http://www.netbeans.org/dtds/autoupdate-info-2_5.dtd\">\n").getBytes());
+            String res = "<module codenamebase=\"" + codeName + "\" " +
+                    "homepage=\"http://au.netbeans.org/\" distribution=\"wrong-path.hbm\" " +
+                    "license=\"standard-nbm-license.txt\" downloadsize=\"98765\" " +
+                    "needsrestart=\"false\" moduleauthor=\"\" " +
+                    "eager=\"false\" " +
+                    "releasedate=\"2006/02/23\">";
+            res +=  "<manifest OpenIDE-Module=\"" + codeName + "\" " +
+                    "OpenIDE-Module-Name=\"" + codeName + "\" " +
+                    "OpenIDE-Module-Specification-Version=\"333.3\"/>";
+            res += "</module>";
+            os.write(res.getBytes());
             os.closeEntry();
         }
-        os.putNextEntry(new ZipEntry("Info/info.xml"));
-        String codeName = name.replaceAll("\\.nbm$", "").replace('-', '.');
-        os.write(("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<!DOCTYPE module_updates PUBLIC \"-//NetBeans//DTD Autoupdate Info 2.5//EN\" \"http://www.netbeans.org/dtds/autoupdate-info-2_5.dtd\">\n").getBytes());
-        String res = "<module codenamebase=\"" + codeName + "\" " +
-                "homepage=\"http://au.netbeans.org/\" distribution=\"wrong-path.hbm\" " +
-                "license=\"standard-nbm-license.txt\" downloadsize=\"98765\" " +
-                "needsrestart=\"false\" moduleauthor=\"\" " +
-                "eager=\"false\" " +
-                "releasedate=\"2006/02/23\">";
-        res +=  "<manifest OpenIDE-Module=\"" + codeName + "\" " +
-                "OpenIDE-Module-Name=\"" + codeName + "\" " +
-                "OpenIDE-Module-Specification-Version=\"333.3\"/>";
-        res += "</module>";
-        os.write(res.getBytes());
-        os.closeEntry();
-        os.close();
 
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/AutoUpdateTest.java
@@ -183,7 +183,7 @@ public class AutoUpdateTest extends TestBase {
         File tracking = new File(install, "ide/update_tracking/org-apache-commons-io.xml");
         assertTrue(tracking.isFile());
         Document doc = XMLUtil.parse(new InputSource(tracking.toURI().toString()), false, false, null, null);
-        Set<String> files = new TreeSet<String>();
+        Set<String> files = new TreeSet<>();
         NodeList nl = doc.getElementsByTagName("file");
         for (int i = 0; i < nl.getLength(); i++) {
             files.add(((Element) nl.item(i)).getAttribute("name"));
@@ -699,7 +699,7 @@ public class AutoUpdateTest extends TestBase {
     }
 
     public File generateNBM (String name, String... files) throws IOException {
-        List<String> filesAndContent = new ArrayList<String>();
+        List<String> filesAndContent = new ArrayList<>();
         for (String s : files) {
             filesAndContent.add(s);
             filesAndContent.add("empty");

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/BrandingTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/BrandingTest.java
@@ -72,8 +72,7 @@ public class BrandingTest extends NbTestCase {
         b.execute();
         File jar = new File(cluster, "core/locale/core_myapp.jar");
         assertTrue(jar.isFile());
-        JarFile jf = new JarFile(jar);
-        try {
+        try (JarFile jf = new JarFile(jar)) {
             Enumeration<JarEntry> entries = jf.entries();
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
@@ -89,8 +88,6 @@ public class BrandingTest extends NbTestCase {
                     assertEquals("org/netbeans/core/startup/Bundle_myapp.properties", entry.getName());
                 }
             }
-        } finally {
-            jf.close();
         }
     }
 

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ConvertImportTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ConvertImportTest.java
@@ -93,9 +93,9 @@ public class ConvertImportTest extends NbTestCase {
 
     private File createFile(String xml) throws IOException {
        testFile = new File(getWorkDir(),"testFile.xml");
-       PrintStream ps = new PrintStream(testFile);
-       ps.print(xml);
-       ps.close();
+        try (PrintStream ps = new PrintStream(testFile)) {
+            ps.print(xml);
+        }
        return testFile;
     }
 

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
@@ -133,17 +133,16 @@ public class FixTestDependenciesTest extends TestBase {
     }
 
     private File copyFile(String resourceName) throws IOException {
-       InputStream is = getClass().getResourceAsStream(resourceName);
-       byte buf[] = new byte[10000];
-       File retFile = new File(getWorkDir(),resourceName);
-       FileOutputStream fos = new FileOutputStream(retFile);
-       int size;
-       while ((size = is.read(buf)) > 0 ) {
-           fos.write(buf,0,size);
-       }
-       is.close();
-       fos.close();
-       return retFile;
+        File retFile = new File(getWorkDir(), resourceName);
+        try (InputStream is = getClass().getResourceAsStream(resourceName);
+                FileOutputStream fos = new FileOutputStream(retFile);) {
+            byte buf[] = new byte[10000];
+            int size;
+            while ((size = is.read(buf)) > 0) {
+                fos.write(buf, 0, size);
+            }
+        }
+        return retFile;
     }
 
     private Set<ModuleListParser.Entry> getEntries() {

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesTest.java
@@ -102,8 +102,8 @@ public class FixTestDependenciesTest extends TestBase {
 
     public void testWrongBuilClassDep() throws IOException {
         FixTestDependencies ftd = newFixTestDependencies();
-        Set<String> cnb = new HashSet<String>();
-        Set<String> testCnb = new HashSet<String>();
+        Set<String> cnb = new HashSet<>();
+        Set<String> testCnb = new HashSet<>();
  
         Properties props = new Properties();
         String PNAME = "cp.extra";
@@ -147,7 +147,7 @@ public class FixTestDependenciesTest extends TestBase {
     }
 
     private Set<ModuleListParser.Entry> getEntries() {
-        Set<ModuleListParser.Entry> entries = new HashSet<ModuleListParser.Entry>();
+        Set<ModuleListParser.Entry> entries = new HashSet<>();
         File nonexistent = new File("nonexistent");
         entries.add(new ModuleListParser.Entry("org.openide.io",new File("extra/modules/org-openide-io.jar"),
             new File[0],    null,"openide/io",

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
@@ -127,7 +127,7 @@ public class InsertModuleAllTargetsTest extends NbTestCase {
     }
 
     private Set<String> depsToNames(Enumeration en) {
-        Set<String> set = new HashSet<String>();
+        Set<String> set = new HashSet<>();
         while (en.hasMoreElements()) {
             String dep = en.nextElement().toString();
             set.add(dep);

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/InsertModuleAllTargetsTest.java
@@ -63,9 +63,9 @@ public class InsertModuleAllTargetsTest extends NbTestCase {
         assertTrue("cluster.properties file exists", clusters.exists());
         
         Properties clusterProps = new Properties();
-        final FileInputStream is = new FileInputStream(clusters);
-        clusterProps.load(is);
-        is.close();
+        try (FileInputStream is = new FileInputStream(clusters)) {
+            clusterProps.load(is);
+        }
         
         for (Entry<Object, Object> en : clusterProps.entrySet()) {
             p.setProperty(en.getKey().toString(), en.getValue().toString());

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/LocFilesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/LocFilesTest.java
@@ -160,7 +160,7 @@ public class LocFilesTest extends NbTestCase {
         File f = new File(dist, jar.replace('/', File.separatorChar));
         assertTrue("File " + f + " is created", f.exists());
         JarFile jf = new JarFile(f);
-        Set<String> expected = new HashSet<String>(Arrays.asList(files));
+        Set<String> expected = new HashSet<>(Arrays.asList(files));
         Enumeration<JarEntry> en = jf.entries();
         while (en.hasMoreElements()) {
             JarEntry e = en.nextElement();

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
@@ -50,8 +50,8 @@ public class MakeJNLPTest extends TestBase {
     
     private static void assertFilenames(File dir, String... contents) {
         assertTrue(dir + " is a directory", dir.isDirectory());
-        SortedSet<String> expected = new TreeSet<String>(Arrays.asList(contents));
-        SortedSet<String> actual = new TreeSet<String>();
+        SortedSet<String> expected = new TreeSet<>(Arrays.asList(contents));
+        SortedSet<String> actual = new TreeSet<>();
         findFilenames(dir, "", actual);
         assertEquals("correct contents of " + dir, expected/*.toString()*/, actual/*.toString()*/);
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeJNLPTest.java
@@ -337,9 +337,9 @@ public class MakeJNLPTest extends TestBase {
         assertTrue("Created", updateTracking.isDirectory());
         
         File trackingFile = new File(updateTracking, "org-netbeans-modules-autoupdate.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(UTfile);
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(UTfile);
+        }
 
         File output = new File(getWorkDir(), "output");
         File ks = generateKeystore("jnlp", "netbeans-test");
@@ -422,20 +422,20 @@ public class MakeJNLPTest extends TestBase {
         assertTrue("Created", updateTracking.isDirectory());
         
         File trackingFile = new File(updateTracking, "org-netbeans-core-startup.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.my.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
-        "<file name='config/Modules/org-netbeans-core-startup.xml' crc='43434' />\n" +
-        "<file name='modules/locale/core_cs.jar' crc='454244' />\n" +
-        "<file name='modules/locale/core_ja.jar' crc='779831' />\n" +
-        "<file name='modules/locale/core_zh_CN.jar' crc='475345' />\n" +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.my.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
+                                    "<file name='config/Modules/org-netbeans-core-startup.xml' crc='43434' />\n" +
+                                    "<file name='modules/locale/core_cs.jar' crc='454244' />\n" +
+                                    "<file name='modules/locale/core_ja.jar' crc='779831' />\n" +
+                                    "<file name='modules/locale/core_zh_CN.jar' crc='475345' />\n" +
+                                    "    </module_version>\n" +
+                                    "</module>\n"
+            );
+        }
         
         
         File output = new File(parent, "output");
@@ -487,20 +487,20 @@ public class MakeJNLPTest extends TestBase {
         assertTrue("Created", updateTracking.isDirectory());
         
         File trackingFile = new File(updateTracking, "org-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.my.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
-        "<file name='config/Modules/org-my-module.xml' crc='43434' />\n" +
-        "<file name='modules/locale/0_cs.jar' crc='454244' />\n" +
-        "<file name='modules/locale/0_ja.jar' crc='779831' />\n" +
-        "<file name='modules/locale/0_zh_CN.jar' crc='475345' />\n" +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.my.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
+                                    "<file name='config/Modules/org-my-module.xml' crc='43434' />\n" +
+                                    "<file name='modules/locale/0_cs.jar' crc='454244' />\n" +
+                                    "<file name='modules/locale/0_ja.jar' crc='779831' />\n" +
+                                    "<file name='modules/locale/0_zh_CN.jar' crc='475345' />\n" +
+                                    "    </module_version>\n" +
+                                    "</module>\n"
+            );
+        }
         
         
         File output = new File(parent, "output");
@@ -580,20 +580,20 @@ public class MakeJNLPTest extends TestBase {
         assertTrue("Created", updateTracking.isDirectory());
         
         File trackingFile = new File(updateTracking, "org-netbeans-core-startup.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.my.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        "<file name='core/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
-        "<file name='config/Modules/org-netbeans-core-startup.xml' crc='43434' />\n" +
-        "<file name='core/locale/core_cs.jar' crc='454244' />\n" +
-        "<file name='core/locale/core_ja.jar' crc='779831' />\n" +
-        "<file name='core/locale/core_zh_CN.jar' crc='475345' />\n" +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.my.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            "<file name='core/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
+                                    "<file name='config/Modules/org-netbeans-core-startup.xml' crc='43434' />\n" +
+                                    "<file name='core/locale/core_cs.jar' crc='454244' />\n" +
+                                    "<file name='core/locale/core_ja.jar' crc='779831' />\n" +
+                                    "<file name='core/locale/core_zh_CN.jar' crc='475345' />\n" +
+                                    "    </module_version>\n" +
+                                    "</module>\n"
+            );
+        }
         
         
         File output = new File(parent, "output");
@@ -645,20 +645,20 @@ public class MakeJNLPTest extends TestBase {
         assertTrue("Created", updateTracking.isDirectory());
         
         File trackingFile = new File(updateTracking, "org-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.my.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
-        "<file name='config/Modules/org-my-module.xml' crc='43434' />\n" +
-        "<file name='modules/locale/0_cs.jar' crc='454244' />\n" +
-        "<file name='modules/locale/0_ja.jar' crc='779831' />\n" +
-        "<file name='modules/locale/0_zh_CN.jar' crc='475345' />\n" +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.my.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            "<file name='modules/" + simpleJar.getName() + "' crc='3245456472'/>\n" +
+                                    "<file name='config/Modules/org-my-module.xml' crc='43434' />\n" +
+                                    "<file name='modules/locale/0_cs.jar' crc='454244' />\n" +
+                                    "<file name='modules/locale/0_ja.jar' crc='779831' />\n" +
+                                    "<file name='modules/locale/0_zh_CN.jar' crc='475345' />\n" +
+                                    "    </module_version>\n" +
+                                    "</module>\n"
+            );
+        }
         
         
         File output = new File(parent, "output");
@@ -948,19 +948,19 @@ public class MakeJNLPTest extends TestBase {
         enableXML.createNewFile();
         
         File trackingFile = new File(updateTracking, "aaa-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.apache.tools.ant.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        (useNonModule ? ("<file name='modules/" + nonModule.getName() + "' crc='1536373800'/>\n") : "") +
-        "<file name='modules/" + module.getName() + "' crc='3245456472'/>\n" +
-        "<file name='config/Modules/aaa-my-module.xml' crc='43434' />\n" +
-        (fakeEntry != null ? "<file name='" + fakeEntry + "' crc='43222' />\n" : "") +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.apache.tools.ant.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            (useNonModule ? ("<file name='modules/" + nonModule.getName() + "' crc='1536373800'/>\n") : "") +
+                            "<file name='modules/" + module.getName() + "' crc='3245456472'/>\n" +
+                                    "<file name='config/Modules/aaa-my-module.xml' crc='43434' />\n" +
+                            (fakeEntry != null ? "<file name='" + fakeEntry + "' crc='43222' />\n" : "") +
+                            "    </module_version>\n" +
+                                    "</module>\n"
+            );
+        }
         
         
         
@@ -1078,21 +1078,20 @@ public class MakeJNLPTest extends TestBase {
             manifest.getMainAttributes().putValue("OpenIDE-Module-Localizing-Bundle", "some/fake/prop/name/Bundle.properties");
         }
         
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-        
-        if (props != null) {
-            os.putNextEntry(new JarEntry("some/fake/prop/name/Bundle.properties"));
-            props.store(os, "# properties for the module");
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            if (props != null) {
+                os.putNextEntry(new JarEntry("some/fake/prop/name/Bundle.properties"));
+                props.store(os, "# properties for the module");
+                os.closeEntry();
+            }
+            
+            
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        
-        
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
-        }
-        os.closeEntry ();
-        os.close();
         
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeMasterJNLPTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeMasterJNLPTest.java
@@ -191,14 +191,13 @@ public class MakeMasterJNLPTest extends TestBase {
     protected final File generateJar (String[] content, Manifest manifest) throws IOException {
         File f = createNewJarFile ();
         
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-        
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        os.closeEntry ();
-        os.close();
         
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeNBMTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeNBMTest.java
@@ -58,16 +58,16 @@ public class MakeNBMTest extends TestBase {
         
         File ut = new File (new File(getWorkDir(), "update_tracking"), "org-my-module.xml");
         ut.getParentFile().mkdirs();
-        FileWriter w = new FileWriter(ut);
-        String UTfile =   
-            "<?xml version='1.0' encoding='UTF-8'?>" +
-            "<module codename='org.netbeans.modules.autoupdate/1'>" +
-            "    <module_version install_time='1136503038669' last='true' origin='installer' specification_version='2.16.1'>" +
-            "        <file crc='3405032071' name='modules/" + simpleJar.getName() + "'/>" +
-            "    </module_version>" +
-            "</module>";
-        w.write(UTfile);
-        w.close();
+        try (FileWriter w = new FileWriter(ut)) {
+            String UTfile =
+                    "<?xml version='1.0' encoding='UTF-8'?>" +
+                    "<module codename='org.netbeans.modules.autoupdate/1'>" +
+                    "    <module_version install_time='1136503038669' last='true' origin='installer' specification_version='2.16.1'>" +
+                    "        <file crc='3405032071' name='modules/" + simpleJar.getName() + "'/>" +
+                    "    </module_version>" +
+                    "</module>";
+            w.write(UTfile);
+        }
         
         java.io.File f = extractString (
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
@@ -161,21 +161,20 @@ public class MakeNBMTest extends TestBase {
             manifest.getMainAttributes().putValue("OpenIDE-Module-Localizing-Bundle", "some/fake/prop/name/Bundle.properties");
         }
         
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-        
-        if (props != null) {
-            os.putNextEntry(new JarEntry("some/fake/prop/name/Bundle.properties"));
-            props.store(os, "# properties for the module");
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            if (props != null) {
+                os.putNextEntry(new JarEntry("some/fake/prop/name/Bundle.properties"));
+                props.store(os, "# properties for the module");
+                os.closeEntry();
+            }
+            
+            
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        
-        
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
-        }
-        os.closeEntry ();
-        os.close();
         
         return f;
     }
@@ -232,9 +231,9 @@ public class MakeNBMTest extends TestBase {
         mani.getMainAttributes().putValue("OpenIDE-Module", "mod");
         OutputStream os = new FileOutputStream(new File(modules, "mod.jar"));
         try {
-            JarOutputStream jos = new JarOutputStream(os, mani);
-            jos.finish();
-            jos.close();
+            try (JarOutputStream jos = new JarOutputStream(os, mani)) {
+                jos.finish();
+            }
         } finally {
             os.close();
         }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
@@ -96,14 +96,14 @@ public class MakeOSGiTest extends NbTestCase {
         // boilerplate:
         assertEquals("1.0", osgi.remove(new Attributes.Name("Manifest-Version")));
         assertEquals("2", osgi.remove(new Attributes.Name("Bundle-ManifestVersion")));
-        SortedMap<String,String> osgiMap = new TreeMap<String,String>();
+        SortedMap<String,String> osgiMap = new TreeMap<>();
         for (Map.Entry<Object,Object> entry : osgi.entrySet()) {
             osgiMap.put(((Attributes.Name) entry.getKey()).toString(), (String) entry.getValue());
         }
         assertEquals(expectedOsgi, osgiMap.toString().replace('"', '\''));
     }
     private static Set<String> set(String... items) {
-        return new TreeSet<String>(Arrays.asList(items));
+        return new TreeSet<>(Arrays.asList(items));
     }
 
     public void testTranslateDependency() throws Exception {

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/MakeOSGiTest.java
@@ -129,13 +129,10 @@ public class MakeOSGiTest extends NbTestCase {
 
     public void testPrescan() throws Exception {
         File j = new File(getWorkDir(), "x.jar");
-        OutputStream os = new FileOutputStream(j);
-        try {
+        try (OutputStream os = new FileOutputStream(j)) {
             JarOutputStream jos = new JarOutputStream(os, new Manifest(new ByteArrayInputStream("Manifest-Version: 1.0\nBundle-SymbolicName: org.eclipse.mylyn.bugzilla.core;singleton:=true\nExport-Package: org.eclipse.mylyn.internal.bugzilla.core;x-friends:=\"org.eclipse.mylyn.bugzilla.ide,org.eclipse.mylyn.bugzilla.ui\",org.eclipse.mylyn.internal.bugzilla.core.history;x-friends:=\"org.eclipse.mylyn.bugzilla.ide,org.eclipse.mylyn.bugzilla.ui\",org.eclipse.mylyn.internal.bugzilla.core.service;x-internal:=true\n".getBytes())));
             jos.flush();
             jos.close();
-        } finally {
-            os.close();
         }
         Info info = new MakeOSGi.Info();
         JarFile jf = new JarFile(j);

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleDependenciesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleDependenciesTest.java
@@ -1401,14 +1401,13 @@ public class ModuleDependenciesTest extends TestBase {
     private File generateJar(String[] content, Manifest manifest) throws IOException {
         File f = createNewJarFile ();
         
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-        
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        os.closeEntry ();
-        os.close();
         
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
@@ -69,7 +69,7 @@ public class ModuleListParserTest extends TestBase {
     }
 
     public void testScanSourcesInNetBeansOrg() throws Exception {
-        Hashtable<String,Object> properties = new Hashtable<String,Object>();
+        Hashtable<String,Object> properties = new Hashtable<>();
         properties.put("nb_all", nball.getAbsolutePath());
         File build = file(nball, "nbbuild/netbeans");
         properties.put("netbeans.dest.dir", build.getAbsolutePath());
@@ -132,7 +132,7 @@ public class ModuleListParserTest extends TestBase {
             public void buildStarted(BuildEvent buildEvent) {}
             public void buildFinished(BuildEvent buildEvent) {}
         });
-        Hashtable<String,Object> properties = new Hashtable<String,Object>();
+        Hashtable<String,Object> properties = new Hashtable<>();
         properties.put("cluster.path.final", filePath(nball, "nbbuild/netbeans/platform")
                 + File.pathSeparator + filePath(nball, "nbbuild/netbeans/ide"));
         properties.put("basedir", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite1/action-project"));
@@ -225,7 +225,7 @@ public class ModuleListParserTest extends TestBase {
         assertEquals("One file generated", 1, arr.length);
         assertEquals(dashCnb + ".xml", arr[0]);
 
-        Hashtable<String,Object> properties = new Hashtable<String,Object>();
+        Hashtable<String,Object> properties = new Hashtable<>();
         properties.put("cluster.path.final", filePath(nball, "nbbuild/netbeans/platform")
                 + File.pathSeparator + getWorkDir());
         properties.put("basedir", filePath(nball, "apisupport.ant/test/unit/data/example-external-projects/suite1/action-project"));

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleListParserTest.java
@@ -256,14 +256,13 @@ public class ModuleListParserTest extends TestBase {
 //    }
 
     private File generateJar (File f, String[] content, Manifest manifest) throws IOException {
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        os.closeEntry ();
-        os.close();
 
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleSelectorTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleSelectorTest.java
@@ -151,36 +151,36 @@ public class ModuleSelectorTest extends TestBase {
         File aModule = generateJar(new String[0], m);
         
         File trackingFile = new File(updateTracking, "org-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version='1.0' encoding='UTF-8'?>\n" +
-"<module codename='org.apache.tools.ant.module/3'>\n" +
-    "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-        "<file name='ant/bin/ant' crc='1536373800'/>\n" +
-        "<file name='ant/bin/ant.bat' crc='3245456472'/>\n" +
-        "<file name='ant/bin/ant.cmd' crc='3819623376'/>\n" +
-        "<file name='ant/bin/antRun' crc='2103827286'/>\n" +
-        "<file name='ant/bin/antRun.bat' crc='2739687679'/>\n" +
-        "<file name='ant/bin/antRun.pl' crc='3955456526'/>\n" +
-"    </module_version>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                            "<module codename='org.apache.tools.ant.module/3'>\n" +
+                            "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                            "<file name='ant/bin/ant' crc='1536373800'/>\n" +
+                            "<file name='ant/bin/ant.bat' crc='3245456472'/>\n" +
+                            "<file name='ant/bin/ant.cmd' crc='3819623376'/>\n" +
+                            "<file name='ant/bin/antRun' crc='2103827286'/>\n" +
+                            "<file name='ant/bin/antRun.bat' crc='2739687679'/>\n" +
+                            "<file name='ant/bin/antRun.pl' crc='3955456526'/>\n" +
+                            "    </module_version>\n" +
+                            "</module>\n"
+            );
+        }
 
         StringBuilder sb = new StringBuilder();
         sb.append(trackingFile.getPath());
         
         while (--parents > 0) {
             File x = new File(getWorkDir(), parents + ".xml");
-            FileWriter xw = new FileWriter(x);
-            xw.write(
-    "<?xml version='1.0' encoding='UTF-8'?>\n" +
-    "<module codename='" + x + "/3'>\n" +
-        "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
-    "    </module_version>\n" +
-    "</module>\n"
-            );
-            xw.close();
+            try (FileWriter xw = new FileWriter(x)) {
+                xw.write(
+                        "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                                "<module codename='" + x + "/3'>\n" +
+                                        "<module_version specification_version='3.22' origin='installer' last='true' install_time='1124194231878'>\n" +
+                                        "    </module_version>\n" +
+                                        "</module>\n"
+                );
+            }
             
             sb.insert(0, File.pathSeparator);
             sb.insert(0, x.getPath());

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleStateSelectorTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ModuleStateSelectorTest.java
@@ -56,20 +56,20 @@ public class ModuleStateSelectorTest extends TestBase {
         File aModule = generateJar("org.my.module", new String[0], m);
         
         File trackingFile = new File(cfg, "org-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-"<!DOCTYPE module PUBLIC \"-//NetBeans//DTD Module Status 1.0//EN\"\n" +
-"                        \"http://www.netbeans.org/dtds/module-status-1_0.dtd\">\n" +
-"<module name=\"org.my.module\">\n" +
-"    <param name=\"autoload\">true</param>\n" +
-"    <param name=\"eager\">false</param>\n" +
-"    <param name=\"jar\">modules/org-openide-awt.jar</param>\n" +
-"    <param name=\"reloadable\">false</param>\n" +
-"    <param name=\"specversion\">7.4.0.1</param>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                            "<!DOCTYPE module PUBLIC \"-//NetBeans//DTD Module Status 1.0//EN\"\n" +
+                            "                        \"http://www.netbeans.org/dtds/module-status-1_0.dtd\">\n" +
+                            "<module name=\"org.my.module\">\n" +
+                            "    <param name=\"autoload\">true</param>\n" +
+                            "    <param name=\"eager\">false</param>\n" +
+                            "    <param name=\"jar\">modules/org-openide-awt.jar</param>\n" +
+                            "    <param name=\"reloadable\">false</param>\n" +
+                            "    <param name=\"specversion\">7.4.0.1</param>\n" +
+                            "</module>\n"
+            );
+        }
 
         Parameter p = new Parameter();
         p.setName("acceptEager");
@@ -92,20 +92,20 @@ public class ModuleStateSelectorTest extends TestBase {
         File aModule = generateJar("org.my.module", new String[0], m);
 
         File trackingFile = new File(cfg, "org-my-module.xml");
-        FileWriter w = new FileWriter(trackingFile);
-        w.write(
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-"<!DOCTYPE module PUBLIC \"-//NetBeans//DTD Module Status 1.0//EN\"\n" +
-"                        \"http://www.netbeans.org/dtds/module-status-1_0.dtd\">\n" +
-"<module name=\"org.my.module\">\n" +
-"    <param name=\"autoload\">false</param>\n" +
-"    <param name=\"eager\">true</param>\n" +
-"    <param name=\"jar\">modules/org-openide-awt.jar</param>\n" +
-"    <param name=\"reloadable\">false</param>\n" +
-"    <param name=\"specversion\">7.4.0.1</param>\n" +
-"</module>\n"
-        );
-        w.close();
+        try (FileWriter w = new FileWriter(trackingFile)) {
+            w.write(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                            "<!DOCTYPE module PUBLIC \"-//NetBeans//DTD Module Status 1.0//EN\"\n" +
+                            "                        \"http://www.netbeans.org/dtds/module-status-1_0.dtd\">\n" +
+                            "<module name=\"org.my.module\">\n" +
+                            "    <param name=\"autoload\">false</param>\n" +
+                            "    <param name=\"eager\">true</param>\n" +
+                            "    <param name=\"jar\">modules/org-openide-awt.jar</param>\n" +
+                            "    <param name=\"reloadable\">false</param>\n" +
+                            "    <param name=\"specversion\">7.4.0.1</param>\n" +
+                            "</module>\n"
+            );
+        }
 
         Parameter p = new Parameter();
         p.setName("acceptEager");

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ParseProjectXmlTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ParseProjectXmlTest.java
@@ -151,21 +151,20 @@ public class ParseProjectXmlTest extends TestBase {
 
     private File extractFile(String content, String fileName) throws IOException {
         File f = new File(getWorkDir(),fileName);
-        FileOutputStream fos = new FileOutputStream(f);
-        fos.write(content.getBytes("UTF-8"));
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(f)) {
+            fos.write(content.getBytes("UTF-8"));
+        }
         return f;
     }
 
     private File generateJar (File f, String[] content, Manifest manifest) throws IOException {
-        JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest);
-
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry (content[i]));
-            os.closeEntry();
+        try (JarOutputStream os = new JarOutputStream (new FileOutputStream (f), manifest)) {
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry (content[i]));
+                os.closeEntry();
+            }
+            os.closeEntry ();
         }
-        os.closeEntry ();
-        os.close();
 
         return f;
     }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/PrintIconTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/PrintIconTest.java
@@ -43,13 +43,13 @@ public class PrintIconTest extends TestBase {
                  break;
              }
         }
-        OutputStream os = new FileOutputStream(f);
-        InputStream is = PrintIconTest.class.getResourceAsStream(resource);
-        int c;
-        while ((c = is.read()) != -1) {
-            os.write(c);
+        try (OutputStream os = new FileOutputStream(f);
+                InputStream is = PrintIconTest.class.getResourceAsStream(resource)) {
+            int c;
+            while ((c = is.read()) != -1) {
+                os.write(c);
+            }
         }
-        os.close();
         return f;
     }
 

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/RecursiveDepsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/RecursiveDepsTest.java
@@ -49,10 +49,10 @@ public class RecursiveDepsTest extends TestBase {
     private File extractFile(InputStream is, String fileName) throws IOException {
         File f = new File(getWorkDir(),fileName);
         byte bytes[] = new byte[50000];
-        FileOutputStream fos = new FileOutputStream(f);
-        int len = is.read(bytes);
-        fos.write(bytes,0,len);
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(f)) {
+            int len = is.read(bytes);
+            fos.write(bytes,0,len);
+        }
         return f;
     }
     

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/ShorterPathsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/ShorterPathsTest.java
@@ -52,9 +52,9 @@ public class ShorterPathsTest extends TestBase {
         File testProperties = new File(wd, "outtest.properties");
         extraLibsDir.mkdirs();
 
-        PrintStream ps = new PrintStream(extlib);
-        ps.println("content");
-        ps.close();
+        try (PrintStream ps = new PrintStream(extlib)) {
+            ps.println("content");
+        }
 
 
         execute("ShorterPathsTest.xml", new String[]{
@@ -126,20 +126,20 @@ public class ShorterPathsTest extends TestBase {
         assertTrue("Class-Path extension not copied.", classPathExtensionCopy.exists());
 
         Properties props = new Properties();
-        FileInputStream propsIs = new FileInputStream(testProperties);
-        props.load(propsIs);
-        propsIs.close();
+        try (FileInputStream propsIs = new FileInputStream(testProperties)) {
+            props.load(propsIs);
+        }
         assertEquals("extra.test.libs.dir", "${extra.test.libs.dir}/extlib.jar", props.getProperty("extra.test.libs"));
         assertEquals("test.run.cp", "${nb.root.test.dir}/module.jar", props.getProperty("test.run.cp"));
     }
 
     private void generateJar(File jarFile, String[] content, Manifest manifest) throws IOException {
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), manifest);
-        for (int i = 0; i < content.length; i++) {
-            os.putNextEntry(new JarEntry(content[i]));
+        try (JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), manifest)) {
+            for (int i = 0; i < content.length; i++) {
+                os.putNextEntry(new JarEntry(content[i]));
+                os.closeEntry();
+            }
             os.closeEntry();
         }
-        os.closeEntry();
-        os.close();
     }
 }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
@@ -68,16 +68,16 @@ abstract class TestBase extends NbTestCase {
     protected final File extractString(String res) throws Exception {
         File f = File.createTempFile("res", ".xml", getWorkDir());
 
-        FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(res.getBytes("UTF-8"));
-        for (;;) {
-            int ch = is.read();
-            if (ch == -1) {
-                break;
+        try (FileOutputStream os = new FileOutputStream(f)) {
+            InputStream is = new ByteArrayInputStream(res.getBytes("UTF-8"));
+            for (;;) {
+                int ch = is.read();
+                if (ch == -1) {
+                    break;
+                }
+                os.write(ch);
             }
-            os.write(ch);
         }
-        os.close();
 
         return f;
     }
@@ -93,16 +93,16 @@ abstract class TestBase extends NbTestCase {
         assertNotNull("Resource should be found " + res, u);
 
 
-        FileOutputStream os = new FileOutputStream(f);
-        InputStream is = u.openStream();
-        for (;;) {
-            int ch = is.read();
-            if (ch == -1) {
-                break;
+        try (FileOutputStream os = new FileOutputStream(f)) {
+            InputStream is = u.openStream();
+            for (;;) {
+                int ch = is.read();
+                if (ch == -1) {
+                    break;
+                }
+                os.write(ch);
             }
-            os.write(ch);
         }
-        os.close();
     }
 
     protected final void execute(String res, String... args) throws Exception {

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/TestBase.java
@@ -146,7 +146,7 @@ abstract class TestBase extends NbTestCase {
         // for me now, I leave it for the time when somebody really
         // needs that...
 
-        List<String> arr = new ArrayList<String>();
+        List<String> arr = new ArrayList<>();
         arr.add("-f");
         arr.add(f.toString());
         arr.addAll(Arrays.asList(args));

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/TestDepsTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/TestDepsTest.java
@@ -59,10 +59,10 @@ public class TestDepsTest extends TestBase {
     private File extractFile(InputStream is, String fileName) throws IOException {
         File f = new File(getWorkDir(),fileName);
         byte bytes[] = new byte[50000];
-        FileOutputStream fos = new FileOutputStream(f);
-        int len = is.read(bytes);
-        fos.write(bytes,0,len);
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(f)) {
+            int len = is.read(bytes);
+            fos.write(bytes,0,len);
+        }
         return f;
     }
     

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/DownloadBinariesTest.java
@@ -41,9 +41,9 @@ public class DownloadBinariesTest extends NbTestCase {
     private File list;
 
     private static void write(File f, String contents) throws IOException {
-        OutputStream os = new FileOutputStream(f);
-        os.write(contents.getBytes("UTF-8"));
-        os.close();
+        try (OutputStream os = new FileOutputStream(f)) {
+            os.write(contents.getBytes("UTF-8"));
+        }
     }
 
     @Override

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
@@ -141,7 +141,7 @@ public class TestDistFilterTest extends NbTestCase {
         assertNotNull("prop " + propName + " was not defined",listModules);
         log(" listModules " + listModules);
         String arrayModules[] = (listModules.length() == 0) ? new String[0] :listModules.split(":");
-        Set<File> set1 = new HashSet<File>();
+        Set<File> set1 = new HashSet<>();
         for (int i = 0 ; i < arrayModules.length ; i++) {
             String module = arrayModules[i];
             if (module.length() == 1 && i < arrayModules.length + 1) { 
@@ -151,7 +151,7 @@ public class TestDistFilterTest extends NbTestCase {
             log(i + " = " + module );
             set1.add(new File(module)); 
         }
-        Set<File> set2 = new HashSet<File>();
+        Set<File> set2 = new HashSet<>();
         for (int i = 0 ; i < modules.length ; i++) {
             set2.add(new File(getWorkDir(),modules[i]));
         }

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/testdist/TestDistFilterTest.java
@@ -162,11 +162,8 @@ public class TestDistFilterTest extends NbTestCase {
     private void createModule(String path, String runcp) throws IOException {
         File dir = createModule(path);
         File props = new File(dir,"test.properties");
-        PrintStream ps = new PrintStream(props);
-        try { 
+        try (PrintStream ps = new PrintStream(props)) { 
             ps.println("test.unit.run.cp=" + runcp);
-        } finally {
-            ps.close();
         }
     }
 }

--- a/spi.editor.hints/arch.xml
+++ b/spi.editor.hints/arch.xml
@@ -19,8 +19,8 @@
     under the License.
 
 -->
-<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../editor/../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
-  <!ENTITY api-questions SYSTEM "../editor/../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
 ]>
 
 <api-answers


### PR DESCRIPTION
The main commits are the first and last commit of this series:

The first commit cleans up the usage of the xmlcatalog in nbbuild. When the xhtml DTDs were reintegrated into the codebase, the fallout was, that the unittests, that expected them in certain places began to fail. This was fixed by creating an xmlcatalog, that resolves the XSDs and DTDs in the `nbantext.jar`. This approach was consolidated and expanded to the javadoctools. When running `ant -f arch-all.xml` several `arch.xml` were reported, that were showing errors. The structural problems were fixed, the problems on the content level are still present.

The last commit resolves javac warnings when the build tools are bootstrapped. The output of the netbeans build is not very usable, as it is littered with warnings. This is the first of many fixes, to get this down.

The "Inspect+Transform" commits are basicly applications of the NetBeans tools to get the codebase to a newer level and remove redundancy.