### PR TITLE
[NETBEANS-492] disable QuickSearchProvider for JavaHelp

### DIFF
--- a/javahelp/src/org/netbeans/modules/javahelp/resources/layer.xml
+++ b/javahelp/src/org/netbeans/modules/javahelp/resources/layer.xml
@@ -96,16 +96,16 @@
         </folder>
     </folder>
     
-    <folder name="QuickSearch">
+<!--    <folder name="QuickSearch">
           <folder name="Help">
-              <!--Attribute for localization - provide localized display name of category!-->
+              Attribute for localization - provide localized display name of category!
               <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.javahelp.Bundle"/>
-              <!--Attribute for command prefix - used to narrow search to this category only!-->
+              Attribute for command prefix - used to narrow search to this category only!
               <attr name="command" stringvalue="h"/>
-              <!--Attribute for category ordering!-->
+              Attribute for category ordering!
               <attr name="position" intvalue="1000"/>
-              <!--Note that multiple providers can contribute to one category!-->
+              Note that multiple providers can contribute to one category!
               <file name="org-netbeans-modules-javahelp-JavaHelpQuickSearchProviderImpl.instance"/>
           </folder>
-    </folder>
+    </folder>-->
 </filesystem>


### PR DESCRIPTION
Disabling the QuickSearchProvider for JavaHelp so that the Quick Search text field continues to work for all other QuickSearchProviders, just not for JavaHelp (until JavaHelp is included at some point in the future).