### PR TITLE
Makes ProgressHandle and AggregateProgressHandle AutoCloseable

### DIFF
--- a/api.progress/nbproject/project.properties
+++ b/api.progress/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.7
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/api.progress/src/org/netbeans/api/progress/BaseProgressUtils.java
+++ b/api.progress/src/org/netbeans/api/progress/BaseProgressUtils.java
@@ -192,13 +192,10 @@ public final class BaseProgressUtils {
             PROVIDER.runOffEventDispatchThread(new Runnable() {
                 @Override
                 public void run() {
-                    ProgressHandle handle = ProgressHandle.createHandle(displayName);
-                    handle.start();
-                    handle.switchToIndeterminate();
-                    try {
+                    try (ProgressHandle handle = ProgressHandle.createHandle(displayName)) {
+                        handle.start();
+                        handle.switchToIndeterminate();
                         ref.set(operation.run(handle));
-                    } finally {
-                        handle.finish();
                     }
                 }
             }, displayName, new AtomicBoolean(false), true, 0, 0);

--- a/api.progress/src/org/netbeans/api/progress/ProgressHandle.java
+++ b/api.progress/src/org/netbeans/api/progress/ProgressHandle.java
@@ -38,7 +38,7 @@ import org.openide.util.Cancellable;
  * 
  * @author Milos Kleint (mkleint@netbeans.org)
  */
-public final class ProgressHandle {
+public final class ProgressHandle implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(ProgressHandle.class.getName());
 
@@ -165,6 +165,14 @@ public final class ProgressHandle {
         internal.toDeterminate(workunits, estimate);
     }
     
+    /**
+     * Calls {@link #finish()}
+     */
+    @Override
+    public final void close() {
+        finish();
+    }
+
     /**
      * Finish the task, remove the task's component from the progress bar UI.
      * This method has to be called after calling <code>start</code> method (the task has to be running).

--- a/api.progress/src/org/netbeans/api/progress/aggregate/AggregateProgressHandle.java
+++ b/api.progress/src/org/netbeans/api/progress/aggregate/AggregateProgressHandle.java
@@ -37,7 +37,7 @@ import org.openide.util.Cancellable;
  * For a more simple version of progress indication, see {@link org.netbeans.api.progress.ProgressHandle}
  * @author Milos Kleint (mkleint@netbeans.org)
  */
-public final class AggregateProgressHandle {
+public final class AggregateProgressHandle implements AutoCloseable {
     private static final Logger LOG = Logger.getLogger(AggregateProgressHandle.class.getName());
 
     private ProgressMonitor monitor;
@@ -80,6 +80,14 @@ public final class AggregateProgressHandle {
         handle.start(WORKUNITS, estimate);
         current = 0;
     }  
+
+    /**
+     * Calls {@link #finish()}
+     */
+    @Override
+    public void close() {
+        finish();
+    }
     
     /**
      * finish the task, remove the task's component from the progress bar UI, any additional incoming events from the 

--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManager.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/PlatformLayersCacheManager.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.core.startup.layers.LayerCacheManager;
 import org.netbeans.modules.apisupport.project.api.ManifestManager;
 import org.netbeans.modules.apisupport.project.spi.LayerUtil;
@@ -237,8 +236,7 @@ public class PlatformLayersCacheManager {
         List<FileSystem> entries = new ArrayList<FileSystem>();
         LOGGER.fine("getCache for clusters: " + Arrays.toString(clusters) + (filter != null ? ", FILTERED" : ""));
         synchronized (loadedCaches) {
-            ProgressHandle handle = ProgressHandleFactory.createHandle(MSG_scanning_layers());
-            try {
+            try (ProgressHandle handle = ProgressHandle.createHandle(MSG_scanning_layers())) {
                 handle.start(clusters.length + 1);
                 int c = 0;
                 for (File cl : clusters) {
@@ -287,8 +285,6 @@ public class PlatformLayersCacheManager {
                 // getCache would wait for finishing its cache, optionally scheduling it as priority
                 storeCaches();
                 handle.progress(c++);
-            } finally {
-                handle.finish();
             }
         }
         return entries;

--- a/diff/src/org/netbeans/modules/diff/DiffAction.java
+++ b/diff/src/org/netbeans/modules/diff/DiffAction.java
@@ -43,7 +43,6 @@ import org.openide.windows.WindowManager;
 import org.netbeans.api.diff.*;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.modules.diff.builtin.DefaultDiff;
 import org.netbeans.modules.diff.builtin.SingleDiffPanel;
 import org.netbeans.modules.diff.options.AccessibleJFileChooser;
@@ -220,12 +219,9 @@ public class DiffAction extends NodeAction {
                 }
             };
             String name = NbBundle.getMessage(DiffAction.class, "BK0001");
-            ProgressHandle ph = ProgressHandleFactory.createHandle(name, killer);
-            try {
+            try (ProgressHandle ph = ProgressHandle.createHandle(name, killer)) {
                 ph.start();
                 sdp = new SingleDiffPanel(fo1, fo2, type);
-            } finally {
-                ph.finish();
             }
         } catch (IOException ioex) {
             ErrorManager.getDefault().notify(ioex);

--- a/diff/src/org/netbeans/modules/diff/PatchAction.java
+++ b/diff/src/org/netbeans/modules/diff/PatchAction.java
@@ -28,7 +28,6 @@ import java.text.DateFormat;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.openide.ErrorManager;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
@@ -109,9 +108,8 @@ public class PatchAction extends NodeAction {
     }
 
     public static boolean performPatch(File patch, File file) throws MissingResourceException {
-        ProgressHandle ph = ProgressHandleFactory.createHandle(NbBundle.getMessage(PatchAction.class, "MSG_AplyingPatch", new Object[] {patch.getName()}));
         List<ContextualPatch.PatchReport> report = null;
-        try {
+        try (ProgressHandle ph = ProgressHandle.createHandle(NbBundle.getMessage(PatchAction.class, "MSG_AplyingPatch", new Object[] {patch.getName()}))) {
             ph.start();
             ContextualPatch cp = ContextualPatch.create(patch, file);
             try {
@@ -122,8 +120,6 @@ public class PatchAction extends NodeAction {
                 ErrorManager.getDefault().notify(ErrorManager.USER, ioex);
                 return false;
             }
-        } finally {
-            ph.finish();
         }
         return displayPatchReport(report, patch);
     }

--- a/diff/src/org/netbeans/modules/diff/builtin/DiffPresenter.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DiffPresenter.java
@@ -88,7 +88,7 @@ public class DiffPresenter extends javax.swing.JPanel {
      */
     public DiffPresenter() {
         String label = NbBundle.getMessage(DiffPresenter.class, "diff.prog");
-        ProgressHandle progress = ProgressHandleFactory.createHandle(label);
+        ProgressHandle progress = ProgressHandle.createHandle(label);
         progressPanel = ProgressHandleFactory.createProgressComponent(progress);
         add(progressPanel);
         progress.start();
@@ -366,16 +366,13 @@ public class DiffPresenter extends javax.swing.JPanel {
                 try {
                     Difference[] adiffs = fdiffs;
                     String message = NbBundle.getMessage(DiffPresenter.class, "BK0001");
-                    ProgressHandle ph = ProgressHandleFactory.createHandle(message);
                     if (adiffs == null) {
-                        try {
+                        try (ProgressHandle ph = ProgressHandle.createHandle(message)) {
                             ph.start();
                             adiffs = p.computeDiff(
                                     diffInfo.createFirstReader(),
                                     diffInfo.createSecondReader()
                             );
-                        } finally {
-                            ph.finish();
                         }
                     }
 

--- a/image/nbproject/project.properties
+++ b/image/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.7

--- a/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -399,12 +399,9 @@ public class ImageViewer extends CloneableTopComponent {
         loadImageTask = RP.create(new Runnable() {
 
             public void run() {
-                ProgressHandle loadImageProgress = ProgressHandleFactory.createHandle(NbBundle.getMessage(ImageViewer.class, "LBL_LoadingImage"));
-                loadImageProgress.start();
-                try {
+                try (ProgressHandle loadImageProgress = ProgressHandle.createHandle(NbBundle.getMessage(ImageViewer.class, "LBL_LoadingImage"))) {
+                    loadImageProgress.start();
                     performLoadImage(imageObj);
-                } finally {
-                    loadImageProgress.finish();
                 }
             }
         });


### PR DESCRIPTION
`ProgressHandle` and `AggregateProgressHandle` fit very well with try-with-resources so we only need to implement `AutoCloseable`.

The usual style is:

```java
ProgressHandle handle = ProgressHandle.createHandle(displayName);
try{
  handle.start();
  ...
} finally{
 handle.finish();
}
```

With try-with-resources it becomes:

```java
try (ProgressHandle handle = ProgressHandle.createHandle(displayName)) {
  handle.start();
  ...
}
```
