### PR TITLE
#517: Prevent a project to be a subproject of itself

### DIFF
--- a/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImpl.java
+++ b/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/SubprojectProviderImpl.java
@@ -153,6 +153,7 @@ public final class SubprojectProviderImpl implements SubprojectProvider {
                 }
             }
         }
+        s.remove(project);
         return s;
     }
     


### PR DESCRIPTION
The `api.common.annotations` module was listed at its own subproject. Preventing similar issues by removing the `project` from the subproject `s` set before returning it.

Fixes [NETBEANS-517](https://issues.apache.org/jira/browse/NETBEANS-517) bug.