### PR TITLE
Adds the netbeans.diff.default.compact system property for a more com…

### DIFF
--- a/diff/apichanges.xml
+++ b/diff/apichanges.xml
@@ -91,6 +91,18 @@ is the proper place.
 
   <changes>
   
+    <change id="netbeans_diff_default_compact">
+        <api name="diff"/>
+        <summary>Show compact diff with netbeans.diff.default.compact system property</summary>
+        <version major="1" minor="52"/>
+        <date day="2" month="5" year="2018"/>
+        <author login="emi"/>
+        <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
+        <description>
+            Added the system property netbeans.diff.default.compact which instructs the default DiffControllerProvider to
+            show only the graphical diff (instead of the tabbed pane with the graphical and textual diffs).
+        </description>
+    </change>
     <change id="diff-api">
       <api name="diff"/>
       <summary>The Diff APIs created</summary>

--- a/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProvider.java
+++ b/diff/src/org/netbeans/modules/diff/builtin/DefaultDiffControllerProvider.java
@@ -39,6 +39,9 @@ public class DefaultDiffControllerProvider extends DiffControllerProvider {
 
     @Override
     public DiffControllerImpl createEnhancedDiffController(StreamSource base, StreamSource modified) throws IOException {
+        if (Boolean.getBoolean("netbeans.diff.default.compact")) {
+            return createDiffController(base, modified);
+        }
         return new EditableDiffView(base, modified, true);
     }
 }


### PR DESCRIPTION
…pact diff view that only shows the graphical diff and not the big tabbed pane with the graphical and text diff

This basically gets rid of these tab buttons (as well as the huge border on the macOS LnF) which saves about 45 pixels on my machine, ie. 2 lines of visible code:

<img width="184" alt="graph-text" src="https://user-images.githubusercontent.com/991554/39506564-0b08ddae-4de2-11e8-9523-db2294fd89c6.png">
