### PR TITLE
[NETBEANS-406] Fix a potential memory leak involving DocumentUtilities.addPropertyChangeListener.

### DIFF
--- a/editor.lib/src/org/netbeans/editor/BaseDocument.java
+++ b/editor.lib/src/org/netbeans/editor/BaseDocument.java
@@ -21,7 +21,6 @@ package org.netbeans.editor;
 
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.beans.VetoableChangeListener;
 import java.io.IOException;
@@ -1826,23 +1825,6 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 
     public @Override void atomicUndo() {
         breakAtomicLock();
-    }
-
-    /**
-     * Remove a PropertyChangeListener that was added via
-     * {@code o.n.lib.editor.util.swing.DocumentUtilities#addPropertyChangeListener(Document,PropertyChangeListener)}.
-     * This method exists so that org.openide.util.WeakListenerImpl can find it by reflection in
-     * case {@code DocumentUtilities#addPropertyChangeListener} was called with a weak listener.
-     * The method is package-private to minimize avoid exposure as a public API. WeakListenerImpl
-     * will still be able to call it, since it calls
-     * {@code java.lang.reflect.Method.setAccessible(true)} first.
-     *
-     * @deprecated do not call directly; this method exists only so it can be found and invoked by
-     *             reflection via org.openide.util.WeakListenerImpl.
-     */
-    @Deprecated
-    void removePropertyChangeListener(PropertyChangeListener l) {
-        org.netbeans.lib.editor.util.swing.DocumentUtilities.removePropertyChangeListener(this, l);
     }
 
     /**

--- a/editor.lib/src/org/netbeans/editor/BaseDocument.java
+++ b/editor.lib/src/org/netbeans/editor/BaseDocument.java
@@ -21,6 +21,7 @@ package org.netbeans.editor;
 
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.beans.VetoableChangeListener;
 import java.io.IOException;
@@ -1825,6 +1826,23 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 
     public @Override void atomicUndo() {
         breakAtomicLock();
+    }
+
+    /**
+     * Remove a PropertyChangeListener that was added via
+     * {@code o.n.lib.editor.util.swing.DocumentUtilities#addPropertyChangeListener(Document,PropertyChangeListener)}.
+     * This method exists so that org.openide.util.WeakListenerImpl can find it by reflection in
+     * case {@code DocumentUtilities#addPropertyChangeListener} was called with a weak listener.
+     * The method is package-private to minimize avoid exposure as a public API. WeakListenerImpl
+     * will still be able to call it, since it calls
+     * {@code java.lang.reflect.Method.setAccessible(true)} first.
+     *
+     * @deprecated do not call directly; this method exists only so it can be found and invoked by
+     *             reflection via org.openide.util.WeakListenerImpl.
+     */
+    @Deprecated
+    void removePropertyChangeListener(PropertyChangeListener l) {
+        org.netbeans.lib.editor.util.swing.DocumentUtilities.removePropertyChangeListener(this, l);
     }
 
     /**

--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -37,6 +37,7 @@ import java.awt.font.TextLayout;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -909,7 +910,12 @@ public final class DocumentViewOp
             Document doc = docView.getDocument();
             updateTextLimitLine(doc);
             clearStatusBits(AVAILABLE_WIDTH_VALID);
-            DocumentUtilities.addPropertyChangeListener(doc, WeakListeners.propertyChange(this, doc));
+            /* DocumentUtilities.addPropertyChangeListener does not work with weak listeners, so add the listener explicitly
+            to the underlying PropertyChangeSupport instead. */
+            PropertyChangeSupport pcs = (PropertyChangeSupport) doc.getProperty(PropertyChangeSupport.class);
+            if(pcs != null) {
+                pcs.addPropertyChangeListener(WeakListeners.propertyChange(this, pcs));
+            }
         }
     }
     

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -972,6 +972,11 @@ public final class DocumentUtilities {
      * @since 1.35
      */
     public static void addPropertyChangeListener(Document doc, PropertyChangeListener l) {
+        /* In case the listener is a weak listener, we have added a package-private
+        BaseDocument.removePropertyChangeListener(PropertyChangeListener) method that can be found
+        and called by org.openide.util.WeakListenerImpl. (In the case that doc is not a
+        BaseDocument, pcs will likely be null here, and so the listener will not be added in the first
+        place.) */
         PropertyChangeSupport pcs = (PropertyChangeSupport) doc.getProperty(PropertyChangeSupport.class);
         if (pcs != null) {
             pcs.addPropertyChangeListener(l);

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -972,11 +972,6 @@ public final class DocumentUtilities {
      * @since 1.35
      */
     public static void addPropertyChangeListener(Document doc, PropertyChangeListener l) {
-        /* In case the listener is a weak listener, we have added a package-private
-        BaseDocument.removePropertyChangeListener(PropertyChangeListener) method that can be found
-        and called by org.openide.util.WeakListenerImpl. (In the case that doc is not a
-        BaseDocument, pcs will likely be null here, and so the listener will not be added in the first
-        place.) */
         PropertyChangeSupport pcs = (PropertyChangeSupport) doc.getProperty(PropertyChangeSupport.class);
         if (pcs != null) {
             pcs.addPropertyChangeListener(l);

--- a/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -966,6 +966,8 @@ public final class DocumentUtilities {
      * <p>Additionally, the list of document properties that clients can listen on
      * is not part of this contract.
      *
+     * <p>Note that this method does <em>not</em> work with {@code WeakListeners}.
+     *
      * @param doc The document to add the listener to.
      * @param l The listener to add to the document.
      *


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/NETBEANS-406 . This fixes the problem underlying the following IDE console warning:

`WARNING [org.openide.util.WeakListenerImpl]: Can't remove java.beans.PropertyChangeListener using method org.netbeans.modules.editor.NbEditorDocument.removePropertyChangeListener from org.netbeans.modules.editor.NbEditorDocument@299b063c, mimeType='text/x-editor-search', kitClass=null, length=9, version=15, file=null`

This was a potential memory leak, though I'm not sure if it had a serious impact or not.