### PR TITLE
More robustness when resource name of loadImageIcon is null

### DIFF
--- a/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -403,6 +403,9 @@ public final class ImageUtilities {
 
     static Image getIcon(String resource, boolean localized) {
         if (localized) {
+            if (resource == null) {
+                return null;
+            }
             synchronized (localizedCache) {
                 ActiveRef<String> ref = localizedCache.get(resource);
                 Image img = null;
@@ -475,6 +478,9 @@ public final class ImageUtilities {
     *  and is not optimized/interned
     */
     private static Image getIcon(String name, ClassLoader loader, boolean localizedQuery) {
+        if (name == null) {
+            return null;
+        }
         ActiveRef<String> ref = cache.get(name);
         Image img = null;
 

--- a/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
+++ b/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
@@ -21,10 +21,9 @@ package org.openide.util;
 import java.awt.Color;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
-import java.awt.image.ImageObserver;
-import java.net.MalformedURLException;
 import java.net.URL;
 import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.UIManager;
 import junit.framework.*;
 
@@ -36,6 +35,16 @@ public class ImageUtilitiesTest extends TestCase {
     
     public ImageUtilitiesTest (String testName) {
         super (testName);
+    }
+
+    public void testNullYieldsNullLocalized() throws Exception {
+        ImageIcon icon = ImageUtilities.loadImageIcon(null, true);
+        assertNull(icon);
+    }
+
+    public void testNullYieldsNull() throws Exception {
+        ImageIcon icon = ImageUtilities.loadImageIcon(null, false);
+        assertNull(icon);
     }
 
     public void testMergeImages() throws Exception {


### PR DESCRIPTION
I was getting NPE recently and this would be the general fix.