### PR TITLE
Shielding against NPE when debugging Nashorn scripts

### DIFF
--- a/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
+++ b/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
@@ -4217,7 +4217,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
         if (primitiveType instanceof DoubleType) {
             typeClass = Double.class;
         }
-        if (typeClass != null) {
+        if (typeClass != null && evaluationContext != null && evaluationContext.getVMCache() != null) {
             type = evaluationContext.getVMCache().getClass(typeClass.getName());
         }
         return type;


### PR DESCRIPTION
I am getting `NullPointerException` quite frequently when debugging my [Bck2Brwsr VM](http://github.com/jtulach/bck2brwsr). This change makes the code more robust.