### PR TITLE
[NETBEANS-139] Create archive sample to fix RepositoryUpdaterEventTest.

### DIFF
--- a/parsing.indexing/build.xml
+++ b/parsing.indexing/build.xml
@@ -22,14 +22,4 @@
 <project basedir="." default="netbeans" name="parsing.indexing">
     <description>Builds, tests, and runs the project org.netbeans.modules.parsing.indexing</description>
     <import file="../nbbuild/templates/projectized.xml"/>
-    
-    <target name="do-unit-test-build" depends="projectized.do-unit-test-build,compile">
-        <!-- Prepare demo jar file used in RepositoryUpdaterTest -->
-        <echo message="Creating sample data"/>
-        <mkdir dir="${basedir}/build/test/unit/data/" />
-        <zip file="${basedir}/build/test/unit/data/JavaApplication1.jar">
-            <fileset dir="${basedir}/build/classes/" includes="**" />
-            <fileset dir="${basedir}/build/classes-generated/" includes="**"/>
-        </zip>
-    </target>
 </project>

--- a/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTest.java
+++ b/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdaterTest.java
@@ -23,6 +23,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -158,6 +159,8 @@ public class RepositoryUpdaterTest extends IndexingTestBase {
     private FileObject unknown2;
     private FileObject unknownSrc2;
     protected FileObject srcRootWithFiles1;
+    
+    private FileObject jarFile;
 
     FileObject f1;
     protected FileObject f3;
@@ -232,12 +235,15 @@ public class RepositoryUpdaterTest extends IndexingTestBase {
         assertNotNull (bootRoot1);
         bootRoot2 = wd.createFolder("boot2");
         assertNotNull (bootRoot2);
-        FileUtil.setMIMEType("jar", JARMIME);
-        FileObject jarFile = FileUtil.toFileObject(getDataDir()).getFileObject("JavaApplication1.jar");
-        assertNotNull(jarFile);
-        assertTrue(FileUtil.isArchiveFile(jarFile));
-        bootRoot3 = FileUtil.getArchiveRoot(jarFile);
+        bootRoot3 = wd.createFolder("boot3");
         assertNotNull (bootRoot3);
+        
+        FileUtil.setMIMEType("jar", JARMIME);
+        jarFile = FileUtil.createData(bootRoot3, "JavaApplication1.jar");
+        assertNotNull(jarFile);
+        zipFileObject(jarFile);
+        assertTrue(FileUtil.isArchiveFile(jarFile));
+        
         compSrc1 = wd.createFolder("cs1");
         assertNotNull (compSrc1);
         compSrc2 = wd.createFolder("cs2");
@@ -593,10 +599,6 @@ public class RepositoryUpdaterTest extends IndexingTestBase {
         final Logger logger = Logger.getLogger(RepositoryUpdater.class.getName()+".tests");
         logger.setLevel (Level.FINEST);
         logger.addHandler(handler);
-
-        final FileObject jarFile = FileUtil.toFileObject(getDataDir()).getFileObject("JavaApplication1.jar");
-        assertNotNull(jarFile);
-        assertTrue(FileUtil.isArchiveFile(jarFile));
 
         final FileObject wd = FileUtil.toFileObject(getWorkDir());
         final FileObject[] jar2Delete = new FileObject[] {jarFile.copy(wd, "test", "jar")};
@@ -2451,6 +2453,13 @@ public class RepositoryUpdaterTest extends IndexingTestBase {
     public static void setMimeTypes(final String... mimes) {
         Set<String> mt = new HashSet<>(Arrays.asList(mimes));
         Util.allMimeTypes = mt;
+    }
+    
+    protected static void zipFileObject(FileObject fileObject) throws FileNotFoundException, IOException {
+        File file = FileUtil.toFile(fileObject);
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        ZipOutputStream os = new ZipOutputStream(fileOutputStream);
+        os.close();
     }
 
     // <editor-fold defaultstate="collapsed" desc="Mock Services">

--- a/parsing.nb/build.xml
+++ b/parsing.nb/build.xml
@@ -22,4 +22,5 @@
 <project basedir="." default="netbeans" name="parsing.nb">
     <description>Builds, tests, and runs the project org.netbeans.modules.parsing.nb</description>
     <import file="../nbbuild/templates/projectized.xml"/>
+   
 </project>

--- a/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/RepositoryUpdaterEventTest.java
+++ b/parsing.nb/test/unit/src/org/netbeans/modules/parsing/nb/RepositoryUpdaterEventTest.java
@@ -19,11 +19,9 @@
 
 package org.netbeans.modules.parsing.nb;
 
-import org.netbeans.modules.parsing.nb.EventSupport;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingUtilities;
-import static junit.framework.Assert.assertNotNull;
 import junit.framework.TestSuite;
 import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;


### PR DESCRIPTION
[NETBEANS-139] Create archive sample to fix the RepositoryUpdaterEventTest test on parsing.nb module.
It is the same issue that this: https://github.com/apache/incubator-netbeans/commit/d74705dffc65ae259178fb7f859fc4e8da57a5bb

I use this command to run test: ```ant -f parsing.nb -Dtest.type=unit -Dcontinue.after.failing.tests=true -Dtest.includes=org/netbeans/modules/parsing/nb/RepositoryUpdaterEventTest.java test-single```