### PR TITLE
Make sure the JavaScript coloring prevails inside of Java strings

### DIFF
--- a/editor.htmlui/src/org/netbeans/modules/editor/htmlui/JSEmbeddingProvider.java
+++ b/editor.htmlui/src/org/netbeans/modules/editor/htmlui/JSEmbeddingProvider.java
@@ -108,6 +108,13 @@ public final class JSEmbeddingProvider extends JavaParserResultTask<Parser.Resul
                             final int end = (int) sp.getEndPosition(cu, lt);
                             seq.move(start);
                             while (seq.moveNext() && seq.offset() < end) {
+                                if (
+                                    seq.embedded() != null &&
+                                    seq.embedded().language() != null &&
+                                    "text/x-java-string".equals(seq.embedded().language().mimeType())
+                                ) {
+                                    seq.removeEmbedding(seq.embedded().language());
+                                }
                                 seq.createEmbedding(javaScript, 1, 1, true);
                             }
                         }

--- a/editor.htmlui/src/org/netbeans/modules/editor/htmlui/JSEmbeddingProvider.java
+++ b/editor.htmlui/src/org/netbeans/modules/editor/htmlui/JSEmbeddingProvider.java
@@ -89,11 +89,15 @@ public final class JSEmbeddingProvider extends JavaParserResultTask<Parser.Resul
     public void run(Parser.Result t, SchedulerEvent se) {
         canceled.set(false);
         final CompilationInfo ci = CompilationInfo.get(t);
+        colorizeJSB(ci);
+    }
+
+    public static void colorizeJSB(final CompilationInfo ci) {
         final CompilationUnitTree cu = ci.getCompilationUnit();
         final Trees trees = ci.getTrees();
         final SourcePositions sp = trees.getSourcePositions();
         final Finder f = new Finder(trees);
-        final List<LiteralTree> result = new ArrayList<LiteralTree>();
+        final List<LiteralTree> result = new ArrayList<>();
         f.scan(cu, result);
         if (!result.isEmpty()) {
             try {


### PR DESCRIPTION
The coloring of JavaScript inside of Java strings wasn't visible due to another `text/x-java-string` embedding taking over the JavaScript one. Removing it, if present.