### PR TITLE
[JDK18_3] nb-javac-x jars change and test case issue fixes

### DIFF
--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
@@ -59,7 +59,7 @@ public class PostFlowAnalysisTest extends NbTestCase {
     public void test225887sl17() throws Exception {
         performErrorsCorrectTest("package test; public class Test implements I { public void test() { I.super.test(); } } interface I { public default void test() { } }",
                                  "1.7",
-                                 "109:compiler.err.default.methods.not.supported.in.source");
+                                 "109:compiler.err.feature.not.supported.in.source.plural");
     }
     
     private void performErrorsCorrectTest(String code, String sourceLevel, String... errors) throws Exception {

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -60,6 +60,7 @@ import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
+import org.netbeans.modules.java.source.base.SourceLevelUtils;
 
 /**
  *
@@ -326,12 +327,12 @@ public class JavacParserTest extends NbTestCase {
 
     public void testIfMissingObjectOnBootCPUseCPToGuessSourceLevelWithStringBuilder() throws Exception {
         Source ret = guessSourceLevel(false, true, false);
-        assertEquals("Keeps 1.7, as Object and StringBuilder on bootCP, but no AutoCloseable", Source.JDK1_7, ret);
+        assertEquals("Keeps 1.7, as Object and StringBuilder on bootCP, but no AutoCloseable", SourceLevelUtils.JDK1_7, ret);
     }
 
     public void testIfMissingObjectOnBootCPUseCPToGuessSourceLevelWithStringBuilderAndAutoCloseable() throws Exception {
         Source ret = guessSourceLevel(false, true, true);
-        assertEquals("Kept to 1.7", Source.JDK1_7, ret);
+        assertEquals("Kept to 1.7", SourceLevelUtils.JDK1_7, ret);
     }
     
     private Source guessSourceLevel(boolean objectOnBCP, boolean sbOnCP, boolean acOnCP) throws Exception {

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
@@ -50,6 +50,7 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Pair;
+import org.netbeans.modules.java.source.base.SourceLevelUtils;
 
 /**
  *
@@ -80,7 +81,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         CachingFileManager fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         Iterable<JavaFileObject> res = fm.list(StandardLocation.CLASS_PATH, "org.me", EnumSet.of(JavaFileObject.Kind.CLASS), false);    //NOI18N
@@ -90,7 +91,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "org.me", EnumSet.of(JavaFileObject.Kind.CLASS), false); //NOI18N
@@ -100,7 +101,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "org.me", EnumSet.of(JavaFileObject.Kind.CLASS), false);    //NOI18N
@@ -110,7 +111,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "org.me", EnumSet.of(JavaFileObject.Kind.CLASS), false); //NOI18N
@@ -123,7 +124,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         CachingFileManager fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         Iterable<JavaFileObject> res = fm.list(StandardLocation.CLASS_PATH, "", EnumSet.of(JavaFileObject.Kind.CLASS), true);    //NOI18N
@@ -133,7 +134,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "", EnumSet.of(JavaFileObject.Kind.CLASS), true); //NOI18N
@@ -143,7 +144,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "", EnumSet.of(JavaFileObject.Kind.CLASS), true);    //NOI18N
@@ -153,7 +154,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.list(StandardLocation.CLASS_PATH, "", EnumSet.of(JavaFileObject.Kind.CLASS), true); //NOI18N
@@ -183,7 +184,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         CachingFileManager fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         JavaFileObject res = (JavaFileObject) fm.getFileForInput(StandardLocation.CLASS_PATH, "org.me", "A.class");
@@ -193,7 +194,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForInput(StandardLocation.CLASS_PATH, "org.me", "A.class");
@@ -203,7 +204,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForInput(StandardLocation.CLASS_PATH, "org.me", "A.class");
@@ -213,7 +214,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForInput(StandardLocation.CLASS_PATH, "org.me", "A.class");
@@ -226,7 +227,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         CachingFileManager fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         JavaFileObject res = fm.getJavaFileForInput(StandardLocation.CLASS_PATH, "org.me.A", JavaFileObject.Kind.CLASS);
@@ -236,7 +237,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         res = fm.getJavaFileForInput(StandardLocation.CLASS_PATH, "org.me.A", JavaFileObject.Kind.CLASS);
@@ -246,7 +247,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 bCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.getJavaFileForInput(StandardLocation.CLASS_PATH, "org.me.A", JavaFileObject.Kind.CLASS);
@@ -256,7 +257,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 mvCp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.getJavaFileForInput(StandardLocation.CLASS_PATH, "org.me.A", JavaFileObject.Kind.CLASS);
@@ -270,7 +271,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 null,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         JavaFileObject res = (JavaFileObject) fm.getFileForOutput(StandardLocation.CLASS_PATH, "org.me", "A.class", null);
@@ -281,7 +282,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 null,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForOutput(StandardLocation.CLASS_PATH, "org.me", "A.class", null);
@@ -292,7 +293,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 null,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForOutput(StandardLocation.CLASS_PATH, "org.me", "A.class", null);
@@ -303,7 +304,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 null,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = (JavaFileObject) fm.getFileForOutput(StandardLocation.CLASS_PATH, "org.me", "A.class", null);
@@ -326,7 +327,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         CachingFileManager fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 cp,
-                Source.JDK1_8,
+                SourceLevelUtils.JDK1_8,
                 false,
                 true);
         Iterable<JavaFileObject> res = fm.list(
@@ -339,7 +340,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         fm = new CachingFileManager(
                 CachingArchiveProvider.getDefault(),
                 cp,
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 false,
                 true);
         res = fm.list(

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
@@ -49,6 +49,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.modules.java.source.base.SourceLevelUtils;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Pair;
 
@@ -82,7 +83,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         JavaFileManager.Location l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -98,7 +99,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -117,7 +118,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         JavaFileManager.Location l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -133,7 +134,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -152,7 +153,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         JavaFileManager.Location l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -168,7 +169,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -187,7 +188,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 bCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         JavaFileManager.Location l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)
@@ -203,7 +204,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 CachingArchiveProvider.getDefault(),
                 mvCp,
                 (u)->Collections.singleton(u),
-                Source.JDK1_9,
+                SourceLevelUtils.JDK1_9,
                 StandardLocation.MODULE_PATH,
                 false);
         l = StreamSupport.stream(fm.listLocationsForModules(StandardLocation.MODULE_PATH).spliterator(), true)

--- a/libs.javacapi/external/binaries-list
+++ b/libs.javacapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-184D809687180CF321C724B8E8EA1C3945E8C208 nb-javac-9-api.jar
+1FD58C0401F7F012CE366CFE9E1BB9DA7AB7768F nb-javac-9-api.jar

--- a/libs.javacimpl/external/binaries-list
+++ b/libs.javacimpl/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-EA8670918AF969E28B53ABA8574A661BA36A402A nb-javac-9-impl.jar
+B0715954783E5F4909E329FA39E8BC50E161B1ED nb-javac-9-impl.jar


### PR DESCRIPTION
Fix for following errors with merged nb-java-x jars (https://hg.netbeans.org/main/nb-java-x) in JDK18_3 branch:

1.test225887sl17 : org.netbeans.modules.java.source.PostFlowAnalysisTest

2.updated checksum in binaries-list for nb-java-x jars.
(https://hg.netbeans.org/main/nb-java-x)

3. Enum error of Source.java 
java.lang.NoSuchFieldError: JDK1_9, JDK1_8 and JDK1_7
Use SourceLevelUtils.java in place of Source.java class.

For more details: https://confluence.oraclecorp.com/confluence/pages/viewpage.action?pageId=606328162