### PR TITLE
[NETBEANS-408] Fix AntJUnitManagerProviderTest test at junit.ant.ui module.

### DIFF
--- a/junit.ant.ui/test/unit/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProviderTest.java
+++ b/junit.ant.ui/test/unit/src/org/netbeans/modules/junit/ant/ui/AntJUnitManagerProviderTest.java
@@ -25,6 +25,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.netbeans.modules.gsf.testrunner.ui.api.Manager;
+import org.netbeans.modules.gsf.testrunner.ui.api.TestRunnerNodeFactory;
 
 /**
  *
@@ -56,11 +58,11 @@ public class AntJUnitManagerProviderTest {
      */
     @Test
     public void testRegisterNodeFactory() {
-        System.out.println("registerNodeFactory");
         AntJUnitManagerProvider instance = new AntJUnitManagerProvider();
         instance.registerNodeFactory();
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+        TestRunnerNodeFactory nodeFactory = Manager.getInstance().getNodeFactory();
+        assertNotNull(nodeFactory);
+        assertTrue(AntJUnitTestRunnerNodeFactory.class.isAssignableFrom(nodeFactory.getClass()));
     }
     
 }


### PR DESCRIPTION
[NETBEANS-408](https://issues.apache.org/jira/browse/NETBEANS-408) Fix AntJUnitManagerProviderTest test at junit.ant.ui module.

The AntJUnitManagerProviderTest unit test at Ant Junit UI module fails when execute because it is a prototype and call fail method.

```
AntJUnitManagerProvider instance = new AntJUnitManagerProvider();
instance.registerNodeFactory();
// TODO review the generated test code and remove the default call to fail.
fail("The test case is a prototype.");
```
I use this command to run test: ```ant -f junit.ant.ui -Dtest.type=unit -Dtest.includes=org/netbeans/modules/junit/ant/ui/AntJUnitManagerProviderTest.java test-single```

