### PR TITLE
Use logger level for felix.

### DIFF
--- a/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -125,7 +125,8 @@ implements Cloneable, Stamps.Updater {
             activator = new NetigsoActivator(this);
             configMap.put("netigso.archive", NetigsoArchiveFactory.DEFAULT.create(this)); // NOI18N
             if (!configMap.containsKey("felix.log.level")) { // NOI18N
-              configMap.put("felix.log.level", "4"); // NOI18N - allow others to set log level
+                String felixLevel = felixLogLevel(LOG);
+                configMap.put("felix.log.level", felixLevel); // NOI18N
             }
             configMap.put("felix.bootdelegation.classloaders", activator); // NOI18N
             String startLevel = FRAMEWORK_START_LEVEL();
@@ -155,6 +156,20 @@ implements Cloneable, Stamps.Updater {
                 LOG.log(Level.WARNING, "Cannot fake " + mi.getCodeName(), ex);
             }
         }
+    }
+
+    static String felixLogLevel(final Logger log) {
+        String felixLevel = "1"; // NOI18N
+        if (log.isLoggable(Level.WARNING)) {
+            felixLevel = "2"; // NOI18N
+        }
+        if (log.isLoggable(Level.CONFIG)) {
+            felixLevel = "3"; // NOI18N
+        }
+        if (log.isLoggable(Level.FINE)) {
+            felixLevel = "4"; // NOI18N
+        }
+        return felixLevel;
     }
 
     @Override

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLogTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoLogTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.core.netigso;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Test;
+
+public class NetigsoLogTest {
+    @Test
+    public void testConvertLogsSevere() {
+        assertLog(Level.SEVERE, "1");
+    }
+
+    @Test
+    public void testConvertLogsWarning() {
+        assertLog(Level.WARNING, "2");
+    }
+
+    @Test
+    public void testConvertLogsInfo() {
+        assertLog(Level.INFO, "2");
+    }
+
+    @Test
+    public void testConvertLogsConfig() {
+        assertLog(Level.CONFIG, "3");
+    }
+
+    @Test
+    public void testConvertLogsFineAndLess() {
+        assertLog(Level.FINE, "4");
+        assertLog(Level.FINER, "4");
+        assertLog(Level.FINEST, "4");
+    }
+
+    private static void assertLog(Level level, String felixLevel) {
+        Logger l = Logger.getLogger("my.test.logger." + level);
+        l.setLevel(level);
+        assertTrue("Level is loggable", l.isLoggable(level));
+        Level less = new Level("", level.intValue() - 100) {};
+        assertFalse("Lowever level isn't loggable", l.isLoggable(less));
+
+        String convertedLevel = Netigso.felixLogLevel(l);
+        assertEquals(felixLevel, convertedLevel);
+    }
+
+}

--- a/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
+++ b/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
@@ -26,7 +26,6 @@ import org.netbeans.MockModuleInstaller;
 import org.netbeans.MockEvents;
 import org.netbeans.Module;
 import org.netbeans.ModuleManager;
-import org.netbeans.core.startup.Main;
 import org.netbeans.junit.RandomlyFails;
 
 /**


### PR DESCRIPTION
The default log setting for Felix was to too verbose. On start the Felix printed lines like:
```log
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.annotation.processing) -> [0] 
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.lang.model) -> [0]
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.lang.model.element) -> [0] 
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.lang.model.type) -> [0] 
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.lang.model.util) -> [0] 
DEBUG: WIRE: [124.0] osgi.wiring.package; (osgi.wiring.package=javax.tools) -> [0]
 ```
this output is only printed by Felix when debug log level is on:
```java
        boolean debugLog = m_felix.getLogger().getLogLevel() >= Logger.LOG_DEBUG;
```
and the log level definitions are:
```java
    public static final int LOG_ERROR = 1;
    public static final int LOG_WARNING = 2;
    public static final int LOG_INFO = 3;
    public static final int LOG_DEBUG = 4;
```
this PR is converting various `java.util.logging.Level` values to the above Felix levels. Thus by default, Felix prints nothing. One can change that by using `-Dorg.netbeans.core.netigso.level=FINE` & co. when launching NetBeans.
