### PR TITLE
added unbound generic type argument to Class in BeanNode and Lib

### DIFF
--- a/openide.nodes/src/org/openide/nodes/BeanNode.java
+++ b/openide.nodes/src/org/openide/nodes/BeanNode.java
@@ -373,7 +373,7 @@ public class BeanNode<T> extends AbstractNode {
     */
     @Override
     public java.awt.Component getCustomizer() {
-        Class clazz = beanInfo.getBeanDescriptor().getCustomizerClass();
+        Class<?> clazz = beanInfo.getBeanDescriptor().getCustomizerClass();
 
         if (clazz == null) {
             return null;

--- a/xml.tax/src/org/netbeans/modules/xml/tax/beans/Lib.java
+++ b/xml.tax/src/org/netbeans/modules/xml/tax/beans/Lib.java
@@ -61,7 +61,7 @@ public class Lib {
 
             return null;
         }
-        Class clazz = beanInfo.getBeanDescriptor().getCustomizerClass();
+        Class<?> clazz = beanInfo.getBeanDescriptor().getCustomizerClass();
         if (clazz == null) {
             return null;
         }


### PR DESCRIPTION
This change has been done in order to avoid compile time warnings.