### PR TITLE
[NETBEANS-234] Fixing handling of broken generics in fields.

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -384,9 +384,7 @@ final class VanillaCompileWorker extends CompileWorker {
                 if ((decl.mods.flags & Flags.ENUM) == 0) {
                     decl.init = null;
                 }
-                if (decl.type.getKind() == TypeKind.ERROR) {
-                    decl.sym.type = decl.type = syms.objectType;
-                }
+                decl.sym.type = decl.type = error2Object(decl.type);
                 clearAnnotations(decl.sym.getMetadata());
                 return super.visitVariable(node, p);
             }

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -214,4 +214,22 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                                                        "cache/s1/java/15/classes/test/Test3.sig")),
                      createdFiles);
     }
+
+    public void testRepairFieldBrokenGenerics() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; import java.util.List; public class Test4 { public List<Undef> test; }")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        //TODO: check file content!!!
+    }
+
 }


### PR DESCRIPTION
(This fixes just this single bug in the vanilla javac indexing, so more are likely to come in the future.)