### PR TITLE
[NETBEANS-892] Fix lambda expr and multi catch rewrite issues

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -1452,11 +1452,13 @@ public class CasualDiff {
                 localPointer = oldT.pos;
                 printer.suppressVariableType = suppressParameterTypes;
                 int l = printer.out.length();
-                printer.print(newT.vartype);
-                printer.suppressVariableType = false;
-                if (l < printer.out.length()) {
-                    printer.print(" ");
+                if (!suppressParameterTypes) {
+                    printer.print(newT.vartype);
+                    if (l < printer.out.length()) {
+                        printer.print(" ");
+                    }
                 }
+                printer.suppressVariableType = false;
             }
         } else {
             if (suppressParameterTypes) {
@@ -3760,7 +3762,8 @@ public class CasualDiff {
 
     protected int diffUnionType(JCTypeUnion oldT, JCTypeUnion newT, int[] bounds) {
         int localPointer = bounds[0];
-        return diffParameterList(oldT.alternatives, newT.alternatives, null, localPointer, Measure.MEMBER, diffContext.style.spaceAroundBinaryOps(), diffContext.style.spaceAroundBinaryOps(), false, "|");
+        int pos = diffParameterList(oldT.alternatives, newT.alternatives, null, localPointer, Measure.MEMBER, diffContext.style.spaceAroundBinaryOps(), diffContext.style.spaceAroundBinaryOps(), false, "|");
+        return Math.min(pos, bounds[1]);
     }
 
     private boolean commaNeeded(ResultItem[] arr, ResultItem item) {

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
@@ -80,7 +80,7 @@ public class MoveClassTest extends MoveBase {
                 + "import java.util.List;\n"
                 + "import java.util.function.Function;\n"
                 + "public class A {\n"
-                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void v() {try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}}\n"
                 + "public void breaks(){doStuff(x->x.substring(5));}\n"
                 + "public void doStuff(Function<String, String> stuff){}\n"
                 + "}\n"),
@@ -89,12 +89,12 @@ public class MoveClassTest extends MoveBase {
                 + "/** Class B */\n"
                 + "public class B {\n"
                 + "    public int i = 42;\n"
-                + "    private List lijst;\n"
+                + "    private List list;\n"
                 + "}\n"),
                 new File("a/C.java", "package a;\n"
                 + "import java.util.function.Function;\n"
                 + "public class C {\n"
-                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void v() {try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}}\n"
                 + "public void breaks(){doStuff(x->x.substring(5));}\n"
                 + "public void doStuff(Function<String, String> stuff){}\n"
                 + "}\n"));
@@ -104,7 +104,7 @@ public class MoveClassTest extends MoveBase {
                 + "import java.util.List;\n"
                 + "import java.util.function.Function;\n"
                 + "public class A {\n"
-                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void v() {try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}}\n"
                 + "public void breaks(){doStuff(x->x.substring(5));}\n"
                 + "public void doStuff(Function<String, String> stuff){}\n"
                 + "}\n"),
@@ -112,13 +112,13 @@ public class MoveClassTest extends MoveBase {
                 + "import java.util.List;\n"
                 + "import java.util.function.Function;\n"
                 + "public class C {\n"
-                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void v() {try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}}\n"
                 + "public void breaks(){doStuff(x->x.substring(5));}\n"
                 + "public void doStuff(Function<String, String> stuff){}\n"
                 + "/** Class B */\n"
                 + "public static class B {\n"
                 + "    public int i = 42;\n"
-                + "    private List lijst;\n"
+                + "    private List list;\n"
                 + "}\n"
                 + "}\n"));
     }

--- a/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
+++ b/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/MoveClassTest.java
@@ -74,6 +74,55 @@ public class MoveClassTest extends MoveBase {
                 + "}\n"));
     }
     
+    public void testNETBEANS892() throws Exception { // #204444 - Improve Move Refactoring to support nested/inner classes
+        writeFilesAndWaitForScan(src,
+                new File("a/A.java", "package a;\n"
+                + "import java.util.List;\n"
+                + "import java.util.function.Function;\n"
+                + "public class A {\n"
+                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void breaks(){doStuff(x->x.substring(5));}\n"
+                + "public void doStuff(Function<String, String> stuff){}\n"
+                + "}\n"),
+                new File("a/B.java", "package a;\n"
+                + "import java.util.List;\n"
+                + "/** Class B */\n"
+                + "public class B {\n"
+                + "    public int i = 42;\n"
+                + "    private List lijst;\n"
+                + "}\n"),
+                new File("a/C.java", "package a;\n"
+                + "import java.util.function.Function;\n"
+                + "public class C {\n"
+                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void breaks(){doStuff(x->x.substring(5));}\n"
+                + "public void doStuff(Function<String, String> stuff){}\n"
+                + "}\n"));
+        performMove(src.getFileObject("a/B.java"), 0, src.getFileObject("a/C.java"), 0);
+        verifyContent(src,
+                new File("a/A.java", "package a;\n"                
+                + "import java.util.List;\n"
+                + "import java.util.function.Function;\n"
+                + "public class A {\n"
+                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void breaks(){doStuff(x->x.substring(5));}\n"
+                + "public void doStuff(Function<String, String> stuff){}\n"
+                + "}\n"),
+                new File("a/C.java", "package a;\n"
+                + "import java.util.List;\n"
+                + "import java.util.function.Function;\n"
+                + "public class C {\n"
+                + "try{String bar = \"foo\";}catch (RuntimeException | AssertionError e){}\n"
+                + "public void breaks(){doStuff(x->x.substring(5));}\n"
+                + "public void doStuff(Function<String, String> stuff){}\n"
+                + "/** Class B */\n"
+                + "public static class B {\n"
+                + "    public int i = 42;\n"
+                + "    private List lijst;\n"
+                + "}\n"
+                + "}\n"));
+    }
+    
     public void test243552() throws Exception { // #204444 - Improve Move Refactoring to support nested/inner classes
         writeFilesAndWaitForScan(src,
                 new File("t/A.java", "package t;\n"


### PR DESCRIPTION
Fixed the two compilation issues after refactor : 

catch (RuntimeException | AssertionError e){
getting converted to
catch (RuntimeException | AssertionErrore){

and

doStuff(item-> item.substring(20));
getting converted to
doStuff(String item-> item.substring(20));

(Lambda issue is reproducible in IDE but not with move test below, as param type is coming as ERROR. Need to investigate this.)