### PR TITLE
[NETBEANS-977] Improve text layout in word wrap mode.

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -25,7 +25,6 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Composite;
-import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -71,7 +70,6 @@ import javax.swing.JViewport;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.TransferHandler;
-import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -87,7 +85,6 @@ import javax.swing.text.JTextComponent;
 import javax.swing.text.NavigationFilter;
 import javax.swing.text.Position;
 import javax.swing.text.StyleConstants;
-import javax.swing.text.Utilities;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
@@ -1028,21 +1025,17 @@ public final class EditorCaret implements Caret {
      * For that, the nearest update must reposition scroller's viewrect so that the 
      * recomputed caretBounds is at the same
      */
-    private synchronized void maybeSaveCaretOffset(JTextComponent c, Rectangle cbounds) {
-        if (c.getClientProperty("editorcaret.updateRetainsVisibleOnce")  == null || // NOI18N
+    private synchronized void maybeSaveCaretOffset(Rectangle cbounds) {
+        if (component.getClientProperty("editorcaret.updateRetainsVisibleOnce")  == null || // NOI18N
             lastCaretVisualOffset != -1) {
            return; 
         }
-        Component parent = c.getParent();
         Rectangle editorRect;
-        if (parent instanceof JLayeredPane) {
-            parent = parent.getParent();
-        }
-        if (parent instanceof JViewport) {
-            final JViewport viewport = (JViewport) parent;
+        final JViewport viewport = getViewport();
+        if (viewport != null) {
             editorRect = viewport.getViewRect();
         } else {
-            Dimension size = c.getSize();
+            Dimension size = component.getSize();
             editorRect = new Rectangle(0, 0, size.width, size.height);
         }
         if (cbounds.y >= editorRect.y && cbounds.y < (editorRect.y + editorRect.height)) {
@@ -1059,7 +1052,7 @@ public final class EditorCaret implements Caret {
 
     @Override
     public void paint(Graphics g) {
-        JTextComponent c = component;
+        final JTextComponent c = component;
         if (c == null || !isShowing()) {
             return;
         }
@@ -1109,7 +1102,7 @@ public final class EditorCaret implements Caret {
                         Rectangle newCaretBounds = lvh.modelToViewBounds(dot, Position.Bias.Forward);
                         Rectangle oldBounds = caretItem.setCaretBoundsWithRepaint(newCaretBounds, c, "EditorCaret.paint()", i);
                         if (caretItem == lastCaret && oldBounds != null) {
-                            maybeSaveCaretOffset(c, oldBounds);
+                            maybeSaveCaretOffset(oldBounds);
                         }
                     }
                     Rectangle caretBounds = caretItem.getCaretBounds();
@@ -1956,6 +1949,26 @@ public final class EditorCaret implements Caret {
      */
     private int lastCaretVisualOffset = -1;
 
+    private boolean isWrapping() {
+        // See o.n.modules.editor.lib2.view.DocumentViewOp.updateLineWrapType().
+        Object lwt = null;
+        if (component != null) {
+            lwt = component.getClientProperty(SimpleValueNames.TEXT_LINE_WRAP);
+            if (lwt == null) {
+                lwt = component.getDocument().getProperty(SimpleValueNames.TEXT_LINE_WRAP);
+            }
+        }
+        return (lwt instanceof String) && !"none".equals(lwt);
+    }
+
+    private JViewport getViewport() {
+        Component parent = component.getParent();
+        if (parent instanceof JLayeredPane) {
+            parent = parent.getParent();
+        }
+        return (parent instanceof JViewport) ? (JViewport) parent : null;
+    }
+
     /**
      * Update the caret's visual position.
      * <br>
@@ -1973,13 +1986,9 @@ public final class EditorCaret implements Caret {
         if (c != null) {
             boolean forceUpdate = c.getClientProperty("editorcaret.updateRetainsVisibleOnce") != null;
             boolean log = LOG.isLoggable(Level.FINE);
-            Component parent = c.getParent();
             Rectangle editorRect;
-            if (parent instanceof JLayeredPane) {
-                parent = parent.getParent();
-            }
-            if (parent instanceof JViewport) {
-                final JViewport viewport = (JViewport) parent;
+            final JViewport viewport = getViewport();
+            if (viewport != null) {
                 editorRect = viewport.getViewRect();
             } else {
                 Dimension size = c.getSize();
@@ -1989,7 +1998,7 @@ public final class EditorCaret implements Caret {
                 Rectangle cbounds = getLastCaretItem().getCaretBounds();
                 if (cbounds != null) {
                     // save relative position of the main caret
-                    maybeSaveCaretOffset(c, cbounds);
+                    maybeSaveCaretOffset(cbounds);
                 }
             }
             if (!calledFromPaint && !c.isValid() /* && maintainVisible == null */) {
@@ -2028,27 +2037,40 @@ public final class EditorCaret implements Caret {
                         }
                         if (caretBounds != null) {
                             Rectangle scrollBounds = new Rectangle(caretBounds); // Must possibly be cloned upon change
+                            if (viewport != null && isWrapping()) {
+                                /* When wrapping, only scroll to the right if the caret is
+                                decisively outside the wrapped area (e.g. on a very long unbreakable
+                                word). Otherwise, always scroll back to the left. When typing such
+                                that the caret goes from the end of one wrap line to the next, the
+                                new caret position might be one or more characters away from the
+                                first character on the wrap line, so a regular
+                                scroll-to-make-the-caret-visible would not do the job. */
+                                if (scrollBounds.x <= viewport.getExtentSize().width) {
+                                    scrollBounds.x = 0;
+                                    scrollBounds.width = 1;
+                                    /* Avoid generating a drag-select as a result of the viewport
+                                    being automatically scrolled back to x=0 as a result of the user
+                                    clicking once to move the caret. */
+                                    if (viewport.getViewPosition().x > 0 && getDot() == getMark()) {
+                                        mouseState = MouseState.DEFAULT;
+                                    }
+                                }
+                            }
                             // Only scroll the view for the LAST caret to be visible
                             // For null old bounds (likely at begining of component displayment) ensure that a possible
                             // horizontal scrollbar would not hide the caret so enlarge the scroll bounds by hscrollbar height.
-                            if (oldCaretBounds == null) {
-                                Component viewport = c.getParent();
-                                if (viewport instanceof JLayeredPane) {
-                                    viewport = viewport.getParent();
-                                }
-                                if (viewport instanceof JViewport) {
-                                    Component scrollPane = viewport.getParent();
-                                    if (scrollPane instanceof JScrollPane) {
-                                        JScrollBar hScrollBar = ((JScrollPane) scrollPane).getHorizontalScrollBar();
-                                        if (hScrollBar != null) {
-                                            int hScrollBarHeight = hScrollBar.getPreferredSize().height;
-                                            Dimension extentSize = ((JViewport) viewport).getExtentSize();
-                                            // If the extent size is high enough then extend
-                                            // the scroll region by extra vertical space
-                                            if (extentSize.height >= caretBounds.height + hScrollBarHeight) {
-                                                scrollBounds = new Rectangle(scrollBounds); // Clone
-                                                scrollBounds.height += hScrollBarHeight;
-                                            }
+                            if (oldCaretBounds == null && viewport != null) {
+                                Component scrollPane = viewport.getParent();
+                                if (scrollPane instanceof JScrollPane) {
+                                    JScrollBar hScrollBar = ((JScrollPane) scrollPane).getHorizontalScrollBar();
+                                    if (hScrollBar != null) {
+                                        int hScrollBarHeight = hScrollBar.getPreferredSize().height;
+                                        Dimension extentSize = ((JViewport) viewport).getExtentSize();
+                                        // If the extent size is high enough then extend
+                                        // the scroll region by extra vertical space
+                                        if (extentSize.height >= caretBounds.height + hScrollBarHeight) {
+                                            scrollBounds = new Rectangle(scrollBounds); // Clone
+                                            scrollBounds.height += hScrollBarHeight;
                                         }
                                     }
                                 }
@@ -2586,12 +2608,9 @@ public final class EditorCaret implements Caret {
                 // and if it's fired the caret's bounds will be checked whether
                 // they intersect with the horizontal scrollbar
                 // and if so the view will be scrolled.
-                Container parent = component.getParent();
-                if(parent instanceof JLayeredPane) {
-                    parent = parent.getParent();
-                }
-                if (parent instanceof JViewport) {
-                    parent = parent.getParent(); // parent of viewport
+                final JViewport viewport = getViewport();
+                if (viewport != null) {
+                    Component parent = viewport.getParent();
                     if (parent instanceof JScrollPane) {
                         JScrollPane scrollPane = (JScrollPane) parent;
                         JScrollBar hScrollBar = scrollPane.getHorizontalScrollBar();

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/CharSequenceCharacterIterator.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/CharSequenceCharacterIterator.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.editor.lib2.view;
+
+import java.text.CharacterIterator;
+
+/* This class was written from scratch. I considered using org.apache.pivot.text.CharacterIterator
+from the Apache Pivot project, but it had bugs in the next() and previous() methods (trying to use
+CharacterIterator.DONE = 65535 as an index). */
+/**
+ * Adapter class for providing a {@link CharacterIterator} over a {@link CharSequence} without
+ * making a copy of the entire underlying string.
+ *
+ * @author Eirik Bakke (ebakke@ultorg.com)
+ */
+class CharSequenceCharacterIterator implements CharacterIterator {
+    private final CharSequence charSequence;
+    private int index;
+
+    public CharSequenceCharacterIterator(CharSequence charSequence) {
+        if (charSequence == null) {
+            throw new NullPointerException();
+        }
+        this.charSequence = charSequence;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public char setIndex(int position) {
+        if (position < getBeginIndex() || position > getEndIndex()) {
+            throw new IllegalArgumentException();
+        }
+        this.index = position;
+        return current();
+    }
+
+    @Override
+    public char current() {
+        return index == getEndIndex() ? CharacterIterator.DONE : charSequence.charAt(index);
+    }
+
+    @Override
+    public char first() {
+        return setIndex(getBeginIndex());
+    }
+
+    @Override
+    public char last() {
+        final int endIndex = getEndIndex();
+        return setIndex(charSequence.length() == 0 ? endIndex : (endIndex - 1));
+    }
+
+    @Override
+    public char next() {
+        if (index < getEndIndex()) {
+            index++;
+        }
+        return current();
+    }
+
+    @Override
+    public char previous() {
+        if (index > getBeginIndex()) {
+            index--;
+            return current();
+        } else {
+            return CharacterIterator.DONE;
+        }
+    }
+
+    @Override
+    public int getBeginIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getEndIndex() {
+        return charSequence.length();
+    }
+
+    @Override
+    public Object clone() {
+        CharacterIterator ret = new CharSequenceCharacterIterator(charSequence);
+        ret.setIndex(index);
+        return ret;
+    }
+}

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -1227,10 +1227,12 @@ public final class DocumentViewOp
             setStatusBits(AVAILABLE_WIDTH_VALID);
             availableWidth = Integer.MAX_VALUE;
             renderWrapWidth = availableWidth;
-            TextLayout lineContTextLayout = getLineContinuationCharTextLayout();
-            if (lineContTextLayout != null && (getLineWrapType() != LineWrapType.NONE)) {
-                availableWidth = Math.max(getVisibleRect().width, 4 * getDefaultCharWidth() + lineContTextLayout.getAdvance());
-                renderWrapWidth = availableWidth - lineContTextLayout.getAdvance();
+            if (getLineWrapType() != LineWrapType.NONE) {
+                final TextLayout lineContTextLayout = getLineContinuationCharTextLayout();
+                final float lineContTextLayoutAdvance =
+                    lineContTextLayout == null ? 0f : lineContTextLayout.getAdvance();
+                availableWidth = Math.max(getVisibleRect().width, 4 * getDefaultCharWidth() + lineContTextLayoutAdvance);
+                renderWrapWidth = availableWidth - lineContTextLayoutAdvance;
             }
         }
         return availableWidth;
@@ -1343,7 +1345,17 @@ public final class DocumentViewOp
         return ret;
     }
 
+    /**
+     * @return will be null if the line continuation character should not be shown
+     */
     TextLayout getLineContinuationCharTextLayout() {
+        /* The line continuation character is used to show that a line is automatically being
+        broken into multiple wrap lines via the line wrap feature. This causes a lot of visual
+        clutter, and always takes up an extra character of horizontal space, so don't show it by
+        default. The same information is communicated by the line numbers in the left-hand side of
+        the editor anyway. */
+        if (!docView.op.isNonPrintableCharactersVisible())
+            return null;
         if (lineContinuationTextLayout == null) {
             char lineContinuationChar = LINE_CONTINUATION;
             if (!defaultFont.canDisplay(lineContinuationChar)) {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfo.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfo.java
@@ -122,7 +122,7 @@ final class WrapInfo extends GapList<WrapLine> {
                 allocBounds.x += endPart.width;
             }
             // Paint wrap mark
-            if (i != lastWrapLineIndex) { // but not on last wrap line
+            if (lineContinuationTextLayout != null && i != lastWrapLineIndex) { // but not on last wrap line
                 PaintState paintState = PaintState.save(g);
                 try {
                     ViewUtils.applyForegroundColor(g, null, textComponent);

--- a/ide/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/AdjustBreakOffsetToWordTest.java
+++ b/ide/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/view/AdjustBreakOffsetToWordTest.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.editor.lib2.view;
+
+import java.util.Objects;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link HighlightsViewUtils#adjustBreakOffsetToWord(CharSequence,int,boolean)}.
+ */
+public class AdjustBreakOffsetToWordTest {
+    private void testOne(String original, String expected, boolean allowWhitespaceBeyondEnd) {
+        TextWithCaret originalTwC = TextWithCaret.fromEncoded(original);
+        TextWithCaret expectedTwC = TextWithCaret.fromEncoded(expected);
+        TextWithCaret actualTwC = new TextWithCaret(originalTwC.text,
+                HighlightsViewUtils.adjustBreakOffsetToWord(originalTwC.text, originalTwC.caret,
+                allowWhitespaceBeyondEnd));
+        Assert.assertEquals(expectedTwC, actualTwC);
+    }
+
+    private void testOne(String original, String expected) {
+        testOne(original, expected, false);
+        testOne(original, expected, true);
+    }
+
+    private void testOne(String original, String
+            expectedDisallowWhitespaceBeyondEnd, String expectedAllowWhitespaceBeyondEnd)
+    {
+        testOne(original, expectedDisallowWhitespaceBeyondEnd, false);
+        testOne(original, expectedAllowWhitespaceBeyondEnd, true);
+    }
+
+    @Test
+    public void testLongWord() {
+        // Forward-skipping is necessary.
+        testOne("|this is a test", "this| is a test", "this |is a test");
+        testOne("t|his is a test", "this| is a test", "this |is a test");
+        testOne("th|is is a test", "this| is a test", "this |is a test");
+        testOne("thi|s is a test", "this| is a test", "this |is a test");
+        testOne("this| is a test", "this| is a test", "this |is a test");
+    }
+
+    @Test
+    public void testBasic() {
+        // Forward-skipping is not necessary.
+        testOne("this |is a test", "this |is a test");
+        testOne("this i|s a test", "this |is a test");
+        /* If !allowWhitespaceBeyondEnd, break must backtrack to before "is" to avoid the new line
+        starting with a whitespace. */
+        testOne("this is| a test", "this |is a test", "this is |a test");
+        testOne("this is |a test", "this is |a test");
+        testOne("this is a| test", "this is |a test", "this is a |test");
+        testOne("this is a |test", "this is a |test");
+        testOne("this is a t|est", "this is a |test");
+        testOne("this is a te|st", "this is a |test");
+        testOne("this is a tes|t", "this is a |test");
+        testOne("this is a test|", "this is a test|");
+    }
+
+    @Test
+    public void testDashInFirstWord() {
+        testOne("|foo-test bar is", "foo-|test bar is");
+        testOne("f|oo-test bar is", "foo-|test bar is");
+        testOne("fo|o-test bar is", "foo-|test bar is");
+        testOne("foo|-test bar is", "foo-|test bar is");
+        testOne("foo-|test bar is", "foo-|test bar is");
+        testOne("foo-t|est bar is", "foo-|test bar is");
+        testOne("foo-te|st bar is", "foo-|test bar is");
+        testOne("foo-tes|t bar is", "foo-|test bar is");
+        testOne("foo-test| bar is", "foo-|test bar is", "foo-test |bar is");
+        testOne("foo-test |bar is", "foo-test |bar is");
+        testOne("foo-test b|ar is", "foo-test |bar is");
+    }
+
+    @Test
+    public void testDashInNonFirstWord() {
+        testOne("this is| foo-test bar", "this |is foo-test bar", "this is |foo-test bar");
+        testOne("this is |foo-test bar", "this is |foo-test bar");
+        testOne("this is f|oo-test bar", "this is |foo-test bar");
+        testOne("this is fo|o-test bar", "this is |foo-test bar");
+        testOne("this is foo|-test bar", "this is |foo-test bar");
+        testOne("this is foo-|test bar", "this is foo-|test bar");
+        testOne("this is foo-t|est bar", "this is foo-|test bar");
+        testOne("this is foo-te|st bar", "this is foo-|test bar");
+        testOne("this is foo-tes|t bar", "this is foo-|test bar");
+        testOne("this is foo-test| bar", "this is foo-|test bar", "this is foo-test |bar");
+        testOne("this is foo-test |bar", "this is foo-test |bar");
+        testOne("this is foo-test b|ar", "this is foo-test |bar");
+    }
+
+    @Test
+    public void testJustWhitespace() {
+        testOne("|", "|");
+        testOne("| ", " |");
+        testOne(" |", " |");
+        testOne("|  ", " | ");
+        testOne(" | ", " | ", "  |");
+        testOne("  |", "  |");
+        testOne("|   ", " |  ");
+        testOne(" |  ", " |  ", "  | ");
+        testOne("  | ", "  | ",  "   |");
+        testOne("   |", "   |");
+    }
+
+    @Test
+    public void testTrailingNewline() {
+        // A newline character should just be treated like any other whitespace here.
+        testOne("|this is a test\n", "this| is a test\n", "this |is a test\n");
+        testOne("t|his is a test\n", "this| is a test\n", "this |is a test\n");
+        testOne("th|is is a test\n", "this| is a test\n", "this |is a test\n");
+        testOne("thi|s is a test\n", "this| is a test\n", "this |is a test\n");
+        testOne("this| is a test\n", "this| is a test\n", "this |is a test\n");
+        testOne("this |is a test\n", "this |is a test\n");
+        testOne("this i|s a test\n", "this |is a test\n");
+        testOne("this is| a test\n", "this |is a test\n", "this is |a test\n");
+        testOne("this is |a test\n", "this is |a test\n");
+        testOne("this is a| test\n", "this is |a test\n", "this is a |test\n");
+        testOne("this is a |test\n", "this is a |test\n");
+        testOne("this is a t|est\n", "this is a |test\n");
+        testOne("this is a te|st\n", "this is a |test\n");
+        testOne("this is a tes|t\n", "this is a |test\n");
+        testOne("this is a test|\n", "this is a |test\n", "this is a test\n|");
+        testOne("this is a test\n|", "this is a test\n|");
+    }
+
+    @Test
+    public void testSpacesBetween() {
+        // Multiple whitespace characters between first and second word.
+        testOne("th|is   is a test", "this|   is a test", "this |  is a test");
+        testOne("thi|s   is a test", "this|   is a test", "this |  is a test");
+        testOne("this|   is a test", "this|   is a test", "this |  is a test");
+        testOne("this |  is a test", "this |  is a test", "this  | is a test");
+        testOne("this  | is a test", "this  | is a test", "this   |is a test");
+        testOne("this   |is a test", "this   |is a test");
+        testOne("this   i|s a test", "this   |is a test");
+        testOne("this   is| a test", "this   |is a test", "this   is |a test");
+        testOne("this   is |a test", "this   is |a test");
+        // Multiple whitespace characters between words not including the first word.
+        testOne("this |is   aaaa test", "this |is   aaaa test");
+        testOne("this i|s   aaaa test", "this |is   aaaa test");
+        testOne("this is|   aaaa test", "this |is   aaaa test", "this is |  aaaa test");
+        testOne("this is |  aaaa test", "this |is   aaaa test", "this is  | aaaa test");
+        testOne("this is  | aaaa test", "this |is   aaaa test", "this is   |aaaa test");
+        testOne("this is   |aaaa test", "this is   |aaaa test");
+        testOne("this is   a|aaa test", "this is   |aaaa test");
+        testOne("this is   aa|aa test", "this is   |aaaa test");
+        testOne("this is   aaa|a test", "this is   |aaaa test");
+        testOne("this is   aaaa| test", "this is   |aaaa test", "this is   aaaa |test");
+        testOne("this is   aaaa |test", "this is   aaaa |test");
+    }
+
+    @Test
+    public void testTrailingSpaces() {
+        // One trailing whitespace character.
+        testOne("this is a test| ", "this is a |test ", "this is a test |");
+        testOne("this is a test |", "this is a test |");
+        // Two trailing whitespace characters.
+        testOne("this is a tes|t  ", "this is a |test  ", "this is a |test  ");
+        testOne("this is a test|  ", "this is a |test  ", "this is a test | ");
+        testOne("this is a test | ", "this is a |test  ", "this is a test  |");
+        testOne("this is a test  |", "this is a test  |", "this is a test  |");
+        // Long line with one trailing whitespace character.
+        testOne("|testtest ", "testtest| ", "testtest |");
+        testOne("t|esttest ", "testtest| ", "testtest |");
+        testOne("testte|st ", "testtest| ", "testtest |");
+        testOne("testtes|t ", "testtest| ", "testtest |");
+        testOne("testtest| ", "testtest| ", "testtest |");
+        testOne("testtest |", "testtest |", "testtest |");
+        // Long line with two trailing whitespace characters.
+        testOne("|testtest  ", "testtest|  ", "testtest | ");
+        testOne("t|esttest  ", "testtest|  ", "testtest | ");
+        testOne("testte|st  ", "testtest|  ", "testtest | ");
+        testOne("testtes|t  ", "testtest|  ", "testtest | ");
+        testOne("testtest|  ", "testtest|  ", "testtest | ");
+        testOne("testtest | ", "testtest | ", "testtest  |");
+        testOne("testtest  |", "testtest  |");
+    }
+
+    @Test
+    public void testAdjustBreakOffsetToWordLeadingSpace() {
+        // One leading space
+        testOne("| this is a test", " |this is a test");
+        testOne(" |this is a test", " |this is a test");
+        testOne(" t|his is a test", " |this is a test");
+        testOne(" th|is is a test", " |this is a test");
+        testOne(" thi|s is a test", " |this is a test");
+        testOne(" this| is a test", " |this is a test", " this |is a test");
+        testOne(" this |is a test", " this |is a test");
+        testOne(" this i|s a test", " this |is a test");
+        // Two leading spaces
+        testOne("|  this is a test", " | this is a test");
+        testOne(" | this is a test", " | this is a test", "  |this is a test");
+        testOne("  |this is a test", "  |this is a test");
+        testOne("  t|his is a test", "  |this is a test");
+        testOne("  th|is is a test", "  |this is a test");
+        testOne("  thi|s is a test", "  |this is a test");
+        testOne("  this| is a test", "  |this is a test", "  this |is a test");
+        testOne("  this |is a test", "  this |is a test");
+        testOne("  this i|s a test", "  this |is a test");
+    }
+
+    private static final class TextWithCaret {
+        public final String text;
+        public final int caret;
+
+        public TextWithCaret(String text, int caret) {
+            this(text, caret, true);
+        }
+
+        private TextWithCaret(String text, int caret, boolean check) {
+            if (text == null) {
+                throw new NullPointerException();
+            }
+            if (caret < 0 || caret > text.length()) {
+                throw new IllegalArgumentException();
+            }
+            this.text = text;
+            this.caret = caret;
+
+            if (check && !equals(fromEncoded(toString()))) {
+                throw new AssertionError();
+            }
+        }
+
+        /**
+         * @param encoded string containing a single '|' character indicating the caret position
+         */
+        public static TextWithCaret fromEncoded(String encoded) {
+            final StringBuilder psb = new StringBuilder();
+            Integer caret = null;
+            for (char ec : encoded.toCharArray()) {
+                if (ec == '|') {
+                    if (caret != null) {
+                        throw new IllegalArgumentException("Multiple caret positions specified");
+                    }
+                    caret = psb.length();
+                } else {
+                    psb.append(ec);
+                }
+            }
+            if (caret == null) {
+                throw new IllegalArgumentException("No caret position specified");
+            }
+            return new TextWithCaret(psb.toString(), caret, false);
+        }
+
+        @Override
+        public String toString() {
+            return text.substring(0, caret) + '|' + text.substring(caret);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TextWithCaret)) {
+                return false;
+            }
+            TextWithCaret other = (TextWithCaret) obj;
+            return this.text.equals(other.text)
+                && this.caret == other.caret;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(text, caret);
+        }
+    }
+}


### PR DESCRIPTION
Improve text layout for the NetBeans editor's "word wrap" feature. This makes the word wrap behavior more in line with that of other editors, and makes wrapped text more readable. See detailed description and before/after screenshot (also attached here) at https://issues.apache.org/jira/browse/NETBEANS-977 .

![wrappingdiff](https://user-images.githubusercontent.com/886243/41788682-c239bcfe-764c-11e8-9ec3-efa2cbe21fa0.png)
