### PR TITLE
Fixes bug that prevents NetBeans from quitting on macOS

### DIFF
--- a/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK8.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK8.java
@@ -79,5 +79,7 @@ public class NbApplicationAdapterJDK8 extends NbApplicationAdapter implements Ab
     @Override
     public void handleQuitRequestWith(AppEvent.QuitEvent e, QuitResponse response) {
         handleQuit();
+        //need to do this otherwise the user will never be able to quit again
+        response.cancelQuit();
     }
 }

--- a/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK9.java
+++ b/applemenu/src/org/netbeans/modules/applemenu/NbApplicationAdapterJDK9.java
@@ -82,5 +82,7 @@ public class NbApplicationAdapterJDK9 extends NbApplicationAdapter implements Ab
     @Override
     public void handleQuitRequestWith(QuitEvent e, QuitResponse response) {
         handleQuit();
+        //need to do this otherwise the user will never be able to quit again
+        response.cancelQuit();
     }
 }


### PR DESCRIPTION
Fixes bug that prevents NetBeans from quitting on macOS if the user previously canceled a quit

Multiple issue about how pressing Cancel on the macOS 'Quit NetBeans' menu prevents the users from even quitting.

> https://netbeans.org/bugzilla/show_bug.cgi?id=268549
> https://netbeans.org/bugzilla/show_bug.cgi?id=271946
> https://netbeans.org/bugzilla/show_bug.cgi?id=269724
> (probably) https://netbeans.org/bugzilla/show_bug.cgi?id=247690

Brought to my attention by Marco Rossi on the users@ mailing list.

It's a workaround but it has low impact. We could also call all the time `response.cancelQuit()` since it might not impact anything when a `System.exit` arrives but it seems odd to call it all the time.

Awaiting feedback.