### PR TITLE
[NETBEANS-227] Preventing NPE during indexing: the parsed fileobject …

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
+import com.sun.tools.javac.api.ClientCodeWrapper.Trusted;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -387,6 +388,7 @@ class WriteBackTransaction extends FileManagerTransaction {
      * 
      * The CacheFO may be "flushed" (written to shadowFile) or "committed" (moved to the final dest).
      */
+    @Trusted
     static class CachedFileObject extends FileObjects.FileBase {
 
         private static final byte[] NOTHING = new byte[0];


### PR DESCRIPTION
…was wrapped and then not found in the tuple map.

This fixes a NPE from VanillaCompileWorker, caused by javac wrapping the provided JavaFileObject, as it is not @Trusted (and the wrapped JavaFileObject then cannot be found among the original input file objects). Unfortunately, not easy to test, so just making the class trusted.