### PR TITLE
[NETBEANS-602] Improved support for getting the name from Multi-Release jars

### DIFF
--- a/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
+++ b/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
@@ -225,7 +225,9 @@ public class CompilationInfo {
             final String name = FileObjects.convertFolder2Package(FileObjects.stripExtension(FileUtil.getRelativePath(this.impl.getRoot(), this.impl.getFileObject())));
             final TypeElement e = Optional.ofNullable(
                     SourceVersion.RELEASE_9.compareTo(getSourceVersion()) <= 0 ?
-                            SourceUtils.getModuleName(impl.getRoot().toURL(), true) :
+                            SourceUtils.getModuleName(
+                                Source.instance(impl.getJavacTask().getContext()),
+                                impl.getRoot().toURL(), true) :
                             null)
                     .map(elements::getModuleElement)
                     .map((module) -> ElementUtils.getTypeElementByBinaryName(this, module, name))

--- a/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -71,6 +71,7 @@ import javax.tools.JavaFileObject;
 
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -1279,7 +1280,23 @@ public class SourceUtils {
     public static String getModuleName(
             @NonNull final URL rootUrl,
             @NonNull final boolean canUseSources) {
-        return ModuleNames.getInstance().getModuleName(null, rootUrl, canUseSources);
+        return getModuleName(null, rootUrl, canUseSources);
+    }
+
+    /**
+     * Returns the name of the module for the given source version.
+     * @param source the source version or null
+     * @param rootUrl the binary root
+     * @param canUseSources
+     * @return the module name or null when no or invalid module
+     * @since 2.31.0
+     */
+    @CheckForNull
+    public static String getModuleName(
+            @NullAllowed final Source source,
+            @NonNull final URL rootUrl,
+            @NonNull final boolean canUseSources) {
+        return ModuleNames.getInstance().getModuleName(source, rootUrl, canUseSources);
     }
 
     /**

--- a/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -51,6 +51,7 @@ import com.sun.tools.javac.api.JavacTaskImpl;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Scope.NamedImportScope;
 import com.sun.tools.javac.code.Scope.StarImportScope;
+import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type;
@@ -1278,7 +1279,7 @@ public class SourceUtils {
     public static String getModuleName(
             @NonNull final URL rootUrl,
             @NonNull final boolean canUseSources) {
-        return ModuleNames.getInstance().getModuleName(rootUrl, canUseSources);
+        return ModuleNames.getInstance().getModuleName(null, rootUrl, canUseSources);
     }
 
     /**

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
@@ -309,7 +309,7 @@ final class ModuleFileManager implements JavaFileManager {
             for (ClassPath.Entry e : modulePath.entries()) {
                 final URL root = e.getURL();
                 if (!seen.contains(root)) {
-                    final String moduleName = SourceUtils.getModuleName(root);
+                    final String moduleName = SourceUtils.getModuleName(this.sourceLevel, root, false);
                     if (moduleName != null) {
                         Collection<? extends URL> p = peers.apply(root);
                         moduleRoots.add(ModuleLocation.create(baseLocation, p, moduleName));


### PR DESCRIPTION
Here's a suggested fix for the issue I reported, to do with detecting the module name in Multi-Release jar files.