### PR TITLE
Restoring original update center.

### DIFF
--- a/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -29,6 +29,6 @@ Services/AutoupdateType/pluginportal-update-provider.instance=Plugin Portal
 #NOI18N
 URL_LatestBuild=http://bits.netbeans.org/dev/nbms-and-javadoc/lastSuccessfulBuild/artifact/nbbuild/nbms/updates.xml.gz
 #NOI18N
-URL_Default_N=http://lahoda.info/netbeans/nb-javac-auc/updates.xml?{$netbeans.hash.code}
+URL_Default_N=http://updates.netbeans.org/netbeans/updates/dev/uc/final/main/catalog.xml.gz?{$netbeans.hash.code}
 #NOI18N
 URL_PluginPortal=http://plugins.netbeans.org/nbpluginportal/updates/8.2/catalog.xml.gz


### PR DESCRIPTION
The temporary AUC on lahoda.info is not needed anymore.