### PR TITLE
#270005: increase the default indexing sleep delay during builds to 15s, and make it configurable

### DIFF
--- a/maven/arch.xml
+++ b/maven/arch.xml
@@ -163,6 +163,12 @@
           section in <code>pom.xml</code> to <em>suppress</em> the JDK libraries.
       </api>
   </p>
+  <p>
+      <api category="devel" group="systemproperty" name="org.netbeans.modules.maven.execute.AbstractOutputHandler.SLEEP_DELAY" type="export">
+          A system property can be used to change the default indexing sleep delay during builds,
+          in case reparsing starts too soon (wasting CPU) or too late (impeding editing).
+      </api>
+  </p>
  </answer>
  
  <answer id="resources-file">

--- a/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
+++ b/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
@@ -66,7 +66,7 @@ public abstract class AbstractOutputHandler {
     private IndexingBridge.Lock protectedMode; // #211005
     private final Object protectedModeLock = new Object();
     private RequestProcessor.Task sleepTask;
-    private static final int SLEEP_DELAY = 5000;
+    private static final int SLEEP_DELAY = Integer.getInteger(AbstractOutputHandler.class.getName() + ".SLEEP_DELAY", 15000); // #270005
 
     protected AbstractOutputHandler(Project proj, final ProgressHandle hand, RunConfig config, OutputVisitor visitor) {
         processors = new HashMap<String, Set<OutputProcessor>>();


### PR DESCRIPTION
Fix for [bug #270005](https://netbeans.org/bugzilla/show_bug.cgi?id=270005). I have been running with this patch for over a year.