### PR TITLE
Making Maven projects usable without properly installed Java support.

### DIFF
--- a/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
+++ b/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
@@ -174,16 +174,21 @@ public class DependenciesNode extends AbstractNode {
         @SuppressWarnings("LeakingThisInConstructor")       
         DependenciesSet(NbMavenProjectImpl project, DependencyType type) {
             this.project = project;
-            this.type = type;           
+            this.type = type;
+            ModuleInfoSupport mis = null;
             switch (type) {   
                 case COMPILE:
                 case TEST:
-                    moduleInfoSupport = new ModuleInfoSupport(project, type);
-                    break;
+                    try {
+                        mis = new ModuleInfoSupport(project, type);
+                        break;
+                    } catch (LinkageError err) {
+                        LOG.log(Level.INFO, "Can't initialize dependencies", err);
+                        // fallthrough
+                    }
                 default:
-                    moduleInfoSupport = null;
-                    break;
             }
+            this.moduleInfoSupport = mis;
             
             NbMavenProject nbmp = project.getProjectWatcher();
             nbmp.addPropertyChangeListener(WeakListeners.propertyChange(this, nbmp));


### PR DESCRIPTION
Avoid following error: java.lang.NoClassDefFoundError: com/sun/source/tree/DirectiveTree
    at org.netbeans.modules.maven.nodes.DependenciesNode$DependenciesSet.<init>(:183)
    at org.netbeans.modules.maven.nodes.DependenciesNodeFactory$NList.<init>(:57)
    at org.netbeans.modules.maven.nodes.DependenciesNodeFactory.createNodes(:44)
    at org.netbeans.spi.project.ui.support.NodeFactorySupport$DelegateChildren$1.run(:174)