### PR TITLE
Removing ancient header from test data.

### DIFF
--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1a.txt
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1a.txt
@@ -1,25 +1,25 @@
 /*
- *                 Sun Public License Notice
  *
- * The contents of this file are subject to the Sun Public License
- * Version 1.0 (the "License"). You may not use this file except in
- * compliance with the License. A copy of the License is available at
- * http://www.sun.com/
  *
- * The Original Code is NetBeans. The Initial Developer of the Original
- * Code is Sun Microsystems, Inc. Portions Copyright 1997-2005 Sun
- * Microsystems, Inc. All Rights Reserved.
-
-If you wish your version of this file to be governed by only the CDDL
-or only the GPL Version 2, indicate your decision by adding
-"[Contributor] elects to include this software in this distribution
-under the [CDDL or GPL Version 2] license." If you do not indicate a
-single choice of license, a recipient has the option to distribute
-your version of this file under either the CDDL, the GPL Version 2 or
-to extend the choice of license to its licensees as provided above.
-However, if you add GPL Version 2 code and therefore, elected the GPL
-Version 2 license, then the option applies only if the new code is
-made subject to such option by the copyright holder.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
  */
 package org.netbeans.modules.debugger.jpda.actions;
 

--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1b.txt
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1b.txt
@@ -1,25 +1,25 @@
 /*
- *                 Sun Public License Notice
  *
- * The contents of this file are subject to the Sun Public License
- * Version 1.0 (the "License"). You may not use this file except in
- * compliance with the License. A copy of the License is available at
- * http://www.sun.com/
  *
- * The Original Code is NetBeans. The Initial Developer of the Original
- * Code is Sun Microsystems, Inc. Portions Copyright 1997-2000 Sun
- * Microsystems, Inc. All Rights Reserved.
-
-If you wish your version of this file to be governed by only the CDDL
-or only the GPL Version 2, indicate your decision by adding
-"[Contributor] elects to include this software in this distribution
-under the [CDDL or GPL Version 2] license." If you do not indicate a
-single choice of license, a recipient has the option to distribute
-your version of this file under either the CDDL, the GPL Version 2 or
-to extend the choice of license to its licensees as provided above.
-However, if you add GPL Version 2 code and therefore, elected the GPL
-Version 2 license, then the option applies only if the new code is
-made subject to such option by the copyright holder.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
  */
 package org.netbeans.modules.debugger.jpda.actions;
 

--- a/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1d.txt
+++ b/diff/test/unit/src/org/netbeans/modules/diff/builtin/provider/DiffTestFile1d.txt
@@ -1,7 +1,3 @@
-10c10
-<  * Code is Sun Microsystems, Inc. Portions Copyright 1997-2005 Sun
----
->  * Code is Sun Microsystems, Inc. Portions Copyright 1997-2000 Sun
 25a26
 > import com.sun.jdi.IncompatibleThreadStateException;
 38a40


### PR DESCRIPTION
Removing accidentally omitted ancient license on a test data to avoid confusion. Some how the ancient Sun Public License has escaped relicesing to CDDL (and GPLwCPex then), and thus it also escaped change of the license to Apache. Fixing it now.