### PR TITLE
[NETBEANS-953] Profiling jdk10 remote target missing conditional branch

### DIFF
--- a/lib.profiler.common/src/org/netbeans/lib/profiler/common/integration/IntegrationUtils.java
+++ b/lib.profiler.common/src/org/netbeans/lib/profiler/common/integration/IntegrationUtils.java
@@ -249,6 +249,8 @@ public class IntegrationUtils {
             return PLATFORM_JAVA_90;
         } else if (javaVersionString.equals(CommonConstants.JDK_CVM_STRING)) {
             return PLATFORM_JAVA_CVM;
+        } else if (javaVersionString.equals(CommonConstants.JDK_110_BEYOND_STRING)) {
+            return PLATFORM_JAVA_110_BEYOND;
         }
         return null;
     }


### PR DESCRIPTION
Jdk10 as remote target seems not to be supported when profiling in netbeans9