### PR TITLE
[NETBEANS-829] Add notice file for ini4j

### DIFF
--- a/libs.ini4j/external/ini4j-0.5.1-notice.txt
+++ b/libs.ini4j/external/ini4j-0.5.1-notice.txt
@@ -1,0 +1,2 @@
+[ini4j]
+Copyright 2005,2009 Ivan SZKIBA


### PR DESCRIPTION
The ini4j distribution on netbeans is missing the notice file. The contents
was extracted from the subversion tag for ini4j version 0.5.1:

https://sourceforge.net/p/ini4j/code/HEAD/tree/tags/ini4j-0.5.1/NOTICE.txt

The ALv2 license was removed, as it is not considered to be part of the
"attribution" notice. The product name was added as a header to make
the notice attributable in the merged NOTICE file.