### PR TITLE
Sets backgroud color on all the separator panels

### DIFF
--- a/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanel.java
+++ b/git/src/org/netbeans/modules/git/ui/diff/MultiDiffPanel.java
@@ -34,6 +34,7 @@ class MultiDiffPanel extends javax.swing.JPanel {
             setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
             controlToolbar.setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
             jPanel1.setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
+            jPanel2.setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
             jPanel3.setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
             jPanel4.setBackground(UIManager.getColor("NbExplorerView.background")); // NOI18N
             treeSelectionPanel.setBackground(UIManager.getColor("NbExplorerView.background")); //NOI18N


### PR DESCRIPTION
Minor UI panel background problem on macOS:

<img width="514" alt="diff-bad-panel-bg" src="https://user-images.githubusercontent.com/991554/39508438-2e66f160-4deb-11e8-986e-2584ca5d3546.png">

After the fix:

<img width="537" alt="diff-bad-panel-bg-fix" src="https://user-images.githubusercontent.com/991554/39508445-3590d046-4deb-11e8-97e4-517483d8503b.png">

Will commit immediately, created PR just to attach these screenshots for historical reference.
