### PR TITLE
[NETBEANS-691]: Corrected undo conversion of constructor to factory w…

### DIFF
--- a/openide.text/src/org/openide/text/UndoRedoManager.java
+++ b/openide.text/src/org/openide/text/UndoRedoManager.java
@@ -263,7 +263,7 @@ final class UndoRedoManager extends UndoRedo.Manager {
     }
         
     private void redoSaveActions() {   
-        if (onSaveTasksEdit != null) {
+        if (onSaveTasksEdit != null && onSaveTasksEdit.canRedo()) {
             checkLogOp("    saveActionsEdit.redo()", onSaveTasksEdit); // NOI18N
             onSaveTasksEdit.redo();
         }

--- a/openide.text/src/org/openide/text/UndoRedoManager.java
+++ b/openide.text/src/org/openide/text/UndoRedoManager.java
@@ -251,7 +251,7 @@ final class UndoRedoManager extends UndoRedo.Manager {
     }
         
     private void undoSaveActions() {
-        if (onSaveTasksEdit != null) {
+        if (onSaveTasksEdit != null && onSaveTasksEdit.canUndo()){
             checkLogOp("    saveActionsEdit.undo()", onSaveTasksEdit); // NOI18N
             onSaveTasksEdit.undo();
         }


### PR DESCRIPTION
…hen refactoring in calling class

On undo-->redo-->undo after refactoring with 'Replace Constructor with factory' , second undo call was throwing CannotUndoException.

 UndoRedoManager.onSaveTasksEdit 'hasBeenDone' field became false after the redo call in this particular scenario.
So when second time undo is called, it throws CannotUndoException as hasBeenDone field is already false 

Jira Link:  https://issues.apache.org/jira/browse/NETBEANS-691