### PR TITLE
Allow to postprocess downloaded binaries

### DIFF
--- a/lib.profiler/build.xml
+++ b/lib.profiler/build.xml
@@ -24,15 +24,8 @@
     <import file="../nbbuild/templates/projectized.xml"/>
 
     <property name="profiler.cluster" value="./release"/>
-    <target name="-release.dir" depends="projectized-common.-release.dir,-define-downloadbinaries-task">
-        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
-            <manifest dir=".">
-                <include name="external/binaries-list"/>
-            </manifest>
-        </downloadbinaries>
+    <target name="-process.release.files">
         <unzip src="external/profiler-external-binaries-8.2.zip" dest="${profiler.cluster}"/>
-        <taskdef name="releasefilesextra" classname="org.netbeans.nbbuild.extlibs.ReleaseFilesExtra" classpath="${nbantext.jar}"/>
-        <releasefilesextra property="release.files.extra"/>
     </target>
 
   <!-- Compile the JFluid engine system library, that depends on JDK version - so there are two libraries -->

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -230,14 +230,19 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
     <target name="-define-downloadbinaries-task" unless="have-downloadbinaries-task">
         <taskdef name="downloadbinaries" classname="org.netbeans.nbbuild.extlibs.DownloadBinaries" classpath="${nbantext.jar}"/>
     </target>
-
-    <!-- See: http://wiki.netbeans.org/wiki/view/DevFaqExternalLibrariesUpdated -->
-    <target name="-release.files" depends="projectized-common.-release.files,-define-downloadbinaries-task">
+    
+    <target name="-process.release.files"/>
+    
+    <target name="-download.release.files" depends="-define-downloadbinaries-task">
         <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
             <manifest dir=".">
                 <include name="external/binaries-list"/>
             </manifest>
         </downloadbinaries>
+    </target>
+
+    <!-- See: http://wiki.netbeans.org/wiki/view/DevFaqExternalLibrariesUpdated -->
+    <target name="-release.files" depends="projectized-common.-release.files,-download.release.files,-process.release.files">
         <taskdef name="releasefilesextra" classname="org.netbeans.nbbuild.extlibs.ReleaseFilesExtra" classpath="${nbantext.jar}"/>
         <releasefilesextra property="release.files.extra"/>
     </target>
@@ -811,5 +816,5 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
             <arg value="org.codehaus.mojo:nb-repository-plugin:1.3:populate"/>
         </exec>
     </target>
-
+    
 </project>

--- a/o.apache.xml.resolver/build.xml
+++ b/o.apache.xml.resolver/build.xml
@@ -58,5 +58,7 @@
     </target>
 
     <!-- Hook into harness "basic-init" task -->
-    <target name="-javac-init" depends="-prepare-patched-binary, projectized-common.-javac-init" />
+    <target name="-process.release.files" depends="-prepare-patched-binary"/>
+
+
 </project>


### PR DESCRIPTION
The apache-resolver needs to compile and patch external JAR to produce the resolver JAR that should go to `modules/ext`. The current build sequence fills in` release.files.extra` property before that, so the JAR is missing from update tracking information. Consequently, applications built on NetBeans platform will not pick the resolver JAR from NB platform during the build and will be broken.
This effect happens just if the NB platform is built from clean sources. Once sources are patched and the build runs again, the patched jar is already in place when release.files.extra is computed and the resulting platform contains correct update tracking info.

The proposed change adds an overridable target to nb module build, which can be overriden in module's build.xml to do additional processing **after** the binaries are downloaded, but **before** `release.files.extra` is computed.

Jarda has pointed out that I could also adapt his patch for profiler lib to this change.