### PR TITLE
[NETBEANS-817] Preventing exceptions when opening project:

### DIFF
--- a/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
+++ b/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
@@ -676,7 +676,7 @@ final class ModuleClassPaths {
                 bestSoFar[1] = Boolean.TRUE;
                 return (List<? extends PathResourceImplementation>) bestSoFar[0];
             }
-            final Collection<File> newModuleInfos = new ArrayDeque<>();
+            final Collection<File> newModuleInfos = new LinkedHashSet<>();
             final List<URL> newActiveProjectSourceRoots = new ArrayList<>();
             collectProjectSourceRoots(systemModules, newActiveProjectSourceRoots);
             collectProjectSourceRoots(userModules, newActiveProjectSourceRoots);
@@ -922,9 +922,9 @@ final class ModuleClassPaths {
                             newModuleInfos
                         });
                     setCache(res);
-                    final Collection<File> added = new ArrayList<>(newModuleInfos);
+                    final Collection<File> added = new LinkedHashSet<>(newModuleInfos);
                     added.removeAll(moduleInfos);
-                    final Collection<File> removed = new ArrayList<>(moduleInfos);
+                    final Collection<File> removed = new LinkedHashSet<>(moduleInfos);
                     removed.removeAll(newModuleInfos);
                     removed.stream().forEach((f) -> FileUtil.removeFileChangeListener(this, f));
                     added.stream().forEach((f) -> FileUtil.addFileChangeListener(this, f));

--- a/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
+++ b/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
@@ -64,6 +64,7 @@ import org.netbeans.modules.java.api.common.TestJavaPlatform;
 import org.netbeans.modules.java.api.common.TestProject;
 import org.netbeans.modules.java.api.common.project.ProjectProperties;
 import org.netbeans.modules.java.j2seplatform.platformdefinition.Util;
+import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
@@ -581,6 +582,25 @@ public class ModuleClassPathsTest extends NbTestCase {
         assertEquals(
                 Collections.singletonList(dist),
                 collectEntries(cp));
+    }
+
+    public void testDuplicateSourceDirsNETBEANS_817() throws Exception {
+        if (systemModules == null) {
+            System.out.println("No jdk 9 home configured.");    //NOI18N
+            return;
+        }
+        assertNotNull(src);
+        final FileObject moduleInfo = createModuleInfo(src, "Modle", "java.logging"); //NOI18N
+        final ClassPath cp = ClassPathFactory.createClassPath(ModuleClassPaths.createModuleInfoBasedPath(
+                systemModules,
+                org.netbeans.spi.java.classpath.support.ClassPathSupport.createProxyClassPath(src, src),
+                systemModules,
+                ClassPath.EMPTY,
+                null,
+                null));
+        final Collection<URL> resURLs = collectEntries(cp);
+        final Collection<URL> expectedURLs = reads(systemModules, NamePredicate.create("java.logging"));  //NOI18N
+        assertEquals(expectedURLs, resURLs);
     }
 
     private static void setSourceLevel(

--- a/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -447,7 +447,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
                     return vote;
                 }
             }
-            final String cmpOptsStr = JavacParser.validateCompilerOptions(compilerOptions.getArguments())
+            final String cmpOptsStr = JavacParser.validateCompilerOptions(compilerOptions.getArguments(), null)
                     .stream()
                     .collect(Collectors.joining(" "));  //NOI18N
             if (JavaIndex.ensureAttributeValue(url, COMPILER_OPTIONS, cmpOptsStr, checkOnly)) {

--- a/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -871,7 +871,7 @@ public class JavacParser extends Parser {
             options.add("-proc:none"); // NOI18N, Disable annotation processors
         }
         if (compilerOptions != null) {
-            for (String compilerOption : validateCompilerOptions(compilerOptions.getArguments())) {
+            for (String compilerOption : validateCompilerOptions(compilerOptions.getArguments(), validatedSourceLevel)) {
                 options.add(compilerOption);
             }
         }
@@ -1029,8 +1029,9 @@ public class JavacParser extends Parser {
     }
 
     @NonNull
-    public static List<? extends String> validateCompilerOptions(@NonNull final List<? extends String> options) {
+    public static List<? extends String> validateCompilerOptions(@NonNull final List<? extends String> options, @NullAllowed com.sun.tools.javac.code.Source sourceLevel) {
         final List<String> res = new ArrayList<>();
+        boolean allowModularOptions = sourceLevel == null || com.sun.tools.javac.code.Source.lookup("9").compareTo(sourceLevel) <= 0;
         boolean xmoduleSeen = false;
         for (int i = 0; i < options.size(); i++) {
             String option = options.get(i);
@@ -1047,12 +1048,13 @@ public class JavacParser extends Parser {
                 xmoduleSeen = true;
             } else if (option.equals("-parameters") || option.startsWith("-Xlint")) {     //NOI18N
                 res.add(option);
-            } else if (
+            } else if ((
                     option.startsWith("--add-modules") ||   //NOI18N
                     option.startsWith("--limit-modules") || //NOI18N
                     option.startsWith("--add-exports") ||   //NOI18N
                     option.startsWith("--add-reads")  ||
-                    option.startsWith(OPTION_PATCH_MODULE)) {
+                    option.startsWith(OPTION_PATCH_MODULE)) &&
+                    allowModularOptions) {
                 int idx = option.indexOf('=');
                 if (idx > 0) {
                    res.add(option);

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -30,7 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -393,7 +395,18 @@ public class JavacParserTest extends NbTestCase {
         
         return JavacParser.validateSourceLevel("1.7", info, false);
     }
-    
+
+    public void testValidateCompilerOptions() {
+        List<String> input = Arrays.asList("--add-exports", "foo/bar=foobar",
+                                           "--add-exports=foo2/bar=foobar",
+                                           "--limit-modules", "foo",
+                                           "--add-modules", "foo",
+                                           "--add-reads", "foo=foo2");
+        assertEquals(Collections.emptyList(), JavacParser.validateCompilerOptions(input, com.sun.tools.javac.code.Source.lookup("1.8")));
+        assertEquals(input, JavacParser.validateCompilerOptions(input, com.sun.tools.javac.code.Source.lookup("9")));
+        assertEquals(input, JavacParser.validateCompilerOptions(input, com.sun.tools.javac.code.Source.lookup("10")));
+    }
+
     private FileObject createFile(String path, String content) throws Exception {
         FileObject file = FileUtil.createData(sourceRoot, path);
         TestUtilities.copyStringToFile(file, content);


### PR DESCRIPTION
-accepting duplicate ClassPath entries with module-infos
-filtering out options that don't match the validated source level

Fixing two problems with the given project - with JDK 10 platform, the sources ClassPath in ModuleClassPaths.ModuleInfoClassPathImplementation has a duplicated entry, leading to having the module-info.java twice in the list of files to which the listener should be added, leading to the reported exception. Proposed fix is to use LinkedHashSet to avoid the duplication. Having duplicated entries in the CP may not be nice, but I suspect it is not reasonable to try to force a constraint that the entries must not be duplicated.

With platform <JDK 10/9, there are multiple problems, but the biggest one is that there are additional compiler options, like --add-reads (auto-injected to make tests work?), but the source level is downgraded below 9, where these options are not allowed and crash with an exception. The proposed (partial) fix is to filter the 9-specific options out when the validated source level < 9.

Any ideas/opinions?
