### PR TITLE
[NETBEANS-238]: speeding up package lookup in jars by not listing the…

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheClassPath.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheClassPath.java
@@ -245,7 +245,7 @@ public class CacheClassPath implements ClassPathImplementation, PropertyChangeLi
             if (result == null) {
                 result = EMPTY;
                 try {
-                    File sigs = JavaIndex.getClassFolder(originalRoot,false,scan);
+                    File sigs = JavaIndex.getClassFolder(originalRoot,false,false);
                     URL orl = FileUtil.urlForArchiveOrDir(sigs);
                     if (orl != null) {
                         result = new URL[] {orl};

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
@@ -120,7 +120,7 @@ public class JavaBinaryIndexer extends BinaryIndexer {
     }
 
     private static void deleteSigFiles(final URL root, final List<? extends ElementHandle<TypeElement>> toRemove) throws IOException {
-        File cacheFolder = JavaIndex.getClassFolder(root);
+        File cacheFolder = JavaIndex.getClassFolder(root, false, false);
         if (cacheFolder.exists()) {
             if (toRemove.size() > CLEAN_ALL_LIMIT) {
                 //Todo: do as SlowIOTask
@@ -287,9 +287,19 @@ public class JavaBinaryIndexer extends BinaryIndexer {
                 } else {
                     txCtx.commit();
                 }
+                File classes = JavaIndex.getClassFolder(context.getRootURI(), false, false);
+                if (classes.exists() && isEmpty(classes)) {
+                    classes.delete();
+                }
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }
+        }
+
+        private boolean isEmpty(File dir) {
+            String[] content = dir.list();
+
+            return content == null || content.length == 0;
         }
 
         @MimeRegistration(mimeType="", service=BinaryIndexerFactory.class)

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndex.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaIndex.java
@@ -366,4 +366,9 @@ public final class JavaIndex {
             }
         }
     }
+
+    public static boolean isCacheFolder(File dir) {
+        File cacheFolder = FileUtil.toFile(CacheFolder.getCacheFolder());
+        return dir.toURI().toASCIIString().startsWith(cacheFolder.toURI().toASCIIString());
+    }
 }

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 import javax.tools.JavaFileObject;
 import org.netbeans.api.annotations.common.NonNull;
@@ -69,4 +70,30 @@ public interface Archive {
      * @return true if the {@link Archive} is supports multiple releases.
      */
     public boolean isMultiRelease();
+
+    public static Archive EMPTY = new Archive() {
+        @Override
+        public Iterable<JavaFileObject> getFiles(String folderName, ClassPath.Entry entry, Set<JavaFileObject.Kind> kinds, JavaFileFilterImplementation filter, boolean recursive) throws IOException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public JavaFileObject create(String relativeName, JavaFileFilterImplementation filter) throws UnsupportedOperationException {
+            return null;
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public JavaFileObject getFile(String name) throws IOException {
+            return null;
+        }
+
+        @Override
+        public boolean isMultiRelease() {
+            return false;
+        }
+    };
 }

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CacheFolderArchive.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CacheFolderArchive.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.java.source.parsing;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.java.classpath.ClassPath.Entry;
+import org.netbeans.modules.java.preprocessorbridge.spi.JavaFileFilterImplementation;
+import org.openide.filesystems.FileAttributeEvent;
+import org.openide.filesystems.FileChangeListener;
+import org.openide.filesystems.FileEvent;
+import org.openide.filesystems.FileRenameEvent;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Parameters;
+
+/**
+ *
+ * @author Tomas Zezula
+ */
+class CacheFolderArchive implements Archive, FileChangeListener {
+
+    private volatile Archive delegate;
+    private final File cache;
+
+    public CacheFolderArchive(
+            @NonNull File cache) {
+        Parameters.notNull("cache", cache); //NOI18N
+        this.cache = cache;
+        if (cache.isDirectory()) {
+            delegate = new FolderArchive(cache);
+        } else {
+            FileUtil.addFileChangeListener(this, cache);
+            delegate = Archive.EMPTY;
+        }
+    }
+
+    @Override
+    public JavaFileObject getFile(String name) throws IOException {
+        return delegate.getFile(name);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public JavaFileObject create(String relativeName, JavaFileFilterImplementation filter) throws UnsupportedOperationException {
+        return delegate.create(relativeName, filter);
+    }
+
+    @Override
+    public boolean isMultiRelease() {
+        return delegate.isMultiRelease();
+    }
+
+    @Override
+    public Iterable<JavaFileObject> getFiles(String folderName, Entry entry, Set<Kind> kinds, JavaFileFilterImplementation filter, boolean recursive) throws IOException {
+        return delegate.getFiles(folderName, entry, kinds, filter, recursive);
+    }
+
+    private void update() {
+        if (cache.isDirectory()) {
+            delegate = new FolderArchive(cache);
+            FileUtil.removeFileChangeListener(this, cache);
+        }
+    }
+
+    @Override
+    public void fileFolderCreated(FileEvent fe) {
+        update();
+    }
+
+    @Override
+    public void fileDataCreated(FileEvent fe) {
+        update();
+    }
+
+    @Override
+    public void fileChanged(FileEvent fe) {
+        update();
+    }
+
+    @Override
+    public void fileDeleted(FileEvent fe) {
+        update();
+    }
+
+    @Override
+    public void fileRenamed(FileRenameEvent fe) {
+        update();
+    }
+
+    @Override
+    public void fileAttributeChanged(FileAttributeEvent fe) {
+        update();
+    }
+
+}

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
@@ -27,17 +27,21 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.modules.java.source.indexing.JavaIndex;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
@@ -241,7 +245,9 @@ public final class CachingArchiveProvider {
         String protocol = root.first().getProtocol();
         if ("file".equals(protocol)) {      //NOI18N
             File f = BaseUtilities.toFile(root.second());
-            if (f.isDirectory()) {
+            if (JavaIndex.isCacheFolder(f)) {
+                return Pair.<Archive,URI>of(new CacheFolderArchive(f), null);
+            } else if (f.isDirectory()) {
                 return Pair.<Archive,URI>of(new FolderArchive (f), null);
             }
             else {

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
@@ -72,7 +72,7 @@ class WriteBackTransaction extends FileManagerTransaction {
         super(true);
         this.root = root;
         try {
-            this.classesFolder = BaseUtilities.toURI(JavaIndex.getClassFolder(root)).toURL();
+            this.classesFolder = BaseUtilities.toURI(JavaIndex.getClassFolder(root, false, false)).toURL();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/TreeLoader.java
+++ b/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/TreeLoader.java
@@ -391,7 +391,7 @@ public class TreeLoader extends LazyTreeLoader {
         }
         int index = surl.lastIndexOf(FileObjects.convertPackage2Folder(binaryName));
         if (index > 0) {
-            return JavaIndex.getClassFolder(new URL(surl.substring(0, index)));
+            return JavaIndex.getClassFolder(new URL(surl.substring(0, index)), false, false);
         } else {
             LOGGER.log(
                Level.INFO,


### PR DESCRIPTION
… adjacent caches if those are empty.

The empty cache detection is based on the existence of the classes, which is no longer automatically created and is deleted by the indexer if empty.