### PR TITLE
[NETBEANS-974] Fix for AWT Event Queue exception on viewing variable value is debug mode

### DIFF
--- a/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAAsynchronousModel.java
+++ b/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDAAsynchronousModel.java
@@ -53,8 +53,8 @@ public class JPDAAsynchronousModel implements AsynchronousModelFilter {
         switch (asynchCall) {
             case VALUE:
             case CHILDREN:
-                return rp;
             case SHORT_DESCRIPTION:
+                return rp;
             case DISPLAY_NAME:
                 return CURRENT_THREAD;
         }


### PR DESCRIPTION
Viewing variable in debugger was causing  AWT Event Queue exception as AWT thread was being used.
Code is modified to make async call for  population of short-description

Jira Link:  https://issues.apache.org/jira/browse/NETBEANS-974

Was not able to add relevant TestCases as in debugger.jdpa.ui module existing test cases are not working
Below Jira was raised for that
https://issues.apache.org/jira/browse/NETBEANS-1027