### PR TITLE
[NETBEANS-251] WidthEstimator is doing estimates based on Symbols, bu…

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -74,7 +74,6 @@ import com.sun.tools.javac.api.JavacTaskImpl;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.*;
 import static com.sun.tools.javac.code.Flags.*;
-import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.comp.Operators;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.DCTree;
@@ -2116,27 +2115,6 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 	out.toCol(n);
     }
 
-    private void printQualified(Symbol t) {
-	if (t.owner != null && t.owner.name.getByteLength() > 0
-		&& !(t.type instanceof Type.TypeVar)
-		&& !(t.owner instanceof MethodSymbol)) {
-	    if (t.owner instanceof Symbol.PackageSymbol)
-		printAllQualified(t.owner);
-	    else
-		printQualified(t.owner);
-	    print('.');
-	}
-	print(t.name);
-    }
-
-    private void printAllQualified(Symbol t) {
-	if (t.owner != null && t.owner.name.getByteLength() > 0) {
-	    printAllQualified(t.owner);
-	    print('.');
-	}
-	print(t.name);
-    }
-    
     protected void printTagName(DocTree node) {
         out.append("@");
         out.append(node.getKind().tagName);


### PR DESCRIPTION
…t that's no desirable, as all trees are printed as they are by VeryPretty.

The immediate issue was that the EqualsHashCodeGenerator tried to attribute trees like "other.foo", which left errors in the tree. The tree was than directly used for code generation. The WidthEstimator was then doing (among other things):
t.owner != t.packge().modle.unnamedPackage

But for the error t.packge() returns the root package, which does not have a module, hence the NPE.

The test could be rewritten to handle this, but I don't think the WidthEstimator(/VeryPretty) should do any tricks with symbols. These should simply print the trees as they are. (Import handling is done on a different level.)
