### PR TITLE
NETBEANS-1049: prevent NPE on unpersistable components

### DIFF
--- a/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
+++ b/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
@@ -348,7 +348,13 @@ public class GroupsManager {
             String id = wmi.findTopComponentID(tc);
             if( tc.equals(welcomeTc) && !welcomeWasOpened )
                 continue;
+            if (tc.getPersistenceType() == TopComponent.PERSISTENCE_NEVER) {
+                continue;
+            }
             FileObject tcFO = FileUtil.toFileObject(new File(componentRoot, id + "." + SETTINGS)); //NOI18N //NOI18N
+            if (tcFO == null) {
+                continue;
+            }
             try {
                 tcFO.copy(groupFO, id, SETTINGS);
             } catch( IOException ex ) {


### PR DESCRIPTION
see description of NETBEANS-1049. The change avoids copying for non-persistable components, or just for components which do not have their `.settings` file for some reason.