### PR TITLE
Fix maven output window links for newer versions of Maven

### DIFF
--- a/maven/manifest.mf
+++ b/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.127
+OpenIDE-Module-Specification-Version: 2.128
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false


### PR DESCRIPTION
This patch was already submitted (and IIRC, accepted) in the netbeans.org hg repo, but was applied after the Apache contribution snapshot was made.  Output window stack links for test results have been broken for some time when using multi-module projects with newer versions of Maven.  I've run with these patches for 9 months and observed no problems as a result.