### PR TITLE
NETBEANS-357: corrected the target folder for toolbar link for action

### DIFF
--- a/editor.lib2/nbproject/project.xml
+++ b/editor.lib2/nbproject/project.xml
@@ -170,6 +170,15 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.openide.loaders</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.nodes</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor</code-name-base>
+                        <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.openide.util.ui</code-name-base>

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
@@ -257,10 +257,11 @@ public final class EditorActionRegistrationProcessor extends LayerGeneratingProc
         int toolBarPosition = annotation.toolBarPosition();
         if (toolBarPosition != Integer.MAX_VALUE) {
             StringBuilder toolBarPresenterFilePath = new StringBuilder(50);
-            toolBarPresenterFilePath.append("Editors/Toolbar/");
+            toolBarPresenterFilePath.append("Editors/");
             if (mimeType.length() > 0) {
                 toolBarPresenterFilePath.append(mimeType).append("/");
             }
+            toolBarPresenterFilePath.append("Toolbars/Default/");
             toolBarPresenterFilePath.append(actionName).append(".shadow");
             LayerBuilder.File toolBarPresenterShadowFile = layer.file(toolBarPresenterFilePath.toString());
             toolBarPresenterShadowFile.stringvalue("originalFile", actionFilePath);


### PR DESCRIPTION
Simple fix, slightly less simple test. The toolbar registration was placed into wrong folder, so the editor did not pick the action up at all.
