### PR TITLE
NETBEANS-1048: display start of product info in about box

### DIFF
--- a/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
+++ b/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
@@ -110,6 +110,7 @@ public class ProductInformationPanel extends JPanel implements HyperlinkListener
                         description.setText(LBL_description(getProductVersionValue(), getJavaValue(), getVMValue(), getOperatingSystemValue(), getEncodingValue(), getSystemLocaleValue(), getUserDirValue(), Places.getCacheDirectory().getAbsolutePath(), updates, FONT_SIZE, getJavaRuntime()));
                         description.setCursor(null);
                         description.revalidate();
+                        description.setCaretPosition(0);
                     }
                 });
             }


### PR DESCRIPTION
See `NETBEANs-1048` for description. I've simply moved the caret to the beginning of the text to force editbox to display the text start.