### PR TITLE
form: Fix compile error under Java 9, method cannot be applied to types

### DIFF
--- a/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
+++ b/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
@@ -264,7 +264,8 @@ public class GridDesigner extends JPanel {
         KeyStroke ks = null;
         FileObject undoRedoFO = FileUtil.getConfigFile(undo ? "Menu/Edit/org-openide-actions-UndoAction.shadow" : "Menu/Edit/org-openide-actions-RedoAction.shadow"); // NOI18N
         if (undoRedoFO != null) {
-            ContextAwareAction undoRedoAction = SystemAction.get(undo ? org.openide.actions.UndoAction.class : org.openide.actions.RedoAction.class);
+            Class<? extends SystemAction> undoClass = undo ? org.openide.actions.UndoAction.class : org.openide.actions.RedoAction.class;
+            ContextAwareAction undoRedoAction = (ContextAwareAction)SystemAction.get(undoClass);
             Action a = undoRedoAction.createContextAwareInstance(Lookup.EMPTY);
             AcceleratorBinding.setAccelerator(a, undoRedoFO);
             Object ksObj = a.getValue(Action.ACCELERATOR_KEY);


### PR DESCRIPTION
Fixes the following compile issue under Java 9. Should be fine under 1.8 and other.

```java
src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java:267: error: method get in class SystemAction cannot be applied to given types;
            ContextAwareAction undoRedoAction = SystemAction.get(undo ? org.openide.actions.UndoAction.class : org.openide.actions.RedoAction.class);
                                                            ^
  required: Class<T>
  found: undo ? org[...]class
  reason: inference variable T has incompatible equality constraints RedoAction,UndoAction
  where T is a type-variable:
    T extends SystemAction declared in method <T>get(Class<T>)

```