### PR TITLE
[NETBEANS-656] Switch docs URL from netbeans.org to netbeans.apache.org.

### DIFF
--- a/utilities/src/org/netbeans/modules/utilities/netbeans-kb.url
+++ b/utilities/src/org/netbeans/modules/utilities/netbeans-kb.url
@@ -1,1 +1,1 @@
-http://www.netbeans.org/kb/index.html
+https://netbeans.apache.org/help/index.html


### PR DESCRIPTION
Docs aren't on netbeans.apache.org yet, but the page on netbeans.apache.org explains that, so pointing to the new correct location is probably a good thing already.