### PR TITLE
Calls the model with a correct object and not the newly created tooltip

### DIFF
--- a/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
+++ b/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
@@ -2099,7 +2099,7 @@ public class TreeModelNode extends AbstractNode {
                 String sd = null;
                 try {
                     tooltip.putClientProperty("getShortDescription", object); // NOI18N
-                    Object tooltipObj = model.getValueAt(tooltip, id);
+                    Object tooltipObj = model.getValueAt(object, id);
                     if (tooltipObj != null) {
                         sd = adjustHTML(tooltipObj.toString());
                     }


### PR DESCRIPTION
This is an old bug reported here https://netbeans.org/bugzilla/show_bug.cgi?id=258373 that still exists.