### PR TITLE
netbeans-480: ConvertToDiamondBulkHint disabled for var type variable initialization

### DIFF
--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
@@ -95,6 +95,15 @@ public class ConvertToDiamondBulkHint {
         @TriggerPattern("new $clazz<$tparams$>($params$)")
     })
     public static ErrorDescription compute(HintContext ctx) {
+        // hint disabled for var type variable initialization.
+        TreePath parentPath = ctx.getPath().getParentPath();
+        boolean isVarInit = MatcherUtilities.matches(ctx, parentPath, "$mods$ $type $name = $init;");   //NOI18N
+        if (isVarInit) {
+            if (ctx.getInfo().getTreeUtilities().isVarType(parentPath)) {
+                return null;
+            }
+        }
+
         if (ctx.getMultiVariables().get("$tparams$").isEmpty()) return null;
         
         TreePath clazz = ctx.getVariables().get("$clazz");

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHintTest.java
@@ -290,6 +290,20 @@ public class ConvertToDiamondBulkHintTest extends NbTestCase {
                 .assertWarnings();
     }
     
+    public void testConfiguration9() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    {\n" +
+                       "        var list = new java.util.LinkedList<String>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("1.10")
+                .run(ConvertToDiamondBulkHint.class)
+                .assertWarnings();
+    }
+
     static {
         TestCompilerSettings.commandLine = "-XDfind=diamond";
     }


### PR DESCRIPTION
Fix hint 'Use diamond inference'  is disabled for var type  variable initialization.

var list = new ArrayList<String>();