### PR TITLE
NETBEANS-324: Maven graph widgets created in EDT

### DIFF
--- a/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
+++ b/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
@@ -78,7 +78,6 @@ import org.netbeans.modules.maven.indexer.spi.ui.ArtifactViewerFactory;
 import org.netbeans.modules.maven.model.Utilities;
 import org.netbeans.modules.maven.model.pom.POMModel;
 import org.netbeans.modules.maven.spi.IconResources;
-import org.netbeans.modules.java.graph.GraphNodeImplementation;
 import org.openide.awt.Mnemonics;
 import org.openide.filesystems.FileObject;
 import org.openide.util.ImageUtilities;
@@ -606,16 +605,16 @@ public class DependencyGraphTopComponent extends TopComponent implements LookupL
                         
                     };
                     
-                    final DependencyGraphScene<MavenDependencyNode> scene2 = new DependencyGraphScene<>(
-                            new MavenActionsProvider(DependencyGraphTopComponent.this, nbProj, model), 
-                            DependencyGraphTopComponent.this::getSelectedDepth, 
-                            versionProvider, 
-                            pp);
-                    
-                    GraphConstructor constr = new GraphConstructor(scene2, prj);
+                    GraphConstructor constr = new GraphConstructor(prj);
                     constr.accept(root);
                     SwingUtilities.invokeLater(new Runnable() {
                         @Override public void run() {
+                            final DependencyGraphScene<MavenDependencyNode> scene2 = new DependencyGraphScene<>(
+                                new MavenActionsProvider(DependencyGraphTopComponent.this, nbProj, model), 
+                                DependencyGraphTopComponent.this::getSelectedDepth, 
+                                versionProvider, 
+                                pp);
+                            constr.updateScene(scene2);
                             scene = scene2;
                             JComponent sceneView = scene.getView();
                             if (sceneView == null) {


### PR DESCRIPTION
The GraphConstructor visitor adds nodes / creates Widgets when the traversal is leaving root node - at the end of the visiting process. Also scene initialization includes adding layers (= widgets) to the scene, which should be done in EDT as well.
I have moved the widget creation into EDT, so the visitor is first applied to the graph, and then in EDT cached data is translated into nodes/widgets.