### PR TITLE
JDK18_3 : var shows without syntax highligting in jdk10

### DIFF
--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
@@ -69,7 +69,7 @@ public class JavaLexer implements Lexer<JavaTokenId> {
         }
         
         Integer ver = (Integer)info.getAttributeValue("version"); //NOI18N
-        this.version = (ver != null) ? ver.intValue() : 9; // TODO: Java 1.8 used by default        
+        this.version = (ver != null) ? ver.intValue() : 10; // TODO: Java 1.8 used by default        
     }
     
     public Object state() {


### PR DESCRIPTION
The default jdk version in JavaLexer is set as 9, but var keyword check requires min version 10. The runtime jdk version is not available via inputAttributes, hence default version value is getting used here.

Working on passing runtime jdk version via inputAttributes in another transaction and will merge separately. 