### PR TITLE
Avoid failure of 'ant javadoc' for modules that don't have src dir, l…

### DIFF
--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -173,7 +173,7 @@ cause it to fail.
 
     <target name="javadoc-check-timestamps" depends="javadoc-init">
         <uptodate targetfile="${javadoc.out.zip}" property="javadoc.up.to.date">
-            <srcfiles dir="${javadoc.src}">
+            <srcfiles dir="${javadoc.src}" erroronmissingdir="false">
                 <or>
                     <and>
                         <selector refid="${javadoc.files}" />


### PR DESCRIPTION
…ike c.google.guava or net.java.html