### PR TITLE
[NETBEANS 363] Fix fallback jdkhome

### DIFF
--- a/nbbuild/jdk.xml
+++ b/nbbuild/jdk.xml
@@ -203,7 +203,7 @@
         </condition>
 
         <!-- Fallback? -->
-        <property name="nbjdk.home" location="${java.home.parent}"/>
+        <property name="nbjdk.home" location="${java.home}"/>
         <available property="have-jdk-1.4" classname="java.lang.CharSequence"/>
         <available property="have-jdk-1.5" classname="java.lang.StringBuilder"/>
         <available property="have-jdk-1.6" classname="java.util.ServiceLoader"/>


### PR DESCRIPTION
As mentioned in bug, tools.jar is not available in JDK 9, 10, hence jdk.home is getting set to fallback value ${java.home.parent} and thus gets incorrectly set to parent folder of java.home. Changing this value to java.home fixes the issue. Verified in Windows+Linux. Is this fallback value used in any other usecase?