### PR TITLE
NETBEANS-998: update display name when DelayedNode resolves it

### DIFF
--- a/openide.loaders/src/org/openide/loaders/TemplateWizard1.java
+++ b/openide.loaders/src/org/openide/loaders/TemplateWizard1.java
@@ -195,7 +195,7 @@ final class TemplateWizard1 extends javax.swing.JPanel implements DataFilter,
         @Override
         protected Node[] createNodes(Node key) {
             Node n = key;
-            String nodeName = n.getDisplayName();
+            String nodeName = null;
             
             DataObject obj = null;
             DataShadow shadow = n.getCookie(DataShadow.class);
@@ -239,7 +239,7 @@ final class TemplateWizard1 extends javax.swing.JPanel implements DataFilter,
         }
         
         public String getDisplayName() {
-            return name;
+            return name != null ? name : super.getDisplayName();
         }
         
         // issue 29867, rename should be prohibited


### PR DESCRIPTION
In the branch for shadow, the name is localized through the DataNode, so the final value is seen immediately and can be fixed for the `DataShadowFilterNode`. But for "normal" nodes, the node may resolve the localized name later, in background and change it. It will fire events which the `DataShadowFilterNode` will happily forward, but `getDisplayName` need to delegate to the filer node so that the current value is returned to the caller.