### PR TITLE
Snap changes for 9.0

### DIFF
--- a/nbbuild/packaging/snap/gui/netbeans.desktop
+++ b/nbbuild/packaging/snap/gui/netbeans.desktop
@@ -17,7 +17,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=NetBeans Dev
+Name=Apache NetBeans 9.0
 Comment=The Smarter Way to Code
 Exec=netbeans %F
 Categories=Application;Development;Java;IDE

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 name: netbeans
-version: "9.0-dev"
-summary: NetBeans Java IDE
+version: "9.0"
+summary: Apache NetBeans IDE
 description: |
   NetBeans IDE lets you quickly and easily develop Java desktop, mobile, and 
   web applications, as well as HTML5 applications with HTML, JavaScript, and


### PR DESCRIPTION
Changed Snap package descriptors for NetBeans 9.0 release. 
I've decided not to include release quality specifier in these files as snap has it's own revision handling and and the branding is going to include the necessary things. So this way is just one less thing to worry about.
BTW this PR shall go to release90 only.