### PR TITLE
Readd missing XML catalogs in o.apache.xml.resolver

### DIFF
--- a/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.dtd
+++ b/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.dtd
@@ -1,0 +1,147 @@
+<!--
+
+Copyright � 2000, 2001 The Organization for the Advancement of Structured
+Information Standards [OASIS]. All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and
+derivative works that comment on or otherwise explain it or assist in its
+implementation may be prepared, copied, published and distributed, in whole or
+in part, without restriction of any kind, provided that the above copyright
+notice and this paragraph are included on all such copies and derivative works.
+However, this document itself may not be modified in any way, such as by
+removing the copyright notice or references to OASIS, except as needed for the
+purpose of developing OASIS specifications, in which case the procedures for
+copyrights defined in the OASIS Intellectual Property Rights document must be
+followed, or as required to translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by
+OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on an "AS IS"
+basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE
+ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+Original XSD can be found here:
+https://www.oasis-open.org/committees/entity/spec-2001-08-06.html
+
+-->
+
+<!-- $Id: catalog.dtd,v 1.9 2001/06/12 14:26:00 ndw Exp $ -->
+
+<!ENTITY % pubIdChars "CDATA">
+<!ENTITY % publicIdentifier "%pubIdChars;">
+<!ENTITY % partialPublicIdentifier "%pubIdChars;">
+<!ENTITY % uriReference "CDATA">
+<!ENTITY % string "CDATA">
+<!ENTITY % systemOrPublic "(system|public)">
+
+<!ENTITY % p "">
+<!ENTITY % s "">
+<!ENTITY % nsdecl "xmlns%s;">
+
+<!ENTITY % catalog "%p;catalog">
+<!ENTITY % public "%p;public">
+<!ENTITY % system "%p;system">
+<!ENTITY % uri "%p;uri">
+<!ENTITY % rewriteSystem "%p;rewriteSystem">
+<!ENTITY % rewriteURI "%p;rewriteURI">
+<!ENTITY % delegatePublic "%p;delegatePublic">
+<!ENTITY % delegateSystem "%p;delegateSystem">
+<!ENTITY % delegateURI "%p;delegateURI">
+<!ENTITY % nextCatalog "%p;nextCatalog">
+<!ENTITY % group "%p;group">
+
+<!ENTITY % local.catalog.attribs "">
+
+<!ELEMENT %catalog; (%public;|%system;|%uri;
+                     |%rewriteSystem;|%rewriteURI;
+                     |%delegatePublic;|%delegateSystem;|%delegateURI;
+                     |%nextCatalog;|%group;)+>
+<!ATTLIST %catalog;
+    %nsdecl;    %uriReference;      #FIXED
+        'urn:oasis:names:tc:entity:xmlns:xml:catalog'
+    prefer      %systemOrPublic;    #IMPLIED
+    xml:base    %uriReference;      #IMPLIED
+    %local.catalog.attribs;
+>
+
+<!ELEMENT %public; EMPTY>
+<!ATTLIST %public;
+    id      ID          #IMPLIED
+    publicId    %publicIdentifier;  #REQUIRED
+    uri     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %system; EMPTY>
+<!ATTLIST %system;
+    id      ID          #IMPLIED
+    systemId    %string;        #REQUIRED
+    uri     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %uri; EMPTY>
+<!ATTLIST %uri;
+    id      ID          #IMPLIED
+    name        %string;        #REQUIRED
+    uri     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %rewriteSystem; EMPTY>
+<!ATTLIST %rewriteSystem;
+    id      ID          #IMPLIED
+    systemIdStartString %string;    #REQUIRED
+    rewritePrefix       %string;        #REQUIRED
+>
+
+<!ELEMENT %rewriteURI; EMPTY>
+<!ATTLIST %rewriteURI;
+    id      ID          #IMPLIED
+    uriStartString  %string;        #REQUIRED
+    rewritePrefix   %string;        #REQUIRED
+>
+
+<!ELEMENT %delegatePublic; EMPTY>
+<!ATTLIST %delegatePublic;
+    id      ID          #IMPLIED
+    publicIdStartString %partialPublicIdentifier;   #REQUIRED
+    catalog     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %delegateSystem; EMPTY>
+<!ATTLIST %delegateSystem;
+    id      ID          #IMPLIED
+    systemIdStartString %string;    #REQUIRED
+    catalog     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %delegateURI; EMPTY>
+<!ATTLIST %delegateURI;
+    id      ID          #IMPLIED
+    uriStartString  %string;        #REQUIRED
+    catalog     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %nextCatalog; EMPTY>
+<!ATTLIST %nextCatalog;
+    id      ID          #IMPLIED
+    catalog     %uriReference;      #REQUIRED
+    xml:base    %uriReference;      #IMPLIED
+>
+
+<!ELEMENT %group; (%public;|%system;|%uri;
+                   |%rewriteSystem;|%rewriteURI;
+                   |%delegatePublic;|%delegateSystem;|%delegateURI;
+                   |%nextCatalog;)+>
+<!ATTLIST %group;
+    id      ID          #IMPLIED
+    prefer      %systemOrPublic;    #IMPLIED
+    xml:base    %uriReference;      #IMPLIED
+>

--- a/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.rng
+++ b/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.rng
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Copyright � 2000, 2001 The Organization for the Advancement of Structured
+Information Standards [OASIS]. All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and
+derivative works that comment on or otherwise explain it or assist in its
+implementation may be prepared, copied, published and distributed, in whole or
+in part, without restriction of any kind, provided that the above copyright
+notice and this paragraph are included on all such copies and derivative works.
+However, this document itself may not be modified in any way, such as by
+removing the copyright notice or references to OASIS, except as needed for the
+purpose of developing OASIS specifications, in which case the procedures for
+copyrights defined in the OASIS Intellectual Property Rights document must be
+followed, or as required to translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by
+OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on an "AS IS"
+basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE
+ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+Original XSD can be found here:
+https://www.oasis-open.org/committees/entity/spec-2001-08-06.html
+
+-->
+<!DOCTYPE module SYSTEM "/share/doctypes/RELAX/relaxCore.dtd">
+
+<module moduleVersion="0.1"
+    relaxCoreVersion="1.0"
+    targetNamespace="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+    xmlns="http://www.xml.gr.jp/xmlns/relaxCore">
+
+  <!-- $Id: catalog.rlx,v 1.7 2001/06/12 14:26:00 ndw Exp $ -->
+
+  <interface>
+    <export label="catalog"/>
+  </interface>
+
+  <attPool role='optional.attributes'>
+    <attribute name='id' type='ID'/>
+    <attribute name='xml:base' type='string'/>
+  </attPool>
+
+  <attPool role='prefer.attribute'>
+    <attribute name='prefer' type='NMTOKEN'>
+      <enumeration value='system'/>
+      <enumeration value='public'/>
+    </attribute>
+  </attPool>
+
+  <elementRule role="catalog">
+    <choice occurs="+">
+      <ref label="public"/>
+      <ref label="system"/>
+      <ref label="uri"/>
+      <ref label="rewriteSystem"/>
+      <ref label="rewriteURI"/>
+      <ref label="delegatePublic"/>
+      <ref label="delegateSystem"/>
+      <ref label="delegateURI"/>
+      <ref label="nextCatalog"/>
+      <ref label="group"/>
+    </choice>
+  </elementRule>
+
+  <elementRule role="public">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="system">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="uri">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="rewriteSystem">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="rewriteURI">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="delegatePublic">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="delegateSystem">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="delegateURI">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="nextCatalog">
+    <empty/>
+  </elementRule>
+
+  <elementRule role="group">
+    <choice occurs="+">
+      <ref label="public"/>
+      <ref label="system"/>
+      <ref label="uri"/>
+      <ref label="rewriteSystem"/>
+      <ref label="rewriteURI"/>
+      <ref label="delegatePublic"/>
+      <ref label="delegateSystem"/>
+      <ref label="delegateURI"/>
+      <ref label="nextCatalog"/>
+    </choice>
+  </elementRule>
+
+  <tag name="catalog">
+    <ref role="optional.attributes"/>
+    <ref role="prefer.attribute"/>
+  </tag>
+
+  <tag name="group">
+    <ref role="optional.attributes"/>
+    <ref role="prefer.attribute"/>
+  </tag>
+
+  <tag name="public">
+    <ref role="optional.attributes"/>
+    <attribute name="publicId" type='string' required='true'/>
+    <attribute name="uri" type='string' required='true'/>
+  </tag>
+
+  <tag name="system">
+    <ref role="optional.attributes"/>
+    <attribute name="systemId" type='string' required='true'/>
+    <attribute name="uri" type='string' required='true'/>
+  </tag>
+
+  <tag name="uri">
+    <ref role="optional.attributes"/>
+    <attribute name="name" type='string' required='true'/>
+    <attribute name="uri" type='string' required='true'/>
+  </tag>
+
+  <tag name="rewriteSystem">
+    <ref role="optional.attributes"/>
+    <attribute name="systemIdStartString" type='string' required='true'/>
+    <attribute name="rewritePrefix" type='string' required='true'/>
+  </tag>
+
+  <tag name="rewriteURI">
+    <ref role="optional.attributes"/>
+    <attribute name="systemIdStartString" type='string' required='true'/>
+    <attribute name="rewritePrefix" type='string' required='true'/>
+  </tag>
+
+  <tag name="delegatePublic">
+    <ref role="optional.attributes"/>
+    <attribute name="publicIdStartString" type='string' required='true'/>
+    <attribute name="catalog" type='string' required='true'/>
+  </tag>
+
+  <tag name="delegateSystem">
+    <ref role="optional.attributes"/>
+    <attribute name="systemIdStartString" type='string' required='true'/>
+    <attribute name="catalog" type='string' required='true'/>
+  </tag>
+
+  <tag name="delegateURI">
+    <ref role="optional.attributes"/>
+    <attribute name="uriStartString" type='string' required='true'/>
+    <attribute name="catalog" type='string' required='true'/>
+  </tag>
+
+  <tag name="nextCatalog">
+    <ref role="optional.attributes"/>
+    <attribute name="catalog" type='string' required='true'/>
+  </tag>
+</module>

--- a/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.xsd
+++ b/o.apache.xml.resolver/src/org/apache/xml/resolver/etc/catalog.xsd
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Copyright � 2000, 2001 The Organization for the Advancement of Structured 
+Information Standards [OASIS]. All Rights Reserved.
+
+This document and translations of it may be copied and furnished to others, and
+derivative works that comment on or otherwise explain it or assist in its 
+implementation may be prepared, copied, published and distributed, in whole or 
+in part, without restriction of any kind, provided that the above copyright 
+notice and this paragraph are included on all such copies and derivative works.
+However, this document itself may not be modified in any way, such as by 
+removing the copyright notice or references to OASIS, except as needed for the 
+purpose of developing OASIS specifications, in which case the procedures for
+copyrights defined in the OASIS Intellectual Property Rights document must be 
+followed, or as required to translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by
+OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on an "AS IS" 
+basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE
+ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+PARTICULAR PURPOSE.
+
+Original XSD can be found here:
+https://www.oasis-open.org/committees/entity/spec-2001-08-06.html
+
+-->
+<!DOCTYPE xs:schema SYSTEM "http://www.w3.org/2001/XMLSchema.dtd" [
+<!ENTITY % schemaAttrs "
+    xmlns:er    CDATA   #IMPLIED
+">
+]>
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'
+           xmlns:er='urn:oasis:names:tc:entity:xmlns:xml:catalog'
+           targetNamespace='urn:oasis:names:tc:entity:xmlns:xml:catalog'
+           elementFormDefault='qualified'>
+
+  <!-- $Id: catalog.xsd,v 1.9 2001/07/30 19:40:04 ndw Exp $ -->
+
+  <xs:simpleType name='pubIdChars'>
+    <!-- A string of the characters defined as pubIdChar in production 13
+         of the Second Edition of the XML 1.0 Recommendation -->
+    <xs:restriction base='xs:string'/>
+  </xs:simpleType>
+
+  <xs:simpleType name='publicIdentifier'>
+    <xs:restriction base='xs:string'/>
+  </xs:simpleType>
+
+  <xs:simpleType name='partialPublicIdentifier'>
+    <xs:restriction base='er:pubIdChars'/>
+  </xs:simpleType>
+
+  <xs:simpleType name='systemOrPublic'>
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value='system'/>
+      <xs:enumeration value='public'/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- The global attribute xml:base is not explicitly declared; -->
+  <!-- it is allowed by the anyAttribute declarations. -->
+
+  <xs:complexType name='catalog'>
+    <xs:choice minOccurs='1' maxOccurs='unbounded'>
+      <xs:element ref='er:public'/>
+      <xs:element ref='er:system'/>
+      <xs:element ref='er:uri'/>
+      <xs:element ref='er:rewriteSystem'/>
+      <xs:element ref='er:rewriteURI'/>
+      <xs:element ref='er:delegatePublic'/>
+      <xs:element ref='er:delegateSystem'/>
+      <xs:element ref='er:delegateURI'/>
+      <xs:element ref='er:nextCatalog'/>
+      <xs:element ref='er:group'/>
+      <xs:any namespace='##other' processContents='skip'/>
+    </xs:choice>
+    <xs:attribute name='id' type='xs:ID'/>
+    <xs:attribute name='prefer' type='er:systemOrPublic'/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:complexType name='public'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="publicId" type="er:publicIdentifier"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='system'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemId" type="xs:string"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='uri'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="name" type="xs:anyURI"
+                       use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='rewriteSystem'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemIdStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="rewritePrefix" type="xs:string" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='rewriteURI'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="uriIdStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="rewritePrefix" type="xs:string" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='delegatePublic'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="publicIdStartString"
+                       type="er:partialPublicIdentifier"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='delegateSystem'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="systemIdStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='delegateURI'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="uriStartString"
+                       type="xs:string"
+                       use="required"/>
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='nextCatalog'>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:attribute name="catalog" type="xs:anyURI" use="required"/>
+        <xs:attribute name='id' type='xs:ID'/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name='group'>
+    <xs:choice minOccurs='1' maxOccurs='unbounded'>
+      <xs:element ref='er:public'/>
+      <xs:element ref='er:system'/>
+      <xs:element ref='er:uri'/>
+      <xs:element ref='er:rewriteSystem'/>
+      <xs:element ref='er:rewriteURI'/>
+      <xs:element ref='er:delegatePublic'/>
+      <xs:element ref='er:delegateSystem'/>
+      <xs:element ref='er:delegateURI'/>
+      <xs:element ref='er:nextCatalog'/>
+      <xs:any namespace='##other' processContents='skip'/>
+    </xs:choice>
+    <xs:attribute name='prefer' type='er:systemOrPublic'/>
+    <xs:attribute name='id' type='xs:ID'/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+
+  <xs:element name="catalog" type="er:catalog"/>
+  <xs:element name="public" type="er:public"/>
+  <xs:element name="system" type="er:system"/>
+  <xs:element name="uri" type="er:uri"/>
+  <xs:element name="rewriteSystem" type="er:rewriteSystem"/>
+  <xs:element name="rewriteURI" type="er:rewriteURI"/>
+  <xs:element name="delegatePublic" type="er:delegatePublic"/>
+  <xs:element name="delegateSystem" type="er:delegateSystem"/>
+  <xs:element name="delegateURI" type="er:delegateURI"/>
+  <xs:element name="nextCatalog" type="er:nextCatalog"/>
+  <xs:element name="group" type="er:group"/>
+
+</xs:schema>

--- a/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/CatalogEntityResolverTest.java
+++ b/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/CatalogEntityResolverTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.xml.catalog;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CatalogEntityResolverTest {
+    @Test
+    public void testOasisCatalogDTDCanBeLoaded() {
+        // This is assumed in CatalogEntityResolver, this test verifies, that
+        // the catalog DTD is at the expected place
+        assertNotNull(org.apache.xml.resolver.Catalog.class.getResource("etc/catalog.dtd"));
+    }
+
+}


### PR DESCRIPTION
When the o.apache.xml.resolver patching mechanism was reworked, the
grammar files were dropped, as they are not part of the o.apache.xml.resolver
sources.

This changeset readds them in the netbeans module itself.