### PR TITLE
Fixing org.netbeans.modules.openide.awt.ActionProcessorTest - ensurin…

### DIFF
--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -172,7 +172,7 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
         <property name="locmakenbm.brands" value="${brandings}"/>
         <!-- When requires.nb.javac property is true, prepend javac-api and javac-impl on bootclasspath to allow override the default annotation
              processing API located in rt.jar. -->
-        <property name="bootclasspath.prepend.nb" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar:${nb_all}/nbbuild/external/nb-javac-impl.jar" />
+        <property name="bootclasspath.prepend.nb" value="${nb_all}/libs.javacapi/external/nb-javac-9-api.jar:${nb_all}/libs.javacimpl/external/nb-javac-9-impl.jar" />
         <property name="bootclasspath.prepend.vanilla" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar:${nb_all}/nbbuild/external/vanilla-javac-impl.jar" />
         <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
             <istrue value="${requires.nb.javac.impl}"/>

--- a/openide.awt/nbproject/project.properties
+++ b/openide.awt/nbproject/project.properties
@@ -20,7 +20,6 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.6
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-requires.nb.javac=true
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\


### PR DESCRIPTION
…g nb-javac-api is used for modules that have requires.nb.javac=true, but removing that flag from openide.awt, as that shouldn't need that.

(Recently, requires.nb.javac=true was changed to always use unmodified vanilla javac API. While that is conceptually good, the vanilla javac API does not seem to be able to load javac on JDK 8.)