### PR TITLE
LookAndFeel improvemnets for HTML UI on Windows

### DIFF
--- a/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.htmlui;
 
+import java.awt.Font;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.application.Platform;
@@ -37,6 +38,7 @@ import javafx.scene.web.WebView;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.Callback;
+import javax.swing.JOptionPane;
 import javax.swing.LookAndFeel;
 import javax.swing.UIManager;
 import net.java.html.boot.fx.FXBrowsers;
@@ -44,11 +46,14 @@ import net.java.html.js.JavaScriptBody;
 import org.openide.util.NbBundle;
 
 final class NbBrowsers {
+
     static {
         Platform.setImplicitExit(false);
     }
+
     public static void load(WebView view, URL page, final Runnable onPageLoad, ClassLoader loader, Object... args) {
         class ApplySkin implements Runnable {
+
             @Override
             public void run() {
                 applyNbSkin();
@@ -85,15 +90,15 @@ final class NbBrowsers {
         loadCss(resource);
     }
 
-    @JavaScriptBody(args = { "css" }, body =
-"  if (!document.head || document.head.getAttribute(\"data-netbeans-css\") == \"false\") {\n" +
-"     return;\n" +
-"  }\n" +
-"  var link = document.createElement(\"link\");\n" +
-"  link.rel = \"stylesheet\";\n" +
-"  link.type = \"text/css\";\n" +
-"  link.href = css;\n" +
-"  document.head.appendChild(link);"
+    @JavaScriptBody(args = {"css"}, body
+            = "  if (!document.head || document.head.getAttribute(\"data-netbeans-css\") == \"false\") {\n"
+            + "     return;\n"
+            + "  }\n"
+            + "  var link = document.createElement(\"link\");\n"
+            + "  link.rel = \"stylesheet\";\n"
+            + "  link.type = \"text/css\";\n"
+            + "  link.href = css;\n"
+            + "  document.head.appendChild(link);"
     )
     private static native void loadCss(String css);
 
@@ -195,6 +200,7 @@ final class NbBrowsers {
 
         FXBrowsers.load(view, page, onPageLoad, loader, args);
     }
+
     private static final class CloseDialogHandler implements EventHandler<ActionEvent> {
 
         private final Stage dialogStage;

--- a/api.htmlui/src/org/netbeans/modules/htmlui/css/wizard-win.css
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/css/wizard-win.css
@@ -67,9 +67,7 @@ input[type=checkbox]:hover:checked {
 }
 
 input[type=radio]{
-    position: relative;
     background: #ffffff;
-    top: 4px;
     width: 16px;
     height: 16px;
     border-radius: 10px;

--- a/api.htmlui/src/org/netbeans/modules/htmlui/css/wizard-win.css
+++ b/api.htmlui/src/org/netbeans/modules/htmlui/css/wizard-win.css
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 body#body{
-    font-family: Dialog;
+    font-family: Tahoma;
     font-weight: 100;
 }
 


### PR DESCRIPTION
Complaints from a user on dev mailing list: font in HTML/Java Wizard doesn't match default font on Windows, and radiobuttons were not aligned with labels. This PR fixes it.