### PR TITLE
Modify the JavaScript script to work with GraalVM 1.0.0-rc1

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1029,11 +1029,11 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
    >
     <script language="javascript">
         v = ''
-        i = new java.util.TreeMap(project.properties).entrySet().iterator()
+        i = new Packages.java.util.TreeMap(project.getProperties()).entrySet().iterator()
         while (i.hasNext()) {
             e = i.next()
-            if (e.key.startsWith('tryme.arg.')) {
-                v += ' ' + e.value
+            if (e.getKey().startsWith('tryme.arg.')) {
+                v += ' ' + e.getValue()
             }
         }
         project.setNewProperty('tryme.args', v)


### PR DESCRIPTION
I am trying to use NetBeans with [GraalVM](http://graalvm.org). Right now executing the Ant script doesn't work:
```bash
incubator-netbeans$ JAVA_HOME=~/bin/graalvm-1.0.0-rc1/ ant tryme -Dtryme.arg.netbeans.close=-J-Dnetbeans.close=true
```
with following patch the IDE starts and shutdowns without an error on GraalVM 1.0.0rc1 as well as official JDK8. CC @woess