### PR TITLE
java.source.base: Fix for Java 11, update args, swap import

### DIFF
--- a/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -424,7 +424,7 @@ public class SourceUtils {
                 importScope.prependSubScope(((PackageSymbol)toImport).members());
                 unit.starImportScope = importScope;
             } else {
-                NamedImportScope importScope = new NamedImportScope(unit.packge, unit.toplevelScope);
+                NamedImportScope importScope = new NamedImportScope(unit.packge);
                 for (Symbol symbol : unit.namedImportScope.getSymbols()) {
                     importScope.importType(symbol.owner.members(), symbol.owner.members(), symbol);
                 }

--- a/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -21,10 +21,10 @@ package org.netbeans.modules.java.source;
 import java.lang.reflect.Field;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jdk.internal.misc.Unsafe;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.openide.modules.OnStart;
-import sun.misc.Unsafe;
 
 /**
  *


### PR DESCRIPTION
Fixes the following issues

```java
src/org/netbeans/api/java/source/SourceUtils.java:427:
error: constructor NamedImportScope in class NamedImportScope cannot be applied to given types;
                NamedImportScope importScope = new NamedImportScope(unit.packge, unit.toplevelScope);
                                               ^
  required: Symbol
  found: PackageSymbol,WriteableScope
  reason: actual and formal argument lists differ in length

src/org/netbeans/modules/java/source/NoJavacHelper.java:69:
error: cannot find symbol
               unsafe.defineClass("com.sun.tools.javac.code.Scope$WriteableScope", classData, 0, classData.length, scopeClass.getClassLoader(), scopeClass.getProtectionDomain());
                          ^
  symbol:   method defineClass(String,byte[],int,int,ClassLoader,ProtectionDomain)
  location: variable unsafe of type Unsafe
```