### PR TITLE
Fix @PropertyEditorRegistration to work with inner classes

### DIFF
--- a/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
+++ b/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
@@ -122,7 +122,7 @@ public class NodesAnnotationProcessor extends LayerGeneratingProcessor {
                         
                         @Override
                         public String visitType(TypeMirror t, Object p) {
-                            return t.toString();
+                            return processingEnv.getElementUtils().getBinaryName((TypeElement) processingEnv.getTypeUtils().asElement(t)).toString();
                         }
                     }, null);
                     file.stringvalue("targetType." + i, clsName); //NOI18N

--- a/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
+++ b/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
@@ -35,6 +35,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleAnnotationValueVisitor6;
 import javax.tools.Diagnostic.Kind;
@@ -122,7 +123,10 @@ public class NodesAnnotationProcessor extends LayerGeneratingProcessor {
                         
                         @Override
                         public String visitType(TypeMirror t, Object p) {
-                            return processingEnv.getElementUtils().getBinaryName((TypeElement) processingEnv.getTypeUtils().asElement(t)).toString();
+                            if (t.getKind() == TypeKind.DECLARED) {
+                                return processingEnv.getElementUtils().getBinaryName((TypeElement) processingEnv.getTypeUtils().asElement(t)).toString();
+                            }
+                            return t.toString();
                         }
                     }, null);
                     file.stringvalue("targetType." + i, clsName); //NOI18N

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/CustomData.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/CustomData.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.openide.nodes;
+
+/**
+ *
+ * @author sdedic
+ */
+public class CustomData {
+    public static class Inner {
+        
+    }
+}

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PEAnnotationProcessorTest.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/PEAnnotationProcessorTest.java
@@ -75,6 +75,8 @@ public class PEAnnotationProcessorTest extends NbTestCase {
         assertEquals("org.netbeans.modules.openide.nodes.TestPropertyEditor", pEditor.getClass().getName());
         pEditor = PropertyEditorManager.findEditor(short.class);
         assertEquals("org.netbeans.modules.openide.nodes.TestPropertyEditor", pEditor.getClass().getName());
+        pEditor = PropertyEditorManager.findEditor(CustomData.Inner.class);
+        assertEquals("org.netbeans.modules.openide.nodes.TestPropertyEditor", pEditor.getClass().getName());
     }
     
     public void testClassRegistration() {

--- a/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/TestPropertyEditor.java
+++ b/openide.nodes/test/unit/src/org/netbeans/modules/openide/nodes/TestPropertyEditor.java
@@ -29,7 +29,7 @@ import org.openide.nodes.PropertyEditorRegistration;
  *
  * @author Jan Horvath <jhorvath@netbeans.org>
  */
-@PropertyEditorRegistration(targetType = {Integer.class, Double[].class, byte.class, char[][].class, short.class})
+@PropertyEditorRegistration(targetType = {Integer.class, Double[].class, byte.class, char[][].class, short.class, CustomData.Inner.class})
 public final class TestPropertyEditor implements PropertyEditor {
 
     @Override


### PR DESCRIPTION
I found out that when `targetType` is an inner class, the generated layer registration uses `.` as delimiter between outer and inner class simple names.