### PR TITLE
[NETBEANS-710] Ensure the javac's module system is initialized before…

### DIFF
--- a/java.hints.declarative/nbproject/project.xml
+++ b/java.hints.declarative/nbproject/project.xml
@@ -373,6 +373,10 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     </test-dependency>
                     <test-dependency>

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ClassPathProviderImpl.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/ClassPathProviderImpl.java
@@ -33,10 +33,8 @@ public class ClassPathProviderImpl implements ClassPathProvider {
 
     public ClassPath findClassPath(FileObject file, String type) {
         if ("hint".equals(file.getExt())) {
-            if (ClassPath.BOOT.equals(type)) {
-                return MethodInvocationContext.computeClassPaths()[0];
-            } else if (ClassPath.COMPILE.equals(type)) {
-                return MethodInvocationContext.computeClassPaths()[1];
+            if (ClassPath.COMPILE.equals(type)) {
+                return MethodInvocationContext.computeCompileClassPath();
             }
         }
 

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
@@ -477,6 +477,7 @@ public class DeclarativeHintsParser {
         JavaSource.create(cpInfo).runUserActionTask(new Task<CompilationController>() {
             @SuppressWarnings("fallthrough")
             public void run(CompilationController parameter) throws Exception {
+                parameter.toPhase(JavaSource.Phase.RESOLVED);
                 if (invocation == null || invocation.length() == 0) {
                     //XXX: report an error
                     return ;

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
@@ -75,13 +75,12 @@ public class Hacks {
 
     private static final String SOURCE_LEVEL = "1.8"; //TODO: could be possibly inferred from the current Java platform
 
-    public static Map<String, byte[]> compile(ClassPath boot, ClassPath compile, final String code) throws IOException {
+    public static Map<String, byte[]> compile(ClassPath compile, final String code) throws IOException {
         DiagnosticListener<JavaFileObject> devNull = new DiagnosticListener<JavaFileObject>() {
             public void report(Diagnostic<? extends JavaFileObject> diagnostic) {}
         };
         StandardJavaFileManager sjfm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(devNull, null, null);
 
-        sjfm.setLocation(StandardLocation.PLATFORM_CLASS_PATH, toFiles(boot));
         sjfm.setLocation(StandardLocation.CLASS_PATH, toFiles(compile));
 
         final Map<String, ByteArrayOutputStream> class2BAOS = new HashMap<String, ByteArrayOutputStream>();

--- a/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
+++ b/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
@@ -231,10 +231,8 @@ public class MethodInvocationContext {
 
         code.append("}\n");
 
-        ClassPath[] classpaths = computeClassPaths();
-
         try {
-            final Map<String, byte[]> classes = Hacks.compile(classpaths[0], classpaths[1], code.toString());
+            final Map<String, byte[]> classes = Hacks.compile(computeCompileClassPath(), code.toString());
 
             if (!classes.containsKey("$." + className)) {
                 //presumably an error in the custom code, skip
@@ -271,14 +269,8 @@ public class MethodInvocationContext {
         "import org.netbeans.modules.java.hints.declarative.conditionapi.Variable;"
     };
 
-    static ClassPath[] computeClassPaths() {
-        ClassPath boot = JavaPlatform.getDefault().getBootstrapLibraries();
-        ClassPath compile = ClassPathSupport.createClassPath(apiJarURL());
-
-        return new ClassPath[] {
-            boot,
-            compile
-        };
+    static ClassPath computeCompileClassPath() {
+        return ClassPathSupport.createClassPath(apiJarURL());
     }
 
     public static URL apiJarURL() {

--- a/java.source/test/unit/src/org/netbeans/modules/java/TestJavaPlatformProviderImpl.java
+++ b/java.source/test/unit/src/org/netbeans/modules/java/TestJavaPlatformProviderImpl.java
@@ -31,6 +31,7 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.modules.java.platform.implspi.JavaPlatformProvider;
 import org.netbeans.api.java.platform.Specification;
+import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileStateInvalidException;
@@ -82,24 +83,7 @@ public class TestJavaPlatformProviderImpl implements JavaPlatformProvider {
 
         private static synchronized ClassPath getBootClassPath() {
             if (bootClassPath == null) {
-                String cp = System.getProperty("sun.boot.class.path");
-                List<URL> urls = new ArrayList<>();
-                String[] paths = cp.split(Pattern.quote(System.getProperty("path.separator")));
-                for (String path : paths) {
-                    File f = new File(path);
-
-                    if (!f.canRead())
-                        continue;
-
-                    FileObject fo = FileUtil.toFileObject(f);
-                    if (FileUtil.isArchiveFile(fo)) {
-                        fo = FileUtil.getArchiveRoot(fo);
-                    }
-                    if (fo != null) {
-                        urls.add(fo.toURL());
-                    }
-                }
-                bootClassPath = ClassPathSupport.createClassPath((URL[])urls.toArray(new URL[0]));
+                bootClassPath = BootClassPathUtil.getBootClassPath();
             }
             return bootClassPath;
         }


### PR DESCRIPTION
… constructing scope, fixing DeclarativeHintsParserTest tests on JDK 11 by using the default platform's bootclasspath implicitly rather than explicitly.