### PR TITLE
[NetBeans-778] Formatting issue with var declaration statement

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1200,10 +1200,10 @@ public class Reformatter implements ReformatTask {
                         if (node.getType() != null) {
                             spaces(1, fieldGroup);
                         }else {
-                            if(tokens.token().id() == JavaTokenId.VAR){
-                               //Add space after 'var' token
-                               addDiff(new Diff(tokens.offset() + 3, tokens.offset() + 3, " "));
-                               tokens.moveNext();
+                            if (tokens.token().id() == JavaTokenId.VAR) {
+                                //Add space after 'var' token
+                                addDiff(new Diff(tokens.offset() + 3, tokens.offset() + 3, " "));
+                                tokens.moveNext();
                             }
                         }
                         if (!ERROR.contentEquals(node.getName()))

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1199,7 +1199,7 @@ public class Reformatter implements ReformatTask {
                     if (node.getType() == null || scan(node.getType(), p)) {
                         if (node.getType() != null) {
                             spaces(1, fieldGroup);
-                        }else {
+                        } else {
                             if (tokens.token().id() == JavaTokenId.VAR) {
                                 //Add space after 'var' token
                                 addDiff(new Diff(tokens.offset() + 3, tokens.offset() + 3, " "));

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1196,8 +1196,8 @@ public class Reformatter implements ReformatTask {
                 } else {
                     if (!insideForTryOrCatch)
                         continuationIndent = true;
-                    if (node.getType() == null || scan(node.getType(), p)) {
-                        if (node.getType() != null) {
+                    if (node.getType() == null || tokens.token().id() == JavaTokenId.VAR || scan(node.getType(), p)) {
+                        if (node.getType() != null && tokens.token().id() != JavaTokenId.VAR) {
                             spaces(1, fieldGroup);
                         } else {
                             if (tokens.token().id() == JavaTokenId.VAR) {

--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1199,6 +1199,12 @@ public class Reformatter implements ReformatTask {
                     if (node.getType() == null || scan(node.getType(), p)) {
                         if (node.getType() != null) {
                             spaces(1, fieldGroup);
+                        }else {
+                            if(tokens.token().id() == JavaTokenId.VAR){
+                               //Add space after 'var' token
+                               addDiff(new Diff(tokens.offset() + 3, tokens.offset() + 3, " "));
+                               tokens.moveNext();
+                            }
                         }
                         if (!ERROR.contentEquals(node.getName()))
                             accept(IDENTIFIER, UNDERSCORE);

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -4462,19 +4462,19 @@ public class FormatingTest extends NbTestCase {
         TestUtilities.copyStringToFile(testFile, "");
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
-        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
-        String content =
-                "package hierbas.del.litoral;\n\n"
+        String content
+                = "package hierbas.del.litoral;\n\n"
                 + "public class Test {\n\n"
                 + "    public static void main(String[] args) {\n"
                 + "            var    v    =   10; \n"
                 + "    }\n"
                 + "}\n";
 
-        String golden =
-                "package hierbas.del.litoral;\n\n"
+        String golden
+                = "package hierbas.del.litoral;\n\n"
                 + "public class Test {\n\n"
                 + "    public static void main(String[] args) {\n"
                 + "        var v = 10;\n"
@@ -4488,19 +4488,19 @@ public class FormatingTest extends NbTestCase {
         TestUtilities.copyStringToFile(testFile, "");
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
-        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
-        String content =
-                "package hierbas.del.litoral;\n\n"
+        String content
+                = "package hierbas.del.litoral;\n\n"
                 + "public class Test {\n\n"
                 + "    public static void main(String[] args) {\n"
                 + "           final   var    v    =   10; \n"
                 + "    }\n"
                 + "}\n";
 
-        String golden =
-                "package hierbas.del.litoral;\n\n"
+        String golden
+                = "package hierbas.del.litoral;\n\n"
                 + "public class Test {\n\n"
                 + "    public static void main(String[] args) {\n"
                 + "        final var v = 10;\n"

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -4457,6 +4457,58 @@ public class FormatingTest extends NbTestCase {
         reformat(doc, content, golden);
     }
 
+    public void testForVar1() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "            var    v    =   10; \n"
+                + "    }\n"
+                + "}\n";
+
+        String golden =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        var v = 10;\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
+    public void testForVar2() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "           final   var    v    =   10; \n"
+                + "    }\n"
+                + "}\n";
+
+        String golden =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        final var v = 10;\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
     private void reformat(Document doc, String content, String golden) throws Exception {
         reformat(doc, content, golden, 0, content.length());
     }

--- a/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -4463,6 +4463,8 @@ public class FormatingTest extends NbTestCase {
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
         EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        String oldLevel = JavaSourceTest.SourceLevelQueryImpl.sourceLevel;
+        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = "1.10";
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
         String content
@@ -4481,6 +4483,7 @@ public class FormatingTest extends NbTestCase {
                 + "    }\n"
                 + "}\n";
         reformat(doc, content, golden);
+        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = oldLevel;
     }
 
     public void testForVar2() throws Exception {
@@ -4489,6 +4492,8 @@ public class FormatingTest extends NbTestCase {
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
         EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        String oldLevel = JavaSourceTest.SourceLevelQueryImpl.sourceLevel;
+        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = "1.10";
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
         String content
@@ -4507,6 +4512,7 @@ public class FormatingTest extends NbTestCase {
                 + "    }\n"
                 + "}\n";
         reformat(doc, content, golden);
+        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = oldLevel;
     }
 
     private void reformat(Document doc, String content, String golden) throws Exception {


### PR DESCRIPTION
Jira Id : https://issues.apache.org/jira/browse/NETBEANS-778

Issue details:

Before Formatting:

{                 final[extra space ]int[extra space ] i[extra space ] = 0;   
                                final[extra space ]var[extra space ]v[extra space ]  = 0; 
}

 

After Formatting (ALT+SHIFT+F):

{      final int i = 0;    
       final[extra space ]var[extra space ]v [extra space ] = 0; 
}