### PR TITLE
[NETBEANS-764] JDK10-LVTI: Skip ConvertToVar hint for compound variable declaration

### DIFF
--- a/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHint.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHint.java
@@ -157,6 +157,10 @@ public class ConvertToVarHint {
             return false;
         }
 
+        // hint is not applicable for compound variable declaration.
+        if (info.getTreeUtilities().isPartOfCompoundVariableDeclaration(treePath.getLeaf()))
+            return false;
+
         //  hint is not applicable for  variable declaration where type is already 'var'
         return !info.getTreeUtilities().isVarType(treePath);
     }

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHintTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHintTest.java
@@ -492,5 +492,38 @@ public class ConvertToVarHintTest {
                         + "    }\n"
                         + "}");
     }
+
+    @Test
+    public void testCompoundVariableDeclStatement() throws Exception {
+        HintTest.create()
+                .input("package test;\n"
+                        + "import java.util.List;\n"
+                        + "public class Test {\n"
+                        + "    void m() {\n"
+                        + "         int i =10,j=20;\n"
+                        + "    }\n"
+                        + "}")
+                .sourceLevel("1.10")
+                .run(ConvertToVarHint.class)
+                .assertNotContainsWarnings(VAR_CONV_DESC);
+
+    }
+
+    @Test
+    public void testCompoundVariableDeclStatement2() throws Exception {
+        HintTest.create()
+                .input("package test;\n"
+                        + "import java.util.List;\n"
+                        + "public class Test {\n"
+                        + "    void m() {\n"
+                        + "        final int /*comment*/l =10/*comment*/,i=20/*comment*/,j=5/*comment*/;\n"
+                        + "    }\n"
+                        + "}")
+                .sourceLevel("1.10")
+                .run(ConvertToVarHint.class)
+                .assertNotContainsWarnings(VAR_CONV_DESC);
+
+    }
+
     
 }

--- a/java.source.base/apichanges.xml
+++ b/java.source.base/apichanges.xml
@@ -62,6 +62,18 @@
         </description>
         <class name="TreeUtilities" package="org.netbeans.api.java.source"/>
     </change>
+    <change id="TreeUtilities.isPartOfCompoundVariableDeclaration">
+        <api name="javasource_base"/>
+        <summary>Check the tree is the end of compound declaration.</summary>
+        <version major="1" minor="2.34"/>
+        <date day="14" month="5" year="2018"/>
+        <author login="arusinha"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"/>
+        <description>
+            Check whether tree is part of compound declaration.
+        </description>
+        <class name="TreeUtilities" package="org.netbeans.api.java.source"/>
+    </change>
     <change id="ElementHandle.createModuleElementHandle">
         <api name="javasource_base"/>
         <summary>Added a method to create an <code>ElementHandle</code> for module</summary>

--- a/java.source.base/nbproject/project.properties
+++ b/java.source.base/nbproject/project.properties
@@ -23,7 +23,7 @@ javadoc.name=Java Source Base
 javadoc.title=Java Source Base
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=2.33.0
+spec.version.base=2.34.0
 test.qa-functional.cp.extra=${refactoring.java.dir}/modules/ext/nb-javac-api.jar
 test.unit.run.cp.extra=${o.n.core.dir}/core/core.jar:\
     ${o.n.core.dir}/lib/boot.jar:\

--- a/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1885,11 +1885,10 @@ public final class TreeUtilities {
  
     /**
      * Checks whether tree is part of compound variable declaration.
-     * {@link Tree}.
      *
-     * @param tree the tree{@link Tree}
-     * @return true if tree is part of compound variable declaration else return
-     * false.
+     * @param tree tree to examine.
+     * @return true if {@code tree} is part of compound var declaration.
+     * @since 2.34.0
      */
     public boolean isPartOfCompoundVariableDeclaration(@NonNull Tree tree) {
         TokenSequence<JavaTokenId> tokenSequence = tokensFor(tree);

--- a/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1883,6 +1883,51 @@ public final class TreeUtilities {
         return false;
     }
  
+    /**
+     * Checks whether tree is part of compound variable declaration.
+     * {@link Tree}.
+     *
+     * @param tree the tree{@link Tree}
+     * @return true if tree is part of compound variable declaration else return
+     * false.
+     */
+    public boolean isPartOfCompoundVariableDeclaration(@NonNull Tree tree) {
+        TokenSequence<JavaTokenId> tokenSequence = tokensFor(tree);
+
+        if (tree.getKind() != Tree.Kind.VARIABLE) {
+            return false;
+        }
+
+        // If tree ends with comma then tree is part of compound variable declaration.
+        tokenSequence.moveEnd();
+        if (tokenSequence.movePrevious() && tokenSequence.token().id() == JavaTokenId.COMMA) {
+            return true;
+        }
+
+        int startPos = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree);
+        tokenSequence.moveStart();
+
+        int tokensLength = 0;
+
+        // To find out the first subtree from compound varaible declaration statement(if any).
+        while (tokenSequence.moveNext()) {
+            tokensLength += tokenSequence.token().length();
+            if (tokenSequence.token().id() == JavaTokenId.IDENTIFIER) {
+
+                Tree path = pathFor(startPos + tokensLength).getLeaf();
+                TokenSequence<JavaTokenId> TokenSeq = tokensFor(path);
+                TokenSeq.moveEnd();
+
+                if (TokenSeq.movePrevious() && TokenSeq.token().id() == JavaTokenId.COMMA) {
+                    return true;
+                }
+                break;
+            }
+        }
+
+        return false;
+    }
+
     private static final class NBScope implements Scope {
 
         private final JavacScope delegate;

--- a/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
@@ -592,4 +592,21 @@ public class TreeUtilitiesTest extends NbTestCase {
         assertFalse(info.getTreeUtilities().isEndOfCompoundVariableDeclaration(bt.getStatements().get(1)));
         assertTrue(info.getTreeUtilities().isEndOfCompoundVariableDeclaration(bt.getStatements().get(2)));
     }
+
+    public void testIsPartOfCompoundVariableDeclaration() throws Exception {
+        prepareTest("Test", "package test; public class Test {public Test(){int i = 10, j = 11; int k = 1;}}");
+
+        //int i = 10
+        VariableTree var1 = (VariableTree) info.getTreeUtilities().pathFor(55).getLeaf();
+        assertTrue(info.getTreeUtilities().isPartOfCompoundVariableDeclaration(var1));
+
+        //int j = 11
+        VariableTree var2 = (VariableTree) info.getTreeUtilities().pathFor(60).getLeaf();
+        assertTrue(info.getTreeUtilities().isPartOfCompoundVariableDeclaration(var2));
+
+        //int k = 1
+        VariableTree var3 = (VariableTree) info.getTreeUtilities().pathFor(71).getLeaf();
+        assertFalse(info.getTreeUtilities().isPartOfCompoundVariableDeclaration(var3));
+
+    }
 }


### PR DESCRIPTION
Jira Id: https://issues.apache.org/jira/browse/NETBEANS-764

For compound variable declaration (e.g.,int i =10, j=20; )

There are two 'Convert to var type' hints displayed , selecting any will convert the declaration at the current cursor position. 

To prevent this from happening ConvertToVar hint will be disabled for compound variable declaration. 