### PR TITLE
[NETBEANS-860] Hints: Convert Lambda to Use 'var' Parameter Types

### DIFF
--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/LambdaTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/LambdaTest.java
@@ -552,6 +552,58 @@ public class LambdaTest {
                                       "}\n");
     }
 
+    //Todo: Verification is pending on nb-javac of JDK11
+    @Test
+    public void testImplicitVarParameterTypes1() throws Exception {
+        HintTest.create()
+                .setCaretMarker('^')
+                .input("package test;\n" +
+                       "import java.util.function.IntBinaryOperator;\n" +
+                       "public class Test {\n" +
+                       "    public void main(String list) {\n" +
+                       "        IntBinaryOperator calc3 = (int x, int y)^ ->  x + y;\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("1.11")
+                .run(Lambda.class)
+                .findWarning("4:48-4:48:verifier:ERR_addImplicitVarLambdaParameters")
+                .applyFix()
+                .assertCompilable()
+                .assertVerbatimOutput("package test;\n" +
+                                      "import java.util.function.IntBinaryOperator;\n" +
+                                      "public class Test {\n" +
+                                      "    public void main(List<String> list) {\n" +
+                                      "        IntBinaryOperator calc3 = (var x, var y) ->  x + y;\n" +
+                                      "    }\n" +
+                                      "}\n");
+    }
+
+    //Todo: Verification is pending on nb-javac of JDK11
+    @Test
+    public void testImplicitVarParameterTypes2() throws Exception {
+        HintTest.create()
+                .setCaretMarker('^')
+                .input("package test;\n" +
+                       "import java.util.function.IntBinaryOperator;\n" +
+                       "public class Test {\n" +
+                       "    public void main(String list) {\n" +
+                       "        IntBinaryOperator calc3 = (x, y)^ ->  x + y;\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("1.11")
+                .run(Lambda.class)
+                .findWarning("4:48-4:48:verifier:ERR_addImplicitVarLambdaParameters")
+                .applyFix()
+                .assertCompilable()
+                .assertVerbatimOutput("package test;\n" +
+                                      "import java.util.function.IntBinaryOperator;\n" +
+                                      "public class Test {\n" +
+                                      "    public void main(List<String> list) {\n" +
+                                      "        IntBinaryOperator calc3 = (var x, var y) ->  x + y;\n" +
+                                      "    }\n" +
+                                      "}\n");
+    }
+
     static {
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }


### PR DESCRIPTION
Hint "Use var Parameter Types" should be enable for below expressions. 

IntBinaryOperator calc=  (int x, int y) -> x + y;
 IntBinaryOperator calc=  (x, y) -> x + y;
Proposed fix : 
IntBinaryOperator calc = (var x, var y) -> x + y;

Note: This hintsfor homogeneous explicit and implicit parameter types.
        Todo: 
        1. Test cases will verify when nb-javac for JDK11 will available.
        2. Will provide the hints for error scenario (invalid lambda parameter declaration)