### PR TITLE
Optimize readability of the NOTICE file

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1559,8 +1559,8 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
           <filterchain>
               <tokenfilter>
                   <filetokenizer />
-                  <replaceregex pattern="(\r?\n)(\r?\n)+"
-                                replace="\1\1"
+                  <replaceregex pattern="(\r?\n)(\r?\n)(\r?\n)+"
+                                replace="\1\1\1"
                                 flags="g" />
              </tokenfilter>
           </filterchain>

--- a/nbbuild/notice-stub.txt
+++ b/nbbuild/notice-stub.txt
@@ -11,3 +11,4 @@ The code was Copyright 1997-2016 Oracle and/or its affiliates.  The Initial
 Developer of the Original Software was Sun Microsystems, Inc. Portions
 Copyright 1997-2006 Sun Microsystems, Inc.
 
+


### PR DESCRIPTION
While looking into NETBEANS-827 it was found, that the NOTICE file is
difficult to read, as no clear sections were visible.

This adjust the output as such, that:

- the primary header is separated from the following entries by
  two empty lines
- all imported entries are normalized, so that multiple empty lines
  are collapsed into one empty line
- all imported entries are separated from each other by two empty
  lines

To illustrate here are the pre- and post picture:

[notice-pre.txt](https://github.com/apache/incubator-netbeans/files/2040691/notice-pre.txt)
[notice-post.txt](https://github.com/apache/incubator-netbeans/files/2040690/notice-post.txt)

I tried to see what NETBEANS-827 is about and at first I did not even find the entry. The corresponding entry is:

> Apache Commons Net
> Copyright 2001-2017 The Apache Software Foundation

From my interpretation of the legal FAQ this is the correct form, but in the "pre" version is difficult to find.