### PR TITLE
Keep parameter names during indexing and read them back while reading…

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -811,6 +811,7 @@ public class JavacParser extends Parser {
         }
         options.add("-XDide");   // NOI18N, javac runs inside the IDE
         options.add("-XDsave-parameter-names");   // NOI18N, javac runs inside the IDE
+        options.add("-parameters");   // NOI18N, save and read parameter names
         options.add("-XDsuppressAbortOnBadClassFile");   // NOI18N, when a class file cannot be read, produce an error type instead of failing with an exception
         options.add("--should-stop:at=GENERATE");   // NOI18N, parsing should not stop in phase where an error is found
         options.add("-g:source"); // NOI18N, Make the compiler to maintian source file info


### PR DESCRIPTION
… classfiles, so that the parameter names are shown in code completion.