### PR TITLE
Fixing 'downgrading to 1.8' log messages by producing module bootpath…

### DIFF
--- a/maven.persistence/nbproject/project.xml
+++ b/maven.persistence/nbproject/project.xml
@@ -58,7 +58,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.5</specification-version>
+                        <specification-version>1.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/EntityClassScopeProviderImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/EntityClassScopeProviderImpl.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.maven.persistence;
 
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.classpath.JavaClassPathConstants;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
 import org.netbeans.modules.j2ee.persistence.api.EntityClassScope;
@@ -50,10 +51,14 @@ public class EntityClassScopeProviderImpl implements EntityClassScopeProvider {
     private synchronized EntityMappingsMetadataModelHelper getHelper() {
         if (helper == null) {
             ProjectSourcesClassPathProvider cp = project.getLookup().lookup(ProjectSourcesClassPathProvider.class);
-            helper = EntityMappingsMetadataModelHelper.create(
-                    cp.getProjectSourcesClassPath(ClassPath.BOOT),
-                    cp.getProjectSourcesClassPath(ClassPath.COMPILE),
-                    cp.getProjectSourcesClassPath(ClassPath.SOURCE));
+            helper = new EntityMappingsMetadataModelHelper.Builder(cp.getProjectSourcesClassPath(ClassPath.BOOT))
+                .setModuleBootPath(cp.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_BOOT_PATH))
+                .setClassPath(cp.getProjectSourcesClassPath(ClassPath.COMPILE))
+                .setModuleCompilePath(cp.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_COMPILE_PATH))
+                .setModuleClassPath(cp.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_CLASS_PATH))
+                .setSourcePath(cp.getProjectSourcesClassPath(ClassPath.SOURCE))
+                //The CP provider does not support: JavaClassPathConstants.MODULE_SOURCE_PATH
+                .build();
         }
         return helper;
     }

--- a/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeImpl.java
+++ b/maven.persistence/src/org/netbeans/modules/maven/persistence/PersistenceScopeImpl.java
@@ -23,6 +23,7 @@ package org.netbeans.modules.maven.persistence;
 
 import org.netbeans.modules.maven.api.classpath.ProjectSourcesClassPathProvider;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.classpath.JavaClassPathConstants;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
 import org.netbeans.modules.j2ee.persistence.api.metadata.orm.EntityMappingsMetadata;
 import org.netbeans.modules.j2ee.persistence.spi.PersistenceLocationProvider;
@@ -111,10 +112,14 @@ public class PersistenceScopeImpl implements PersistenceScopeImplementation
     }
     
     private EntityMappingsMetadataModelHelper createEntityMappingsHelper() {
-        return EntityMappingsMetadataModelHelper.create(
-            cpProvider.getProjectSourcesClassPath(ClassPath.BOOT),
-            cpProvider.getProjectSourcesClassPath(ClassPath.COMPILE),
-            cpProvider.getProjectSourcesClassPath(ClassPath.SOURCE));
+        return new EntityMappingsMetadataModelHelper.Builder(cpProvider.getProjectSourcesClassPath(ClassPath.BOOT))
+                .setModuleBootPath(cpProvider.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_BOOT_PATH))
+                .setClassPath(cpProvider.getProjectSourcesClassPath(ClassPath.COMPILE))
+                .setModuleCompilePath(cpProvider.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_COMPILE_PATH))
+                .setModuleClassPath(cpProvider.getProjectSourcesClassPath(JavaClassPathConstants.MODULE_CLASS_PATH))
+                .setSourcePath(cpProvider.getProjectSourcesClassPath(ClassPath.SOURCE))
+                //The CP provider does not support: JavaClassPathConstants.MODULE_SOURCE_PATH
+                .build();
     }
     
     

--- a/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
+++ b/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
@@ -423,7 +423,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
     }
     
     private ClassPath getModuleBootPath() {
-        return computeIfAbsent(MODULE_BOOT_PATH, () -> createModuleInfoSelector(() -> createPlatformModulesPath(), () -> ClassPath.EMPTY, "ModuleBootPath")); // XXX empty? // NOI18N                
+        return computeIfAbsent(MODULE_BOOT_PATH, () -> createModuleInfoSelector(() -> createPlatformModulesPath(), () -> createPlatformModulesPath(), "ModuleBootPath")); // NOI18N
     }
 
     private ClassPath getModuleCompilePath(int type) {

--- a/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
+++ b/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
@@ -207,6 +207,32 @@ public class ClassPathProviderImplTest extends NbTestCase {
         assertRoots(entries, "target/classes");
     }        
 
+    public void testModuleBootPathNoModuleInfo() throws Exception {
+        if (systemModules == null) {
+            System.out.println("No jdk 9 home configured.");    //NOI18N
+            return;
+        }
+        TestFileUtils.writeFile(d,
+                "pom.xml",
+                "<project xmlns='http://maven.apache.org/POM/4.0.0'>" +
+                "<modelVersion>4.0.0</modelVersion>" +
+                "<groupId>grp</groupId>" +
+                "<artifactId>art</artifactId>" +
+                "<packaging>jar</packaging>" +
+                "<version>1.0-SNAPSHOT</version>" +
+                "<name>Test</name>" +
+                "    <properties>" +
+                "        <maven.compiler.source>11</maven.compiler.source>" +
+                "        <maven.compiler.target>11</maven.compiler.target>" +
+                "    </properties>" +
+                "</project>");
+        FileObject src = FileUtil.createFolder(d, "src/main/java");
+        ClassPath cp = ClassPath.getClassPath(src, JavaClassPathConstants.MODULE_BOOT_PATH);
+        assertNotNull(cp);
+        List<ClassPath.Entry> entries = cp.entries();
+        assertFalse(entries.isEmpty());
+    }
+
     private void assertRoots(List<ClassPath.Entry> entries, String rootPath) throws URISyntaxException {
         for (ClassPath.Entry entry : entries) {
             URL url = entry.getURL();


### PR DESCRIPTION
… in Maven even when module-info is not present; and propagating the module bootpath as needed in Maven persistence.