### PR TITLE
[NETBEANS 470] Var shows as keyword in jdk8, 9

### DIFF
--- a/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
+++ b/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
@@ -146,6 +146,9 @@ public class JavaKit extends NbEditorKit {
             FileObject fo = NbEditorUtilities.getFileObject(doc);
             return fo != null ? fo.getNameExt() : null;
         }, true);
+        attrs.setValue(JavaTokenId.language(), "version", (Supplier<String>) () -> { //NOI18N
+            return getSourceLevel(doc);
+        }, true);
         doc.putProperty(InputAttributes.class, attrs);
       }
     

--- a/java.lexer/nbproject/project.properties
+++ b/java.lexer/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.title=Java Lexer API
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
@@ -56,7 +56,7 @@ public class JavaLexer implements Lexer<JavaTokenId> {
     private final int version;
     
     private Integer state = null;
-
+    
     public JavaLexer(LexerRestartInfo<JavaTokenId> info) {
         this.input = info.input();
         this.tokenFactory = info.tokenFactory();
@@ -68,7 +68,16 @@ public class JavaLexer implements Lexer<JavaTokenId> {
             }
         }
         
-        Integer ver = (Integer)info.getAttributeValue("version"); //NOI18N
+        Integer ver = null;
+        Object verAttribute = info.getAttributeValue("version"); //NOI18N 
+        if (verAttribute instanceof Supplier) {
+            Object val = ((Supplier) verAttribute).get();
+            if (val instanceof String) {
+                ver = getVersionAsInt(((Supplier<String>) (verAttribute)).get());
+            }
+        } else if (verAttribute instanceof Integer) {
+            ver = (Integer) verAttribute;
+        }
         this.version = (ver != null) ? ver.intValue() : 10; // TODO: Java 1.8 used by default        
     }
     
@@ -1296,6 +1305,25 @@ public class JavaLexer implements Lexer<JavaTokenId> {
             JavaTokenId.BLOCK_COMMENT, JavaTokenId.JAVADOC_COMMENT,
             JavaTokenId.LINE_COMMENT, JavaTokenId.WHITESPACE
     );
+
+    private Integer getVersionAsInt(String version) {
+        Integer ver = null;
+        if (version != null) {
+            try {
+                // expect format 1.x or x
+                if (version.startsWith("1.")) { //NOI18N
+                    ver = Integer.parseInt(version.substring(version.indexOf(".") + 1)); //NOI18N
+                } else {
+                    ver = Integer.parseInt(version);
+                }
+            } catch (NumberFormatException e) {
+                // should not happen if version is
+                // set using SourceLevelQuery,
+                // ignore other strings
+            }
+        }
+        return ver;
+    }
 
     public void release() {
     }

--- a/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
+++ b/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
@@ -1306,13 +1306,14 @@ public class JavaLexer implements Lexer<JavaTokenId> {
             JavaTokenId.LINE_COMMENT, JavaTokenId.WHITESPACE
     );
 
+    // Get version as Integer x for version String 1.x
     private Integer getVersionAsInt(String version) {
         Integer ver = null;
         if (version != null) {
             try {
                 // expect format 1.x or x
                 if (version.startsWith("1.")) { //NOI18N
-                    ver = Integer.parseInt(version.substring(version.indexOf(".") + 1)); //NOI18N
+                    ver = Integer.parseInt(version.substring(2));
                 } else {
                     ver = Integer.parseInt(version);
                 }

--- a/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
+++ b/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.lib.java.lexer;
 
 import java.util.EnumSet;
+import java.util.function.Supplier;
 import junit.framework.TestCase;
 import org.netbeans.api.java.lexer.JavaStringTokenId;
 import org.netbeans.api.java.lexer.JavaTokenId;
@@ -593,6 +594,44 @@ public class JavaLexerBatchTest extends TestCase {
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.DOT, ".");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.IDENTIFIER, "var");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.RPAREN, ")");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.SEMICOLON, ";");
+    }
+    
+    public void testVarKeywordWithStringVersion() {
+        String text = "var /*comment*/ /**comment*/ var = 0;";
+        InputAttributes attr = new InputAttributes();
+        attr.setValue(JavaTokenId.language(), "version", (Supplier<String>) () -> {return "10";}, true);
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.VAR, "var");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.BLOCK_COMMENT, "/*comment*/");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.JAVADOC_COMMENT, "/**comment*/");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.IDENTIFIER, "var");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.EQ, "=");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.INT_LITERAL, "0");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.SEMICOLON, ";");
+    }
+
+    public void testVarIdentWithStringVersion() {
+        String text = "var var = 0;";
+        InputAttributes attr = new InputAttributes();
+        attr.setValue(JavaTokenId.language(), "version", (Supplier<String>) () -> {return "1.8";}, true);
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.IDENTIFIER, "var");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.IDENTIFIER, "var");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.EQ, "=");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.INT_LITERAL, "0");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.SEMICOLON, ";");
     }
 }

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractSourceFileObject.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/AbstractSourceFileObject.java
@@ -41,6 +41,7 @@ import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.lexer.InputAttributes;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.queries.FileEncodingQuery;
@@ -303,6 +304,11 @@ public abstract class AbstractSourceFileObject implements PrefetchableJavaFileOb
             final CharBuffer charBuffer = getCharContent(true);
             InputAttributes attrs = new InputAttributes();
             attrs.setValue(JavaTokenId.language(), "fileName", (Supplier<String>) () -> getName(), true); //NOI18N            
+            attrs.setValue(JavaTokenId.language(), "version", (Supplier<String>) () -> { //NOI18N  
+                FileObject fo = handle.resolveFileObject(false);
+                return (fo != null) ? SourceLevelQuery.getSourceLevel(fo) : null;
+            }, true);         
+  
             this.tokens = TokenHierarchy.create(charBuffer, false, JavaTokenId.language(), null, attrs); //TODO: .createSnapshot();
         }
         return this.tokens;


### PR DESCRIPTION
SourceLevel is not passed to JavaLexer, hence version is set to default, which is the latest version supported. So version always set to 10.  Fixed by passing version as inputAttribute to JavaLexer.