### PR TITLE
[NETBEANS-712] Improve label/button alignment in output pane header on Aqua

### DIFF
--- a/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
@@ -569,6 +569,11 @@ final class CloseButtonTabbedPane extends JTabbedPane implements PropertyChangeL
             };
             add(label);
             JButton tabCloseButton = CloseButtonFactory.createCloseButton();
+            if (IS_AQUA_LAF) {
+              // NETBEANS-172: Improve positioning of label and close button within the tab button.
+              setBorder(BorderFactory.createEmptyBorder(1, 0, 0, 0));
+              tabCloseButton.setBorder(BorderFactory.createEmptyBorder(2, 2, 0, 0));
+            }
             tabCloseButton.addActionListener(new ActionListener() {
 
                 @Override


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/NETBEANS-712 ; a screenshot before and after is attached there. Also reported earlier on Bugzilla https://netbeans.org/bugzilla/show_bug.cgi?id=251441 . See also the prior discussion on https://github.com/emilianbold/netbeans-releases/pull/4 (an old pull request from before the incubator-netbeans repo was up and running).