### PR TITLE
[NETBEANS-491] use framework support to disable error reporting

### DIFF
--- a/ide.branding/uihandler/src/org/netbeans/modules/uihandler/Bundle_nb.properties
+++ b/ide.branding/uihandler/src/org/netbeans/modules/uihandler/Bundle_nb.properties
@@ -41,7 +41,7 @@ METRICS_URL=https://netbeans.org/nonav/uigestures/index4.html
 
 # URL to display to as a welcome text in case of error
 #NOI18N
-ERROR_URL=http://netbeans-vm.apache.org/misc/bug_report.html
+ERROR_URL=https://netbeans.apache.org/nb/issues.html
 
 #NOI18N
 CHECKING_SERVER_URL=http://statistics.netbeans.org/analytics/authenticate?username={0}&secur_passwd={1}

--- a/ide.branding/uihandler/src/org/netbeans/modules/uihandler/Bundle_nb.properties
+++ b/ide.branding/uihandler/src/org/netbeans/modules/uihandler/Bundle_nb.properties
@@ -41,7 +41,7 @@ METRICS_URL=https://netbeans.org/nonav/uigestures/index4.html
 
 # URL to display to as a welcome text in case of error
 #NOI18N
-ERROR_URL=https://netbeans.org/nonav/uigestures/error2.html
+ERROR_URL=http://netbeans-vm.apache.org/misc/bug_report.html
 
 #NOI18N
 CHECKING_SERVER_URL=http://statistics.netbeans.org/analytics/authenticate?username={0}&secur_passwd={1}

--- a/uihandler/src/org/netbeans/modules/uihandler/UIHandler.java
+++ b/uihandler/src/org/netbeans/modules/uihandler/UIHandler.java
@@ -250,11 +250,7 @@ implements ActionListener, Runnable, Callable<JButton> {
         if (w != null) {
             w.dispose();
         }
-        try {
-            HtmlBrowser.URLDisplayer.getDefault().showURL(new URL(ISSUE_REPORTER_LINK));
-        } catch (MalformedURLException ex) {
-            Installer.LOG.log(Level.FINE, null, ex);
-        }
+        Installer.RP.post(this);
     }
 
     private boolean shouldReportScanCancel() {


### PR DESCRIPTION
Removed change done in #471 to invoke JIRA url in browser on Review and Report Problem button click. Framework already supports disabling issue reporting via ERROR_URL page.