### PR TITLE
[NETBEANS-285] Removing javahelp quick search provider

### DIFF
--- a/javahelp/src/org/netbeans/modules/javahelp/resources/layer.xml
+++ b/javahelp/src/org/netbeans/modules/javahelp/resources/layer.xml
@@ -96,16 +96,4 @@
         </folder>
     </folder>
     
-    <folder name="QuickSearch">
-          <folder name="Help">
-              <!--Attribute for localization - provide localized display name of category!-->
-              <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.javahelp.Bundle"/>
-              <!--Attribute for command prefix - used to narrow search to this category only!-->
-              <attr name="command" stringvalue="h"/>
-              <!--Attribute for category ordering!-->
-              <attr name="position" intvalue="1000"/>
-              <!--Note that multiple providers can contribute to one category!-->
-              <file name="org-netbeans-modules-javahelp-JavaHelpQuickSearchProviderImpl.instance"/>
-          </folder>
-    </folder>
 </filesystem>


### PR DESCRIPTION
Removing javahelp quick search provider from the layer Lookup, so it won't cause CNFE