### PR TITLE
Providing exact steps used to rebuild the Equinox JAR

### DIFF
--- a/netbinox/external/M20140115-0800.patch
+++ b/netbinox/external/M20140115-0800.patch
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+diff --git a/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java b/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
+index 617db7f..1851f4a 100644
+--- a/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
++++ b/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
+@@ -563,11 +563,19 @@ public class Framework implements EventPublisher, Runnable {
+ 
+ 	private URL findNextBestProfile(String javaEdition, Version javaVersion) {
+ 		URL result = null;
++                int major = javaVersion.getMajor();
+ 		int minor = javaVersion.getMinor();
+-		do {
+-			result = findInSystemBundle(javaEdition + javaVersion.getMajor() + "." + minor + PROFILE_EXT); //$NON-NLS-1$
+-			minor = minor - 1;
+-		} while (result == null && minor > 0);
++            do {
++                result = findInSystemBundle(javaEdition + major + "." + minor + PROFILE_EXT); //$NON-NLS-1$
++                if (major > 9) {
++                    major -= 1;
++                } else if (major == 9) {
++                    minor = major - 1;
++                    major = 1;
++                } else {
++                    minor -= 1;
++                }
++            } while (result == null && ((minor > 0) || (major > 1)));
+ 		return result;
+ 	}
+ 

--- a/netbinox/external/binaries-list
+++ b/netbinox/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-E5DDC5E827D3D62E7BE9F7E32927CA01F2839971 org.eclipse.osgi_3.9.1.v20140110-1610.jar
+CB97D80CEDF7963313E1B1EADC0F1E49F62570DD org.eclipse.osgi_3.9.1.nb9.jar

--- a/netbinox/external/org.eclipse.osgi_3.9.1.v20140110-1610-license.txt
+++ b/netbinox/external/org.eclipse.osgi_3.9.1.v20140110-1610-license.txt
@@ -2,7 +2,7 @@ Name: Equinox
 Version: 3.9.1
 Description: Eclipse OSGi container
 License: OSGi
-Files: org.eclipse.osgi_3.9.1.v20140110-1610.jar
+Files: org.eclipse.osgi_3.9.1.nb9.jar
 Origin: Eclipse
 URL: http://www.eclipse.org/equinox/
 

--- a/netbinox/external/rebuild-equinox.sh
+++ b/netbinox/external/rebuild-equinox.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+BASE=`dirname $0`
+cd $BASE
+BASE=`pwd`
+
+git clone https://git.eclipse.org/r/equinox/rt.equinox.framework
+cd rt.equinox.framework
+git checkout M20140115-0800
+git show M20140115-0800:bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java  >Framework.java
+patch <../M20140115-0800.patch
+if ! [ -e org.eclipse.osgi-3.9.1.v20140110-1610.jar ]; then
+  wget https://repo.eclipse.org/content/repositories/releases/org/eclipse/core/org.eclipse.osgi/3.9.1.v20140110-1610/org.eclipse.osgi-3.9.1.v20140110-1610.jar
+fi
+mkdir -p out
+javac -cp org.eclipse.osgi-3.9.1.v20140110-1610.jar Framework.java -d out || exit 1
+cd out
+zip -d ../org.eclipse.osgi-3.9.1.v20140110-1610.jar META-INF/ECLIPSE_.SF META-INF/ECLIPSE_.RSA
+zip -r ../org.eclipse.osgi-3.9.1.v20140110-1610.jar .
+
+cd "$BASE"
+mv rt.equinox.framework/org.eclipse.osgi-3.9.1.v20140110-1610.jar org.eclipse.osgi_3.9.1.nb9.jar

--- a/netbinox/nbproject/project.properties
+++ b/netbinox/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-release.external/org.eclipse.osgi_3.9.1.v20140110-1610.jar=modules/ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar
+release.external/org.eclipse.osgi_3.9.1.nb9.jar=modules/ext/org.eclipse.osgi_3.9.1.nb9.jar
 javac.source=1.6
 javac.target=1.7
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/netbinox/nbproject/project.xml
+++ b/netbinox/nbproject/project.xml
@@ -122,8 +122,8 @@
                 <package>org.eclipse.osgi.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.osgi_3.9.1.v20140110-1610.jar</binary-origin>
+                <runtime-relative-path>ext/org.eclipse.osgi_3.9.1.nb9.jar</runtime-relative-path>
+                <binary-origin>external/org.eclipse.osgi_3.9.1.nb9.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
+++ b/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
@@ -453,7 +453,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
             file.equals(System.getProperty("netbeans.home")) ||
             (file + File.separator + "platform").equals(System.getProperty("netbeans.home")) ||
             file.matches(".*/modules/ext/org\\.eclipse\\.osgi_[0-9\\.]*v[0-9]*\\.jar") ||
-            containsPath(file, "modules/ext/org.eclipse.osgi_3.9.1.v20140110-1610.jar") ||
+            containsPath(file, "modules/ext/org.eclipse.osgi_3.9.1") ||
             containsPath(file, "modules/org-netbeans-modules-netbinox.jar") ||
             containsPath(file, "platform/lib/org-openide-util.jar") ||
             containsPath(file, "platform/lib/org-openide-util-base.jar") ||


### PR DESCRIPTION
Providing exact steps used to rebuild the Equinox JAR and renaming it to stress the fact it has been modified. Addresses bug https://issues.apache.org/jira/browse/LEGAL-361