### PR TITLE
Better consistency between SaveCookie presence and modified status

### DIFF
--- a/csl.api/src/org/netbeans/modules/csl/core/GsfDataObject.java
+++ b/csl.api/src/org/netbeans/modules/csl/core/GsfDataObject.java
@@ -96,7 +96,7 @@ public class GsfDataObject extends MultiDataObject {
     @Override
     public void setModified(boolean modif) {
         super.setModified(modif);
-        if (!modif) {
+        if (!isModified()) {
             GenericEditorSupport ges = getLookup().lookup(GenericEditorSupport.class);
             // defect #203688, probably file deletion in parallel with DO's creation - not completed, so cookie not registered yet.
             if (ges != null) {

--- a/csl.api/test/unit/src/org/netbeans/modules/csl/core/GsfDataObjectTest.java
+++ b/csl.api/test/unit/src/org/netbeans/modules/csl/core/GsfDataObjectTest.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.csl.core;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import org.netbeans.junit.NbTestCase;
 import org.openide.cookies.EditorCookie;
 import org.openide.cookies.SaveCookie;
@@ -47,6 +49,29 @@ public class GsfDataObjectTest extends NbTestCase {
         dob.setModified(false);
         assertFalse("Should not be modified.", dob.isModified());
         assertNull("Should not have SaveCookie.",
+                dob.getLookup().lookup(SaveCookie.class));
+    }
+    
+    public void testSetModifiedNestedChange() throws Exception {
+        FileSystem fs = FileUtil.createMemoryFileSystem();
+        FileObject f = fs.getRoot().createData("index.test");
+        DataObject dob = DataObject.find(f);
+        assertEquals("The right object", GsfDataObject.class, dob.getClass());
+        dob.getLookup().lookup(EditorCookie.class).openDocument().insertString(0,
+                "modified", null);
+        assertTrue("Should be modified.", dob.isModified());
+        dob.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                String s = evt.getPropertyName();
+                if (DataObject.PROP_MODIFIED.equals(s) && !dob.isModified()) {
+                    dob.setModified(true);
+                }
+            }
+        });
+        dob.setModified(false);
+        assertTrue("Should be still modified.", dob.isModified());
+        assertNotNull("Still should have save cookie.",
                 dob.getLookup().lookup(SaveCookie.class));
     }
 }

--- a/html/src/org/netbeans/modules/html/HtmlDataObject.java
+++ b/html/src/org/netbeans/modules/html/HtmlDataObject.java
@@ -160,7 +160,7 @@ public class HtmlDataObject extends MultiDataObject implements CookieSet.Factory
     @Override
     public void setModified(boolean modif) {
         super.setModified(modif);
-        if(!modif) {
+        if(!isModified()) {
             HtmlEditorSupport support = getLookup().lookup(HtmlEditorSupport.class);
             support.removeSaveCookie();
         }

--- a/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
+++ b/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
@@ -185,7 +185,7 @@ public abstract class XmlMultiViewDataObject extends MultiDataObject implements 
     public void setModified(boolean modif) {
         super.setModified(modif);
         //getEditorSupport().updateDisplayName();
-        if (modif) {
+        if (isModified()) {
             // Add save cookie
             if (getCookie(SaveCookie.class) == null) {
                 getCookieSet().add(saveCookie);


### PR DESCRIPTION
The overriden setModified() removes save cookie if the "modified" status is false. The trouble is, that if during invocation of listeners, ..., some cod manages to get the object un-modified again for some reason. Then the cookie is not removed since (local) modified variable no longer corresponds the isModified() result.
The object reports isModifed() == false, but has saveCookie, which enables actions etc.

I'd need the change in JS DataObject, but I put it to other DataObjects that I found overriding setModified too.