### PR TITLE
If compilation during indexing fails on exception, try to fallback to…

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/FileManagerTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/FileManagerTransaction.java
@@ -94,7 +94,7 @@ public abstract class FileManagerTransaction extends TransactionContext.Service 
      * @return 
      */
     @NonNull
-    abstract JavaFileObject  createFileObject(
+    public abstract JavaFileObject  createFileObject(
             @NonNull Location location,
             @NonNull File file,
             @NonNull File root,
@@ -229,7 +229,7 @@ public abstract class FileManagerTransaction extends TransactionContext.Service 
 
         @Override
         @NonNull
-        JavaFileObject createFileObject(
+        public JavaFileObject createFileObject(
                 @NonNull final Location location,
                 @NonNull final File file,
                 @NonNull final File root,
@@ -261,7 +261,7 @@ public abstract class FileManagerTransaction extends TransactionContext.Service 
 
         @Override
         @NonNull
-        JavaFileObject createFileObject(
+        public JavaFileObject createFileObject(
                 @NonNull final Location location,
                 @NonNull final File file,
                 @NonNull final File root,
@@ -304,7 +304,7 @@ public abstract class FileManagerTransaction extends TransactionContext.Service 
 
         @Override
         @NonNull
-        JavaFileObject createFileObject(
+        public JavaFileObject createFileObject(
                 @NonNull final Location location,
                 @NonNull final File file,
                 @NonNull final File root,
@@ -355,7 +355,7 @@ public abstract class FileManagerTransaction extends TransactionContext.Service 
         }
 
         @Override
-        JavaFileObject createFileObject(Location location, File file, File root, JavaFileFilterImplementation filter, Charset encoding) {
+        public JavaFileObject createFileObject(Location location, File file, File root, JavaFileFilterImplementation filter, Charset encoding) {
             return getDelegate().createFileObject(location, file, root, filter, encoding);
         }
 

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/WriteBackTransaction.java
@@ -192,7 +192,7 @@ class WriteBackTransaction extends FileManagerTransaction {
 
     @Override
     @NonNull
-    JavaFileObject createFileObject(
+    public JavaFileObject createFileObject(
             @NonNull final Location location,
             @NonNull final File file,
             @NonNull final File root,


### PR DESCRIPTION
… project's output.

Running using vanilla javac (as opposed to nb-javac) is sometimes troublesome, as the indexing may crash, which may lead to additional errors in dependent source roots (where the indexing may crash as well), and missing sig/class files in the caches may have an impact on performance.

This patch is an attempt to mitigate that, by copying project  build output into the caches. This is not perfect and may have observable effects (e.g. Go to Type is unlikely to find classes in a source root where indexing crashed currently), but when the indexing crashes, having something in the caches is typically much better than having nothing.

We may need more tweaks, based on experience, but so far seems like a step in the right direction.