### PR TITLE
[NetBeans-1019]False positive of "Null Pointer Dereference" when passing a lambda with a null possible result to a non-null argument

### DIFF
--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.java.hints.bugs;
 import com.sun.source.tree.*;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.tree.JCTree;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -625,7 +626,7 @@ public class NPECheck {
             
             TypeMirror currentType = tree != null ? info.getTrees().getTypeMirror(new TreePath(getCurrentPath(), tree)) : null;
             
-            if (currentType != null && currentType.getKind().isPrimitive()) {
+            if ((tree != null && tree instanceof JCTree.JCLambda) || (currentType != null && currentType.getKind().isPrimitive())) {
                 r = State.NOT_NULL;
             }
             

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -625,7 +625,7 @@ public class NPECheck {
             
             TypeMirror currentType = tree != null ? info.getTrees().getTypeMirror(new TreePath(getCurrentPath(), tree)) : null;
             
-            if ((tree != null && tree.getKind().equals(Kind.LAMBDA_EXPRESSION)) || (currentType != null && currentType.getKind().isPrimitive())) {
+            if ((tree != null && tree.getKind() == Kind.LAMBDA_EXPRESSION) || (currentType != null && currentType.getKind().isPrimitive())) {
                 r = State.NOT_NULL;
             }
             

--- a/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.java.hints.bugs;
 import com.sun.source.tree.*;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
-import com.sun.tools.javac.tree.JCTree;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -626,7 +625,7 @@ public class NPECheck {
             
             TypeMirror currentType = tree != null ? info.getTrees().getTypeMirror(new TreePath(getCurrentPath(), tree)) : null;
             
-            if ((tree != null && tree instanceof JCTree.JCLambda) || (currentType != null && currentType.getKind().isPrimitive())) {
+            if ((tree != null && tree.getKind().equals(Kind.LAMBDA_EXPRESSION)) || (currentType != null && currentType.getKind().isPrimitive())) {
                 r = State.NOT_NULL;
             }
             

--- a/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
+++ b/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
@@ -273,6 +273,23 @@ public class NPECheckTest extends NbTestCase {
                             "0:62-0:65:verifier:ERR_POSSIBLENULL_TO_NON_NULL_ARG");
     }
     
+    public void testParameter4() throws Exception {
+        HintTest.create()
+                .sourceLevel("8")
+                .input("test/Test.java", 
+                       "package test; \n" +
+                       "import java.util.function.Function; \n" +
+                       "class Test { \n" +
+                       "       private void func(@NotNull Function<Object, Object> func){} \n" +
+                       "       @CheckForNull private Object foo(){ return null;} \n" +
+                       "       private void bar(){func((item)->foo());} \n" +
+                       "       private @CheckForNull String t() { return null;}} \n" +
+                       "       @interface NotNull {} \n" +
+                       "       @interface CheckForNull {}")
+                .run(NPECheck.class)
+                .assertNotContainsWarnings("ERR_POSSIBLENULL_TO_NON_NULL_ARG");        
+    }
+    
     public void testNoMultipleReports1() throws Exception {
         performAnalysisTest("test/Test.java",
                             "package test;\n" +


### PR DESCRIPTION
Jira Id : https://issues.apache.org/jira/browse/NETBEANS-1019

Issues: False positive of "Null Pointer Dereference" when passing a lambda with a null possible result to a non-null argument
private void func(@NonNull Function<Object, Object> func){
        
    }
    @CheckForNull
    private Object foo(){
        return null;
    }
    private void bar(){
        func(item->foo());//false positive
    }