### PR TITLE
[NETBEANS-461] Better and more correct way to copy the extbrowser DLL…

### DIFF
--- a/extbrowser/build.xml
+++ b/extbrowser/build.xml
@@ -22,12 +22,6 @@
 <project name="extbrowser" default="build" basedir=".">
 
     <import file="../nbbuild/templates/projectized.xml"/>
-    
-    <property name="resourcesdir" value="./release/modules/lib/"/>
-    <target name="-release.dir" depends="projectized-common.-release.dir">
-        <mkdir dir="${resourcesdir}"/>
-        <unzip src="external/extbrowser-dlls-18.03.15.zip" dest="${resourcesdir}"/>
-    </target>
 
     <target name="jnlp" depends="netbeans,-jnlp-init">
         <property name="dir" location="${jnlp.dest.dir}/${code.name.base.dashes}"/>

--- a/extbrowser/nbproject/project.properties
+++ b/extbrowser/nbproject/project.properties
@@ -18,6 +18,8 @@
 javadoc.arch=${basedir}/arch.xml
 # test.unit.cp.extra and/or test.unit.run.cp.extra
 javac.source=1.7
+release.external/extbrowser-dlls-18.03.15.zip!/extbrowser.dll=modules/lib/extbrowser.dll
+release.external/extbrowser-dlls-18.03.15.zip!/extbrowser64.dll=modules/lib/extbrowser64.dll
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\
     **/ExtWebBrowserTest.class,\


### PR DESCRIPTION
…s from the archive into the build.

The current code is setting up the release directory (which would also need to be cleaned by "clean", and ignored in .gitignore), but is probably setting it up too late. So when the build happens and the directory does not exist, the resources won't be copied. But if the directory exists (even if empty, probably), the resources will be copied. Using "release." properties in nbproject/project.properties should be safer. (Note that AFAIK this only works for "nb.org" projects, not for module suite projects, etc.)