### PR TITLE
Bringing Editor Hints SPI up-to-date

### DIFF
--- a/spi.editor.hints/apichanges.xml
+++ b/spi.editor.hints/apichanges.xml
@@ -182,7 +182,20 @@ is the proper place.
                  ErrorDescriptionFactory which uses new ErrorDescription constructor.
              </description>
              <issue number="271070"/>
-        </change>        
+        </change>   
+        
+        <change id="fixable-annotation-default-action">
+             <api name="EditorHintsSPI"/>
+             <summary>Provide a way to have fixable annotation with default action</summary>
+             <version major="1" minor="43" subsubminor="0"/>
+             <date day="24" month="7" year="2017"/>
+             <author login="mromashova"/>
+             <compatibility addition="no" binary="compatible" deletion="no" deprecation="no" modification="no" semantic="compatible" source="compatible"/>
+             <description>
+                 For custom type of annotations will dynamically register this annotation type as fixable, so Fix action (click on the icon) will work for it
+             </description>
+             <issue number="271069"/>
+        </change>                    
 
     </changes>
 

--- a/spi.editor.hints/apichanges.xml
+++ b/spi.editor.hints/apichanges.xml
@@ -168,6 +168,21 @@ is the proper place.
              </description>
              <issue number="254375"/>
         </change>
+        
+        <change id="multiple-annotation-type">
+             <api name="EditorHintsSPI"/>
+             <summary>Support multiple ranges for ErrorDescriptor</summary>
+             <version major="1" minor="42" subsubminor="0"/>
+             <date day="17" month="7" year="2017"/>
+             <author login="mromashova"/>
+             <compatibility addition="yes" binary="compatible" deletion="no" deprecation="no" modification="no" semantic="compatible" source="compatible"/>
+             <description>
+                 Added support for multiple ranges for error/warning. New field added to ErrorDescription  as well as corresponding getter method and new constructor 
+                 in order to be able to provide multiple ranges support for highlight  particular hint. Added new factory method to
+                 ErrorDescriptionFactory which uses new ErrorDescription constructor.
+             </description>
+             <issue number="271070"/>
+        </change>        
 
     </changes>
 

--- a/spi.editor.hints/nbproject/project.properties
+++ b/spi.editor.hints/nbproject/project.properties
@@ -18,6 +18,6 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.7
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=1.41.0
+spec.version.base=1.42.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/spi.editor.hints/nbproject/project.properties
+++ b/spi.editor.hints/nbproject/project.properties
@@ -18,6 +18,6 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.7
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=1.42.0
+spec.version.base=1.43.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixAction.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/FixAction.java
@@ -19,6 +19,9 @@
 package org.netbeans.modules.editor.hints;
 
 import java.awt.event.ActionEvent;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.text.JTextComponent;
@@ -34,16 +37,34 @@ import org.openide.windows.TopComponent;
  */
 public class FixAction extends AbstractAction {
     
+    private static final Set<String> fixableAnnotations = new HashSet<>();
+    static {
+        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_err_fixable"); // NOI18N
+        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"); // NOI18N
+        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"); // NOI18N
+        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"); // NOI18N
+    }
+
     public FixAction() {
         putValue(NAME, NbBundle.getMessage(FixAction.class, "NM_FixAction"));
-        putValue("supported-annotation-types", new String[] {
-            "org-netbeans-spi-editor-hints-parser_annotation_err_fixable",
-            "org-netbeans-spi-editor-hints-parser_annotation_warn_fixable",
-            "org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable",
-            "org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"
-        });
     }
-    
+
+    /*package*/ static void addFixableAnnotationType(String fixableAnnotation) {
+        fixableAnnotations.add(fixableAnnotation);
+    }
+
+    /*package*/ static  Set<String> getFixableAnnotationTypes() {
+        return Collections.unmodifiableSet(fixableAnnotations);
+    }
+
+    @Override
+    public Object getValue(String key) {
+        if ("supported-annotation-types".equals(key)) {//NOI18N
+            return fixableAnnotations.toArray(new String[0]);
+        }
+        return super.getValue(key);
+    }
+
     public void actionPerformed(ActionEvent e) {
         if (!HintsUI.getDefault().invokeDefaultAction(true)) {
             Object source = e.getSource();

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsUI.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/HintsUI.java
@@ -26,7 +26,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
@@ -48,11 +47,9 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -130,20 +127,11 @@ public final class HintsUI implements MouseListener, MouseMotionListener, KeyLis
     //-J-Dorg.netbeans.modules.editor.hints.HintsUI.always.show.error=true
     private static final boolean ALWAYS_SHOW_ERROR_MESSAGE = Boolean.getBoolean(HintsUI.class.getName() + ".always.show.error");
     private static HintsUI INSTANCE;
-    private static final Set<String> fixableAnnotations;
     private static final String POPUP_NAME = "hintsPopup"; // NOI18N
     private static final String SUB_POPUP_NAME = "subHintsPopup"; // NOI18N
     private static final int POPUP_VERTICAL_OFFSET = 5;
     private static final RequestProcessor WORKER = new RequestProcessor(HintsUI.class.getName(), 1, false, false);
 
-    static {
-        fixableAnnotations = new HashSet<String>(3);
-
-        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_err_fixable"); // NOI18N
-        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"); // NOI18N
-        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"); // NOI18N
-        fixableAnnotations.add("org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"); // NOI18N
-    }
 
     public static synchronized HintsUI getDefault() {
         if (INSTANCE == null)
@@ -656,7 +644,7 @@ public final class HintsUI implements MouseListener, MouseMotionListener, KeyLis
                         return false;
                     }
                     String type = activeAnnotation.getAnnotationType();
-                    if (!fixableAnnotations.contains(type) && onlyActive) {
+                    if (!FixAction.getFixableAnnotationTypes().contains(type) && onlyActive) {
                         return false;
                     }
                     if (onlyActive) {

--- a/spi.editor.hints/src/org/netbeans/modules/editor/hints/ParseErrorAnnotation.java
+++ b/spi.editor.hints/src/org/netbeans/modules/editor/hints/ParseErrorAnnotation.java
@@ -103,6 +103,10 @@ public class ParseErrorAnnotation extends Annotation implements PropertyChangeLi
                     throw new IllegalArgumentException(String.valueOf(severity));
             }
         } else {
+            if (hasFixes) {
+                //dynamically register this annotation type as fixable, so Fix action (click on the icon) will work for it
+                FixAction.addFixableAnnotationType(customType);
+            }
             return customType;
         }
     }

--- a/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescription.java
+++ b/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescription.java
@@ -19,6 +19,7 @@
 package org.netbeans.spi.editor.hints;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.openide.filesystems.FileObject;
 import org.openide.text.PositionBounds;
@@ -39,6 +40,7 @@ public final class ErrorDescription {
     private final String customType;
     private final LazyFixList fixes;
     private final PositionBounds span;
+    private final ArrayList<PositionBounds> spanTail = new ArrayList<>();
     private final FileObject file;
 
     /**
@@ -53,6 +55,21 @@ public final class ErrorDescription {
         this.customType = null;
         this.fixes       = fixes;
         this.span        = span;
+        this.file        = file;
+    }
+    
+    
+    ErrorDescription(FileObject file, String id, String description, CharSequence details, Severity severity, String customType, LazyFixList fixes, 
+            PositionBounds span, ArrayList<PositionBounds> spanTail) {
+        this.id = id;
+        this.description = description;
+        this.details = details;
+        this.severity    = severity;
+        this.customType = customType;
+        this.fixes       = fixes;
+        this.span        = span;
+        this.spanTail.clear();
+        this.spanTail.addAll(spanTail);
         this.file        = file;
     }
     
@@ -125,6 +142,15 @@ public final class ErrorDescription {
      */
     public PositionBounds getRange() {
         return span;
+    }
+    
+    /**
+     *  Return range tail: to support multiple ranges for error/warning
+     * @return 
+     * @since 1.42
+     */
+    public ArrayList<PositionBounds> getRangeTail() {
+        return spanTail;
     }
 
     /**

--- a/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/AnnotationHolderTest.java
+++ b/spi.editor.hints/test/unit/src/org/netbeans/modules/editor/hints/AnnotationHolderTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.editor.hints;
 
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
@@ -46,11 +47,11 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
-import org.openide.text.Annotation;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
 
 import static org.netbeans.modules.editor.hints.AnnotationHolder.*;
+import org.netbeans.spi.editor.hints.Fix;
 import static org.netbeans.spi.editor.hints.Severity.*;
 
 /**
@@ -82,6 +83,22 @@ public class AnnotationHolderTest extends NbTestCase {
         ec = od.getCookie(EditorCookie.class);
         doc = ec.openDocument();
     }
+    
+    public void testMultiLineErrors() throws Exception {
+        ErrorDescription ed1 = ErrorDescriptionFactory.createErrorDescription(null, Severity.ERROR, "clank-diagnostics-error", "1", null, 
+                ErrorDescriptionFactory.lazyListForFixes(Collections.<Fix>emptyList()), file, new int[] {33 - 30, 55 - 30 - 1}, 
+                new int[] {40 - 30, 58 - 30 -1});
+        ErrorDescription ed2 = ErrorDescriptionFactory.createErrorDescription(null, Severity.WARNING, "clank-diagnostics-warning", "1", null, 
+                ErrorDescriptionFactory.lazyListForFixes(Collections.<Fix>emptyList()), file, new int[] {55 - 30 - 1, 69 - 30 - 2}, 
+                new int[] {58 - 30 - 1, 75 - 30 - 2});
+        
+        List<ErrorDescription> errors = Arrays.asList(ed1, ed2);
+        final OffsetsBag bag = AnnotationHolder.computeHighlights(doc, errors);
+        assertHighlights("",bag, new int[] {33 - 30, 40 - 30, 55 - 30 - 1, 58 - 30 - 1, 69 - 30 -2, 75 - 30 - 2}, 
+                new AttributeSet[] {AnnotationHolder.getColoring(ERROR, doc), 
+                    AnnotationHolder.getColoring(ERROR, doc), 
+                    AnnotationHolder.getColoring(WARNING, doc)});
+    }    
     
     public void testComputeHighlightsOneLayer1() throws Exception {
         ErrorDescription ed1 = ErrorDescriptionFactory.createErrorDescription(Severity.ERROR, "1", file, 1, 3);


### PR DESCRIPTION
Two API changes were developed by Maria since the 1st donation. This pull request back ports them to give us a chance to use proper versioning (#553) for the `spi.editor.hints` module and make sure the 8.2 and dev modules using `spi.editor.hints` can work with upcoming Apache NetBeans 9.0.

This change should be merged to both - `master` as well as `release90` - branches.