### PR TITLE
Initial NBM of lib.profiler shall contain all libraries.

### DIFF
--- a/lib.profiler/build.xml
+++ b/lib.profiler/build.xml
@@ -23,10 +23,16 @@
     <description>Builds, tests, and runs the project org.netbeans.lib.profiler</description>
     <import file="../nbbuild/templates/projectized.xml"/>
 
-  <property name="profiler.cluster" value="./release"/>
-
-    <target name="build-init" depends="projectized.build-init">
+    <property name="profiler.cluster" value="./release"/>
+    <target name="-release.files" depends="projectized-common.-release.files,-define-downloadbinaries-task">
+        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+            <manifest dir=".">
+                <include name="external/binaries-list"/>
+            </manifest>
+        </downloadbinaries>
         <unzip src="external/profiler-external-binaries-8.2.zip" dest="${profiler.cluster}"/>
+        <taskdef name="releasefilesextra" classname="org.netbeans.nbbuild.extlibs.ReleaseFilesExtra" classpath="${nbantext.jar}"/>
+        <releasefilesextra property="release.files.extra"/>
     </target>
 
   <!-- Compile the JFluid engine system library, that depends on JDK version - so there are two libraries -->

--- a/lib.profiler/build.xml
+++ b/lib.profiler/build.xml
@@ -24,7 +24,7 @@
     <import file="../nbbuild/templates/projectized.xml"/>
 
     <property name="profiler.cluster" value="./release"/>
-    <target name="-release.files" depends="projectized-common.-release.files,-define-downloadbinaries-task">
+    <target name="-release.dir" depends="projectized-common.-release.dir,-define-downloadbinaries-task">
         <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
             <manifest dir=".">
                 <include name="external/binaries-list"/>


### PR DESCRIPTION
We have a problem. The first build of NetBeans produces wrong NBM files & also wrong content of `update_tracking` directory. To simulate that run (with pre-built NetBeans) following command:
```bash
lib.profiler$ rm -rf *; git checkout -f .; ant nbm; unzip -v build/org-netbeans-lib-profiler.nbm
```
then the resulting NBM files has just **49** entries! If you run the `nbm` target once again, you get more than hundred.

This PR is fixing that. Even when running on a clean `lib.profiler` directory, it generates NBM with enough files:
```bash
Archive:  build/org-netbeans-lib-profiler.nbm
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Stored        0   0% 2018-02-06 22:57 00000000  META-INF/
     105  Defl:N       93  11% 2018-02-06 22:57 95d310cb  META-INF/MANIFEST.MF
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/
       0  Stored        0   0% 2018-01-25 09:14 00000000  netbeans/config/
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/config/Modules/
     423  Defl:N      234  45% 2018-02-06 10:46 807f2f7a  netbeans/config/Modules/org-netbeans-lib-profiler.xml
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/
       0  Stored        0   0% 2018-01-25 09:14 00000000  netbeans/lib/deployed/
       0  Stored        0   0% 2018-01-25 09:14 00000000  netbeans/lib/deployed/cvm/
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/cvm/linux/
   42196  Defl:N    15892  62% 2018-02-06 22:57 b28f0c19  netbeans/lib/deployed/cvm/linux/libprofilerinterface.so
  408694  Defl:N   142893  65% 2018-02-06 22:57 9c97e9c4  netbeans/lib/deployed/cvm/linux/libprofilerinterface_g.so
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/deployed/cvm/windows/
   30720  Defl:N    12972  58% 2018-02-06 22:57 034e5a5a  netbeans/lib/deployed/cvm/windows/profilerinterface.dll
   18711  Defl:N     3820  80% 2018-02-06 22:57 82b9a640  netbeans/lib/deployed/cvm/windows/profilerinterface.map
   51712  Defl:N    14064  73% 2018-02-06 22:57 fb0dc80c  netbeans/lib/deployed/cvm/windows/profilerinterface_g.dll
   22097  Defl:N     4251  81% 2018-02-06 22:57 b694f973  netbeans/lib/deployed/cvm/windows/profilerinterface_g.map
       0  Stored        0   0% 2018-01-25 09:14 00000000  netbeans/lib/deployed/jdk15/
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/hpux-pa_risc2.0/
   69632  Defl:N    25123  64% 2018-02-06 22:57 0dfcb7a6  netbeans/lib/deployed/jdk15/hpux-pa_risc2.0/libprofilerinterface.sl
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/hpux-pa_risc2.0w/
   89408  Defl:N    29749  67% 2018-02-06 22:57 a80b3ff4  netbeans/lib/deployed/jdk15/hpux-pa_risc2.0w/libprofilerinterface.sl
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/linux-amd64/
   52047  Defl:N    19820  62% 2018-02-06 22:57 fad1c77f  netbeans/lib/deployed/jdk15/linux-amd64/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/linux/
   42534  Defl:N    16077  62% 2018-02-06 22:57 3cedbe13  netbeans/lib/deployed/jdk15/linux/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/mac/
  185120  Defl:N    55047  70% 2018-02-06 22:57 e5259ee6  netbeans/lib/deployed/jdk15/mac/libprofilerinterface.jnilib
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/solaris-amd64/
   57076  Defl:N    14947  74% 2018-02-06 22:57 932d4505  netbeans/lib/deployed/jdk15/solaris-amd64/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/solaris-i386/
   56948  Defl:N    14929  74% 2018-02-06 22:57 670ab8fc  netbeans/lib/deployed/jdk15/solaris-i386/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/solaris-sparc/
   58504  Defl:N    20043  66% 2018-02-06 22:57 ae38c8c5  netbeans/lib/deployed/jdk15/solaris-sparc/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk15/solaris-sparcv9/
   65896  Defl:N    20152  69% 2018-02-06 22:57 4c4b6006  netbeans/lib/deployed/jdk15/solaris-sparcv9/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/deployed/jdk15/windows-amd64/
   37888  Defl:N    15533  59% 2018-02-06 22:57 b9e95a15  netbeans/lib/deployed/jdk15/windows-amd64/profilerinterface.dll
   13841  Defl:N     2693  81% 2018-02-06 22:57 475f95e7  netbeans/lib/deployed/jdk15/windows-amd64/profilerinterface.map
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/deployed/jdk15/windows/
   45056  Defl:N    12294  73% 2018-02-06 22:57 8dfc884f  netbeans/lib/deployed/jdk15/windows/profilerinterface.dll
   12504  Defl:N     2635  79% 2018-02-06 22:57 e5b63778  netbeans/lib/deployed/jdk15/windows/profilerinterface.map
       0  Stored        0   0% 2018-01-25 09:14 00000000  netbeans/lib/deployed/jdk16/
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/hpux-pa_risc2.0/
   65536  Defl:N    24814  62% 2018-02-06 22:57 b8b981af  netbeans/lib/deployed/jdk16/hpux-pa_risc2.0/libprofilerinterface.sl
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/hpux-pa_risc2.0w/
   89456  Defl:N    30071  66% 2018-02-06 22:57 86a33a95  netbeans/lib/deployed/jdk16/hpux-pa_risc2.0w/libprofilerinterface.sl
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/linux-amd64/
   52047  Defl:N    19907  62% 2018-02-06 22:57 38f007a0  netbeans/lib/deployed/jdk16/linux-amd64/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/linux-arm-vfp-hflt/
   56377  Defl:N    23130  59% 2018-02-06 22:57 ced101ce  netbeans/lib/deployed/jdk16/linux-arm-vfp-hflt/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/linux-arm/
   61022  Defl:N    24704  60% 2018-02-06 22:57 92f229ca  netbeans/lib/deployed/jdk16/linux-arm/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/linux/
   42694  Defl:N    16146  62% 2018-02-06 22:57 8347bea2  netbeans/lib/deployed/jdk16/linux/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/mac/
  185120  Defl:N    55471  70% 2018-02-06 22:57 647222b3  netbeans/lib/deployed/jdk16/mac/libprofilerinterface.jnilib
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/solaris-amd64/
   57372  Defl:N    15093  74% 2018-02-06 22:57 dec6c38f  netbeans/lib/deployed/jdk16/solaris-amd64/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/solaris-i386/
   57244  Defl:N    15074  74% 2018-02-06 22:57 c7cce620  netbeans/lib/deployed/jdk16/solaris-i386/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/solaris-sparc/
   58756  Defl:N    20161  66% 2018-02-06 22:57 f2cf74fd  netbeans/lib/deployed/jdk16/solaris-sparc/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/lib/deployed/jdk16/solaris-sparcv9/
   65928  Defl:N    20262  69% 2018-02-06 22:57 aee3bad2  netbeans/lib/deployed/jdk16/solaris-sparcv9/libprofilerinterface.so
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/deployed/jdk16/windows-amd64/
   40960  Defl:N    16342  60% 2018-02-06 22:57 41e762e5  netbeans/lib/deployed/jdk16/windows-amd64/profilerinterface.dll
   16784  Defl:N     3216  81% 2018-02-06 22:57 18f3110d  netbeans/lib/deployed/jdk16/windows-amd64/profilerinterface.map
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/lib/deployed/jdk16/windows/
   33280  Defl:N    13761  59% 2018-02-06 22:57 17f89902  netbeans/lib/deployed/jdk16/windows/profilerinterface.dll
   16499  Defl:N     3471  79% 2018-02-06 22:57 4e97960b  netbeans/lib/deployed/jdk16/windows/profilerinterface.map
    5663  Defl:N     5668  -0% 2018-02-06 22:57 c0b1b855  netbeans/lib/jfluid-server-15.jar.pack.gz
    1496  Defl:N     1501  -0% 2018-02-06 22:57 bc3fe55a  netbeans/lib/jfluid-server-cvm.jar.pack.gz
   72558  Defl:N    72583   0% 2018-02-06 22:57 15b03ad4  netbeans/lib/jfluid-server.jar.pack.gz
       0  Stored        0   0% 2018-02-06 22:57 00000000  netbeans/modules/
  242608  Defl:N   242683   0% 2018-02-06 22:57 1b289ee3  netbeans/modules/org-netbeans-lib-profiler.jar.pack.gz
       0  Stored        0   0% 2018-02-06 10:46 00000000  netbeans/remote-pack-defs/
     453  Defl:N      250  45% 2018-02-06 22:57 dc7fb098  netbeans/remote-pack-defs/README.txt
   11524  Defl:N     1890  84% 2018-02-06 22:57 fd325d15  netbeans/remote-pack-defs/build.xml
    1265  Defl:N      716  43% 2018-02-06 22:57 d7d70d75  netbeans/remote-pack-defs/calibrate-15.bat
    1212  Defl:N      704  42% 2018-02-06 22:57 8225a0b3  netbeans/remote-pack-defs/calibrate-15.sh
    1246  Defl:N      732  41% 2018-02-06 22:57 f5fc0444  netbeans/remote-pack-defs/calibrate-16.sh
    1303  Defl:N      722  45% 2018-02-06 22:57 7ecc5f0c  netbeans/remote-pack-defs/calibrate-linux-cvm.sh
    1208  Defl:N      703  42% 2018-02-06 22:57 0790e4b6  netbeans/remote-pack-defs/calibrate-mac-15.sh
    1217  Defl:N      709  42% 2018-02-06 22:57 9705873b  netbeans/remote-pack-defs/calibrate-solaris64-15.sh
    1259  Defl:N      696  45% 2018-02-06 22:57 dfddcdf3  netbeans/remote-pack-defs/calibrate-win-cvm.bat
    1268  Defl:N      705  44% 2018-02-06 22:57 3100e03e  netbeans/remote-pack-defs/nb-profile-15.bat
    1275  Defl:N      712  44% 2018-02-06 22:57 73ebb01c  netbeans/remote-pack-defs/nb-profile-amd64-15.bat
    1344  Defl:N      761  43% 2018-02-06 22:57 b37f3131  netbeans/remote-pack-defs/profile-linux-15.sh
    1379  Defl:N      791  43% 2018-02-06 22:57 bcc90ae0  netbeans/remote-pack-defs/profile-linux-16.sh
    1321  Defl:N      742  44% 2018-02-06 22:57 78ee065b  netbeans/remote-pack-defs/profile-linux-cvm.sh
    1351  Defl:N      767  43% 2018-02-06 22:57 40a1b00d  netbeans/remote-pack-defs/profile-linuxamd64-15.sh
    1351  Defl:N      768  43% 2018-02-06 22:57 ce5d81c5  netbeans/remote-pack-defs/profile-linuxamd64-16.sh
    1350  Defl:N      767  43% 2018-02-06 22:57 514ede4e  netbeans/remote-pack-defs/profile-linuxarm-16.sh
    1359  Defl:N      774  43% 2018-02-06 22:57 4a2f4ea6  netbeans/remote-pack-defs/profile-linuxarmvfphflt-16.sh
    1340  Defl:N      762  43% 2018-02-06 22:57 a29e97ae  netbeans/remote-pack-defs/profile-mac-15.sh
    1343  Defl:N      764  43% 2018-02-06 22:57 c5b355a3  netbeans/remote-pack-defs/profile-mac-16.sh
    1359  Defl:N      771  43% 2018-02-06 22:57 f029e6af  netbeans/remote-pack-defs/profile-solamd64-15.sh
    1359  Defl:N      772  43% 2018-02-06 22:57 0fc0c501  netbeans/remote-pack-defs/profile-solamd64-16.sh
    1352  Defl:N      765  43% 2018-02-06 22:57 e6ad03a8  netbeans/remote-pack-defs/profile-solsparc-15.sh
    1353  Defl:N      767  43% 2018-02-06 22:57 b8c153ca  netbeans/remote-pack-defs/profile-solsparc-16.sh
    1360  Defl:N      774  43% 2018-02-06 22:57 68f5271e  netbeans/remote-pack-defs/profile-solsparcv9-15.sh
    1360  Defl:N      775  43% 2018-02-06 22:57 596440d2  netbeans/remote-pack-defs/profile-solsparcv9-16.sh
    1353  Defl:N      768  43% 2018-02-06 22:57 02ead49b  netbeans/remote-pack-defs/profile-solx86-15.sh
    1353  Defl:N      770  43% 2018-02-06 22:57 5017071b  netbeans/remote-pack-defs/profile-solx86-16.sh
    1263  Defl:N      713  44% 2018-02-06 22:57 895b1129  netbeans/remote-pack-defs/profile-win-15.bat
    1171  Defl:N      671  43% 2018-02-06 22:57 37afafb9  netbeans/remote-pack-defs/profile-win-16.bat
    1159  Defl:N      659  43% 2018-02-06 22:57 becb671f  netbeans/remote-pack-defs/profile-win-cvm.bat
    1270  Defl:N      721  43% 2018-02-06 22:57 1f6f6f7e  netbeans/remote-pack-defs/profile-winamd64-15.bat
    1177  Defl:N      676  43% 2018-02-06 22:57 2112544b  netbeans/remote-pack-defs/profile-winamd64-16.bat
       0  Stored        0   0% 2018-02-06 22:57 00000000  Info/
   38029  Defl:N    13103  66% 2018-02-06 22:57 ea530100  Info/info.xml
    1973  Defl:N      279  86% 2018-02-06 22:57 c311ad25  Info/executables.list
--------          -------  ---                            -------
 2674771          1105738  59%                            113 files
```
