### PR TITLE
Adding LICENSE/NOTICE/DISCLAIMER to NBMs, packing OSGi jars into NBMs…

### DIFF
--- a/apisupport.harness/build.xml
+++ b/apisupport.harness/build.xml
@@ -24,14 +24,14 @@
     <import file="../nbbuild/templates/projectized.xml"/>
 
     <target name="nbantext" depends="build-init">
-        <jar jarfile="${cluster}/tasks.jar" compress="${build.package.compress}" index="${build.package.index}">
+        <nb-ext-jar jarfile="${cluster}/tasks.jar" compress="${build.package.compress}" index="${build.package.index}">
             <manifest>
                 <attribute name="NetBeans-Own-Library" value="true"/>
             </manifest>
             <!-- XXX would be more maintainable to use depfind.sf.net / genjar.sf.net / sadun-util.sf.net/pack.html -->
             <zipfileset src="${nbantext.jar}" includes="${bundled.tasks}"/>
             <zipfileset file="taskdefs.properties" fullpath="org/netbeans/nbbuild/taskdefs.properties"/>
-        </jar>
+        </nb-ext-jar>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
 import java.util.jar.JarEntry;
@@ -301,12 +303,13 @@ public class MakeNBM extends Task {
     private boolean isStandardInclude = true;
     private ArrayList<ExternalPackage> externalPackages = null;
     private ArrayList<String> locales = null;
-    private ArrayList<Attributes> moduleAttributes = null;
     private Attributes englishAttr = null;
     private Path updaterJar;
     private FileSet executablesSet;
+    private ZipFileSet extraNBMFiles;
     private boolean usePack200;
     private String pack200excludes;
+    private boolean alwaysCreateNBM;
 
     /** Try to find and create localized info.xml files */
     public void setLocales(String s) {
@@ -340,9 +343,17 @@ public class MakeNBM extends Task {
         this.pack200excludes = pack200excludes;
     }
 
+    public void setAlwaysCreateNBM(boolean alwaysCreateNBM) {
+        this.alwaysCreateNBM = alwaysCreateNBM;
+    }
+
     /** List of executable files in NBM concatinated by ${line.separator}. */
     public FileSet createExecutables() {
         return (executablesSet = new FileSet());
+    }
+    
+    public ZipFileSet createExtraNBMFiles() {
+        return (extraNBMFiles = new ZipFileSet());
     }
     
     /** Module manifest needed for versioning.
@@ -496,6 +507,8 @@ public class MakeNBM extends Task {
         try {
             try (JarFile mjar = new JarFile(mfile)) {
                 if (mjar.getManifest().getMainAttributes().getValue("Bundle-SymbolicName") != null) {
+                    englishAttr = new Attributes();
+                    englishAttr.putValue("OpenIDE-Module", JarWithModuleAttributes.extractCodeName(mjar.getManifest().getMainAttributes()));
                     // #181025: treat bundles specially.
                     return null;
                 }
@@ -581,25 +594,32 @@ public class MakeNBM extends Task {
 	overrideLicenseIfNeeded() ;
         
         
-        moduleAttributes = new ArrayList<> ();
+        Map<String, Supplier<Document>> moduleAttributes = new LinkedHashMap<>();
         File module = new File( productDir, moduleName );
         Attributes attr = getModuleAttributesForLocale("");
         if (attr == null) {
-            // #181025: OSGi bundle, copy unmodified.
-            Copy copy = new Copy();
-            copy.setProject(getProject());
-            copy.setOwningTarget(getOwningTarget());
-            copy.setFile(module);
-            copy.setTofile(new File(nbm.getAbsolutePath().replaceFirst("[.]nbm$", ".jar")));
-            copy.execute();
-            // XXX possibly sign it
-            // XXX could try to run pack200, though not if it was signed
-            return;
+            System.err.println("attr=" + attr);
+            System.err.println("alwaysCreateNBM=" + alwaysCreateNBM);
+            if (!alwaysCreateNBM) {
+                // #181025: OSGi bundle, copy unmodified.
+                Copy copy = new Copy();
+                copy.setProject(getProject());
+                copy.setOwningTarget(getOwningTarget());
+                copy.setFile(module);
+                copy.setTofile(new File(nbm.getAbsolutePath().replaceFirst("[.]nbm$", ".jar")));
+                copy.execute();
+                // XXX possibly sign it
+                // XXX could try to run pack200, though not if it was signed
+                return;
+            } else {
+                moduleAttributes.put("", () -> createFakeOSGiInfo(module));
+            }
+        } else {
+            moduleAttributes.put("", () -> createInfoXml(attr));
         }
-        moduleAttributes.add(attr);
         for (String locale : locales) {
             Attributes a = getModuleAttributesForLocale(locale);
-            if (a != null) moduleAttributes.add(a);
+            if (a != null) moduleAttributes.put(locale, () -> createInfoXml(a));
         }
 
         // Will create a file Info/info.xml to be stored in tmp
@@ -615,10 +635,10 @@ public class MakeNBM extends Task {
         }
         
         ArrayList<ZipFileSet> infoXMLFileSets = new ArrayList<>();
-        for (Attributes modAttr : moduleAttributes) {
-            Document infoXmlContents = createInfoXml(modAttr);
+        for (Map.Entry<String, Supplier<Document>> modAttr : moduleAttributes.entrySet()) {
+            Document infoXmlContents = modAttr.getValue().get();
             File infofile;
-            String loc = modAttr.getValue("locale");
+            String loc = modAttr.getKey();
             if (loc == null)
                 throw new BuildException("Found attributes without assigned locale code", getLocation());
             try {
@@ -643,7 +663,7 @@ public class MakeNBM extends Task {
         String codename = englishAttr.getValue("OpenIDE-Module");
         if (codename == null)
  	    new BuildException( "Can't get codenamebase" );
- 	
+ 	      System.err.println("codename=" + codename);
  	UpdateTracking tracking = new UpdateTracking(productDir.getAbsolutePath());
  	Set<String> _files = new LinkedHashSet<>(Arrays.asList(tracking.getListOfNBM(codename)));
     List<String> __files = new ArrayList<>(_files);
@@ -729,6 +749,10 @@ public class MakeNBM extends Task {
         jar.addZipfileset(fs);
         for (ZipFileSet zfs : infoXMLFileSets) {
             jar.addFileset(zfs);
+        }
+
+        if (extraNBMFiles != null) {
+            jar.addZipfileset(extraNBMFiles);
         }
 
         if (main != null) { // Add the main dir
@@ -1026,6 +1050,29 @@ public class MakeNBM extends Task {
         } else {
             log("No updater.jar specified, cannot validate Info.xml against DTD", Project.MSG_WARN);
         }
+        return doc;
+    }
+
+    private Document createFakeOSGiInfo(File osgiJar) {
+        DOMImplementation domimpl;
+        try {
+            domimpl = DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
+        } catch (ParserConfigurationException x) {
+            throw new BuildException(x, getLocation());
+        }
+
+        log("Creating fake info.xml for OSGi bundle", Project.MSG_VERBOSE);
+        
+        String pub = "-//NetBeans//DTD Autoupdate Module Info 2.5//EN";
+        String sys = "http://www.netbeans.org/dtds/autoupdate-info-2_5.dtd";
+        Document doc = domimpl.createDocument(null, "module", domimpl.createDocumentType("module", pub, sys));
+        
+        try (JarFile jf = new JarFile(osgiJar)) {
+            MakeUpdateDesc.fakeOSGiInfoXml(jf, osgiJar, doc);
+        } catch (IOException x) {
+            throw new BuildException(x, getLocation());
+        }
+
         return doc;
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -598,8 +598,6 @@ public class MakeNBM extends Task {
         File module = new File( productDir, moduleName );
         Attributes attr = getModuleAttributesForLocale("");
         if (attr == null) {
-            System.err.println("attr=" + attr);
-            System.err.println("alwaysCreateNBM=" + alwaysCreateNBM);
             if (!alwaysCreateNBM) {
                 // #181025: OSGi bundle, copy unmodified.
                 Copy copy = new Copy();
@@ -663,7 +661,6 @@ public class MakeNBM extends Task {
         String codename = englishAttr.getValue("OpenIDE-Module");
         if (codename == null)
  	    new BuildException( "Can't get codenamebase" );
- 	      System.err.println("codename=" + codename);
  	UpdateTracking tracking = new UpdateTracking(productDir.getAbsolutePath());
  	Set<String> _files = new LinkedHashSet<>(Arrays.asList(tracking.getListOfNBM(codename)));
     List<String> __files = new ArrayList<>(_files);
@@ -1032,13 +1029,7 @@ public class MakeNBM extends Task {
             }
         }
         module.appendChild(el);
-        // Maybe write out license text.
-        if (license != null) {
-            el = doc.createElement("license");
-            el.setAttribute("name", license.getName());
-            el.appendChild(license.getTextNode(doc));
-            module.appendChild(el);
-        }
+        maybeAddLicense(module);
         if (updaterJar != null && updaterJar.size() > 0) {
             try {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -1069,11 +1060,23 @@ public class MakeNBM extends Task {
         
         try (JarFile jf = new JarFile(osgiJar)) {
             MakeUpdateDesc.fakeOSGiInfoXml(jf, osgiJar, doc);
+            maybeAddLicense(doc.getDocumentElement());
         } catch (IOException x) {
             throw new BuildException(x, getLocation());
         }
 
         return doc;
+    }
+
+    private void maybeAddLicense(Element module) {
+        // Maybe write out license text.
+        if (license != null) {
+            Document doc = module.getOwnerDocument();
+            Element el = doc.createElement("license");
+            el.setAttribute("name", license.getName());
+            el.appendChild(license.getTextNode(doc));
+            module.appendChild(el);
+        }
     }
 
     static void validateAgainstAUDTDs(InputSource input, final Path updaterJar, final Task task) throws IOException, SAXException {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -962,14 +962,7 @@ public class MakeNBM extends Task {
         } else {
             throw new BuildException("NBM distribution URL is not set", getLocation());
         }
-        // Here we only write a name for the license.
-        if (license != null) {
-            String name = license.getName();
-            if (name == null) {
-                throw new BuildException("Every license must have a name or file attribute", getLocation());
-            }
-            module.setAttribute("license", name);
-        }
+        maybeAddLicenseName(module);
         module.setAttribute("downloadsize", "0");
         if (needsrestart != null) {
             module.setAttribute("needsrestart", needsrestart);
@@ -1060,12 +1053,24 @@ public class MakeNBM extends Task {
         
         try (JarFile jf = new JarFile(osgiJar)) {
             MakeUpdateDesc.fakeOSGiInfoXml(jf, osgiJar, doc);
+            maybeAddLicenseName(doc.getDocumentElement());
             maybeAddLicense(doc.getDocumentElement());
         } catch (IOException x) {
             throw new BuildException(x, getLocation());
         }
 
         return doc;
+    }
+
+    private void maybeAddLicenseName(Element module) {
+        // Here we only write a name for the license.
+        if (license != null) {
+            String name = license.getName();
+            if (name == null) {
+                throw new BuildException("Every license must have a name or file attribute", getLocation());
+            }
+            module.setAttribute("license", name);
+        }
     }
 
     private void maybeAddLicense(Element module) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -305,7 +305,6 @@ public class CreateLicenseSummary extends Task {
                         binaries2LicenseHeaders.put(r.getName(), headers);
                     }
                 }
-                System.err.println(r.as(File.class));
             }
         }
         if (binaries2LicenseHeaders.isEmpty())

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -50,6 +50,8 @@ import java.util.zip.ZipFile;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.netbeans.nbbuild.JUnitReportWriter;
 import org.netbeans.nbbuild.extlibs.licenseinfo.Fileset;
@@ -122,6 +124,11 @@ public class CreateLicenseSummary extends Task {
         this.binary = binary;
     }
     
+    private FileSet moduleFiles;
+    public FileSet createModuleFiles() {
+        return (moduleFiles = new FileSet());
+    }
+
     private Map<String, String> pseudoTests;
 
     public @Override
@@ -289,6 +296,18 @@ public class CreateLicenseSummary extends Task {
         List<String> ignoredPatterns = VerifyLibsAndLicenses.loadPatterns("ignored-binary-overlaps");
         if (build != null)
             findBinaries(build, binaries2LicenseHeaders, crc2License, new HashMap<>(), "", testBinariesAreUnique, ignoredPatterns);
+        if (moduleFiles != null) {
+            for (Resource r : moduleFiles) {
+                try (InputStream is = r.getInputStream()) {
+                    long crc = computeCRC32(is);
+                    Map<String, String> headers = crc2License.get(crc);
+                    if (headers != null) {
+                        binaries2LicenseHeaders.put(r.getName(), headers);
+                    }
+                }
+                System.err.println(r.as(File.class));
+            }
+        }
         if (binaries2LicenseHeaders.isEmpty())
             return ;
         pseudoTests.put("testBinariesAreUnique", testBinariesAreUnique.length() > 0 ? "Some binaries are duplicated (edit nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-binary-overlaps as needed)" + testBinariesAreUnique : null);

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -211,6 +211,7 @@
       <subant-junit target="nbm" failonerror="${nbms.fail.on.error}" report="${nb.build.dir}/build-nbms.xml" inheritall="false">
           <buildpath path="${modules.sorted}"/>
           <property name="base.nbm.target.dir" value="${base.nbm.target.dir}"/>
+          <property name="nbm.always.create" value="true" />
       </subant-junit>
   </target>
 
@@ -1894,9 +1895,10 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
       <property name="catalog.notification.url"     value=""/>
       <property name="catalog.content.description"  value=""/>
       <property name="catalog.content.description.url" value=""/>
+      <property name="catalog.license.header" value="${nb_all}/nbbuild/catalog-license-header.txt"/>
 
 <!--      <genau config="ausrc/modules.setup" nbmLocation="${nbms.location}" catalog="${catalog.file}" catalogDeploymentLocation="${catalog.base.url}"/>-->
-      <makeupdatedesc desc="${catalog.file}" distbase="${catalog.base.url}" automaticgrouping="true" uselicenseurl="${use.license.url.in.catalog}" notificationmessage="${catalog.notification.message}" notificationurl="${catalog.notification.url}" contentdescription="${catalog.content.description}" contentdescriptionurl="${catalog.content.description.url}">
+      <makeupdatedesc desc="${catalog.file}" distbase="${catalog.base.url}" automaticgrouping="true" uselicenseurl="${use.license.url.in.catalog}" notificationmessage="${catalog.notification.message}" notificationurl="${catalog.notification.url}" contentdescription="${catalog.content.description}" contentdescriptionurl="${catalog.content.description.url}" desclicense="${catalog.license.header}">
           <fileset dir="${nbms.location}">
               <include name="**/*.nbm"/>
               <include name="**/*.jar"/>

--- a/nbbuild/catalog-license-header.txt
+++ b/nbbuild/catalog-license-header.txt
@@ -1,0 +1,20 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -427,7 +427,11 @@
         <fileset dir="${cluster}" id="module.executable.files" includes="${nbm.executable.files}"/>
     </target>
 
-    <target name="nbm" depends="init,netbeans,-nbm-prompt-for-storepass,-init-executables" description="Build NBM archive.">
+    <target name="-init-extra.nbm.files" unless="extra.nbm.files.provided"> <!-- fallback -->
+        <zipfileset dir="${cluster}" id="extra.nbm.files" includes="[NOTHING]"/>
+    </target>
+
+    <target name="nbm" depends="init,netbeans,-nbm-prompt-for-storepass,-init-executables,-init-extra.nbm.files" description="Build NBM archive.">
         <mkdir dir="${build.dir}"/>
         <property name="nbm.target.cluster" value=""/> <!-- fallback -->
         <property name="license.file.override" value="${license.file}"/>
@@ -444,6 +448,7 @@
                  preferredupdate="${nbm.is.preferredupdate}"
                  usepack200="${use.pack200}"
                  pack200excludes="${pack200.excludes}"
+                 alwayscreatenbm="${nbm.always.create}"
                  targetcluster="${nbm.target.cluster}"
                  releasedate="${nbm.release.date}"
                  moduleauthor="${nbm.module.author}"
@@ -458,6 +463,7 @@
                 </pathfileset>
             </updaterjar>
             <executables refid="module.executable.files"/>
+            <extranbmfiles refid="extra.nbm.files"/>
         </makenbm>
     </target>
 

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -409,11 +409,42 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
     </target>
 
     <target name="-create-license.file" depends="init">
-        <mkdir dir="${build.dir}"/>
-        <property name="license.file.override" location="${build.dir}/license"/>
+        <mkdir dir="${build.dir}/nbm-extras/META-INF"/>
+        <taskdef name="createlicensesummary" classname="org.netbeans.nbbuild.extlibs.CreateLicenseSummary" classpath="${nbantext.jar}"/>
+        <property name="module.name.temp" location="." />
+        <basename property="module.name" file="${module.name.temp}" />
+        <createlicensesummary licenseStub="${nb_all}/LICENSE"
+                              noticeStub="${nb_all}/nbbuild/notice-stub.txt"
+                              nball="${nb_all}"
+                              license="${build.dir}/nbm-extras/META-INF/LICENSE"
+                              notice="${build.dir}/notice-temp"
+                              binary="true"
+                              modules="${module.name}"
+        >
+            <moduleFiles dir="${cluster}">
+                <patternset refid="module.files"/>
+            </moduleFiles>
+        </createlicensesummary>
+
+        <concat destfile="${build.dir}/nbm-extras/META-INF/NOTICE">
+          <fileset file="${build.dir}/notice-temp" />
+          <fileset dir="."
+                   includes="notice.txt" />
+          <filterchain>
+              <tokenfilter>
+                  <filetokenizer />
+                  <replaceregex pattern="(\r?\n)(\r?\n)+"
+                                replace="\1\1"
+                                flags="g" />
+             </tokenfilter>
+          </filterchain>
+        </concat>
+
+        <copy file="${nb_all}/DISCLAIMER" todir="${build.dir}/nbm-extras/META-INF/" />
+        <property name="license.file.override" location="${build.dir}/nbm-extras/META-INF/LICENSE"/>
         <property name="extra.license.files" value=""/>
-        <taskdef name="releasefileslicense" classname="org.netbeans.nbbuild.extlibs.ReleaseFilesLicense" classpath="${nbantext.jar}"/>
-        <releasefileslicense license="${license.file.override}" standardlicense="${nb_all}/nbbuild/standard-nbm-license.txt" extralicensefiles="${extra.license.files}"/>
+        <zipfileset id="extra.nbm.files" dir="${build.dir}/nbm-extras/" />
+        <property name="extra.nbm.files.provided" value=""/>
     </target>
 
     <target name="nbm" depends="-create-dest-dir-nbm,-create-license.file,projectized-common.nbm"/>


### PR DESCRIPTION
… when producing update center from the main checkout, so that it holds the appropriate licenses.

If we'd like to release the update center content, it needs to follow the rules - i.e. have LICENCE/NOTICE/DISCLAIMER, etc.
