### PR TITLE
lib.nbjavac: Fix type change for Java 11

### DIFF
--- a/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMessager.java
+++ b/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBMessager.java
@@ -18,9 +18,9 @@
  */
 package org.netbeans.lib.nbjavac.services;
 
+import com.sun.javadoc.SourcePosition;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javadoc.main.Messager;
 import java.io.PrintWriter;
@@ -79,7 +79,7 @@ public final class NBMessager extends Messager {
 
     @Override
     public void error(
-            final DiagnosticPosition pos,
+            final SourcePosition pos,
             final String key,
             final Object ... args) {
         if (ERR_NOT_IN_PROFILE.equals(key)) {


### PR DESCRIPTION
Fixes the following issue

```java
src/org/netbeans/lib/nbjavac/services/NBMessager.java:80:
error: method does not override or implement a method from a supertype
    @Override
    ^
src/org/netbeans/lib/nbjavac/services/NBMessager.java:98:
error: no suitable method found for error(DiagnosticPosition,String,Object[])
        super.error(pos, key, args);
```