### PR TITLE
Adds Version parsing to svn output.

### DIFF
--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -16,14 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.netbeans.modules.subversion.client.cli.commands;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 import org.netbeans.modules.subversion.Subversion;
 import org.netbeans.modules.subversion.client.cli.SvnCommand;
 import org.tigris.subversion.svnclientadapter.ISVNNotifyListener;
@@ -37,8 +38,8 @@ public class VersionCommand extends SvnCommand {
     private List<String> output = new ArrayList<String>();
     private boolean unsupportedVersion = false;
     private boolean supportedMetadataFormat = false;
-    public static final Version VERSION_15 = Version.parse("1.5");
-    public static final Version VERSION_16 = Version.parse("1.6");
+    static final Version VERSION_15 = Version.parse("1.5");
+    static final Version VERSION_16 = Version.parse("1.6");
 
     @Override
     protected int getCommand() {
@@ -57,7 +58,7 @@ public class VersionCommand extends SvnCommand {
 
     @Override
     public void outputText(String lineString) {
-        if (lineString == null || lineString.trim().equals("")) {
+        if(lineString == null || lineString.trim().equals("")) {
             return;
         }
         output.add(lineString);
@@ -92,7 +93,6 @@ public class VersionCommand extends SvnCommand {
                     supportedMetadataFormat = true;
                 }
             }
-
         }
         return outputProduced;
     }
@@ -115,88 +115,72 @@ public class VersionCommand extends SvnCommand {
     }
 
     /**
-     * Version holder with semantic verioning support. Keep svn --version output
-     * is in mind. The container is compatible with MAJOR.MINOR.PATCH formatp
-     * lus some remainder as it happens in svn --version. I.e. "svn, version
-     * 1.10.0 (r1827917)" is supported Regular 1.10.1 is supported too.
+     * Version holder with semantic verioning support.
      *
-     * Note on exceptions: Exceptions are unchecked and not expected to occur,
-     * if that happens its a bug.
+     * Keep svn --version output in mind. The container is compatible with
+     * MAJOR.MINOR.PATCH format plus some remainder as it happens in svn
+     * --version. I.e. "svn, version 1.10.0 (r1827917)" is supported. Regular
+     * 1.10.1 is supported too.
+     *
      */
     public static class Version implements Comparable<Version> {
 
-        private int[] parts;
-        public String remainder;
+        final int[] parts;
+        final String remainder;
 
-        static final Version UNKNOWN = new Version();
-
-        private Version() {
+        private Version(int[] parts, String remainder) {
+            this.parts = parts;
+            this.remainder = remainder;
         }
 
         /**
          * Parse version string into container. String must be in
          * "MAJOR.MINOR.PATCH reminder" format. Reminder part is optional.
          *
-         * @param version non null string
-         * @return parsed version or UKNOWN if parsing error happens
+         * @param version non null string with version, say "1.10.0 (r1827917)"
+         * @return non null version
+         * @throws NumberFormatException should parse error occur
+         * @throws IllegalArgumentException if one of parameters was null
          */
-        public static Version parse(String version) {
+        public static Version parse(String version) throws NumberFormatException, IllegalArgumentException {
             return parse(version, " ");
         }
 
         /**
          * Parse version string into container. String must be in
          * "MAJOR.MINOR.PATCH-reminder" format. Reminder part is optional.
-         * @param version string with version, say 1.1.1-SNAPSHOT
-         * @param remainderDelimiter a symbol to separate semantic version from reminder, say "-" for "1.1.1-SNAPSHOT"
-         * @return
+         *
+         * @param version non null string with version, say 1.1.1-SNAPSHOT
+         * @param remainderDelimiter a symbol to separate semantic version from
+         * reminder, say "-" for "1.1.1-SNAPSHOT"
+         * @return non null version
+         * @throws NumberFormatException should parse error occur
+         * @throws IllegalArgumentException if one of parameters was null
          */
-        public static Version parse(String version, String remainderDelimiter) {
-            String symanticVersion;
-            int symanticEnds = version.indexOf(remainderDelimiter);
-            symanticVersion = symanticEnds < 0
-                    ? version
-                    : version.substring(0, symanticEnds);
+        public static Version parse(String version, String remainderDelimiter) throws NumberFormatException, IllegalArgumentException {
+            assertNotNullArg(version, "Version parameter must not be null");
+            assertNotNullArg(remainderDelimiter, "reminderDelimiter parameter must not be null");
+            String[] versionMajorParts = version.split(Pattern.quote(remainderDelimiter), 2);
 
-            StringTokenizer tokenizer = new StringTokenizer(symanticVersion, ".");
-            Version result = new Version();
-            if (tokenizer.hasMoreTokens()) {
-                fetchParts(tokenizer, result);
-                result.remainder = symanticEnds < 0
-                        ? ""
-                        : version.substring(symanticEnds + 1);
-                return result;
-            } else {
-                return UNKNOWN;
+            String[] stringParts = versionMajorParts[0].split("\\.");
+            int[] parts = new int[stringParts.length];
+            for (int i = 0; i < stringParts.length; i++) {
+                parts[i] = Integer.parseInt(stringParts[i]);
             }
+
+            return new Version(parts, versionMajorParts.length > 1 ? versionMajorParts[1] : "");
         }
 
-        private static void fetchParts(StringTokenizer t, Version r) {
-            int n = Integer.parseInt(t.nextToken());
-            int a[];
-            if (r.parts == null) {
-                a = new int[]{n};
-            } else {
-                a = new int[r.parts.length + 1];
-                System.arraycopy(r.parts, 0, a, 0, r.parts.length);
-                a[r.parts.length] = n;
+        private static void assertNotNullArg(Object value, String errMessage) throws IllegalArgumentException {
+            if (value == null) {
+                throw new IllegalArgumentException(errMessage);
             }
-            r.parts = a;
-            if (t.hasMoreTokens()) {
-                fetchParts(t, r);
-            }
-        }
-
-        public boolean isUnknown() {
-            return this == UNKNOWN;
         }
 
         @Override
         public int compareTo(Version t) {
             if (t == null) {
                 return 1;
-            } else if (this.isUnknown() && t.isUnknown()) {
-                return 0;
             } else {
                 for (int i = 0; i < parts.length; i++) {
                     if (t.parts.length < i) {
@@ -229,15 +213,9 @@ public class VersionCommand extends SvnCommand {
         }
 
         private Version trim(int level) {
-            if (isUnknown()) {
-                return this;
-            } else {
-                Version n = new Version();
-                n.remainder = this.remainder;
-                n.parts = new int[level];
-                System.arraycopy(parts, 0, n.parts, 0, Math.min(level, parts.length));
-                return n;
-            }
+            int[] newParts = new int[level];
+            System.arraycopy(parts, 0, newParts, 0, Math.min(level, parts.length));
+            return new Version(newParts, this.remainder);
         }
 
         public boolean greaterThan(Version that) {

--- a/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.subversion.client.cli.commands;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringTokenizer;
 import java.util.logging.Level;
 import org.netbeans.modules.subversion.Subversion;
 import org.netbeans.modules.subversion.client.cli.SvnCommand;
@@ -37,31 +37,33 @@ public class VersionCommand extends SvnCommand {
     private List<String> output = new ArrayList<String>();
     private boolean unsupportedVersion = false;
     private boolean supportedMetadataFormat = false;
-    
+    public static final Version VERSION_15 = Version.parse("1.5");
+    public static final Version VERSION_16 = Version.parse("1.6");
+
     @Override
     protected int getCommand() {
         return ISVNNotifyListener.Command.UNDEFINED;
     }
-    
+
     @Override
     public void prepareCommand(Arguments arguments) throws IOException {
-        arguments.add("--version");                
+        arguments.add("--version");
     }
 
     @Override
     protected void config(File configDir, String username, String password, Arguments arguments) {
-        arguments.addConfigDir(configDir);        
+        arguments.addConfigDir(configDir);
     }
 
     @Override
     public void outputText(String lineString) {
-        if(lineString == null || lineString.trim().equals("")) {
+        if (lineString == null || lineString.trim().equals("")) {
             return;
         }
         output.add(lineString);
         super.outputText(lineString);
     }
-    
+
     public boolean checkForErrors() {
         Integer exitCode = getExitCode();
         if ((exitCode == null) || !exitCode.equals(Integer.valueOf(0))) {
@@ -79,21 +81,18 @@ public class VersionCommand extends SvnCommand {
 
             int pos = string.indexOf(" version ");
             if (pos > -1) {
-                Subversion.LOG.log(Level.INFO, "Commandline client version: {0}", string.substring(pos + 9));
+                String vString = string.substring(pos + 9);
+                Subversion.LOG.log(Level.INFO, "Commandline client version: {0}", vString);
+                Version version = Version.parse(vString);
+                if (version.lowerThan(VERSION_15)) {
+                    unsupportedVersion = true;
+                    return false;
+                } else if (version.sameMinor(VERSION_15)
+                        || version.sameMinor(VERSION_16)) {
+                    supportedMetadataFormat = true;
+                }
             }
 
-            if(string.indexOf("version 0.")  > -1 ||
-               string.indexOf("version 1.0") > -1 ||
-               string.indexOf("version 1.1") > -1 ||
-               string.indexOf("version 1.2") > -1 ||
-               string.indexOf("version 1.3") > -1 ||
-               string.indexOf("version 1.4") > -1) {
-                unsupportedVersion = true;
-                return false;
-            } else if(string.indexOf("version 1.5")  > -1 
-                    || string.indexOf("version 1.6") > -1) {
-                supportedMetadataFormat = true;
-            }
         }
         return outputProduced;
     }
@@ -105,7 +104,7 @@ public class VersionCommand extends SvnCommand {
     public boolean isMetadataFormatSupported() {
         return supportedMetadataFormat;
     }
-    
+
     public String getOutput() {
         StringBuffer sb = new StringBuffer();
         for (String string : output) {
@@ -113,5 +112,136 @@ public class VersionCommand extends SvnCommand {
             sb.append('\n');
         }
         return sb.toString();
-    }    
+    }
+
+    /**
+     * Version holder with semantic verioning support. Keep svn --version output
+     * is in mind. The container is compatible with MAJOR.MINOR.PATCH formatp
+     * lus some remainder as it happens in svn --version. I.e. "svn, version
+     * 1.10.0 (r1827917)" is supported Regular 1.10.1 is supported too.
+     *
+     * Note on exceptions: Exceptions are unchecked and not expected to occur,
+     * if that happens its a bug.
+     */
+    public static class Version implements Comparable<Version> {
+
+        private int[] parts;
+        public String remainder;
+
+        static final Version UNKNOWN = new Version();
+
+        private Version() {
+        }
+
+        /**
+         * Parse version string into container. String must be in
+         * "MAJOR.MINOR.PATCH reminder" format. Reminder part is optional.
+         *
+         * @param version non null string
+         * @return parsed version or UKNOWN if parsing error happens
+         */
+        public static Version parse(String version) {
+            return parse(version, " ");
+        }
+
+        /**
+         * Parse version string into container. String must be in
+         * "MAJOR.MINOR.PATCH-reminder" format. Reminder part is optional.
+         * @param version string with version, say 1.1.1-SNAPSHOT
+         * @param remainderDelimiter a symbol to separate semantic version from reminder, say "-" for "1.1.1-SNAPSHOT"
+         * @return
+         */
+        public static Version parse(String version, String remainderDelimiter) {
+            String symanticVersion;
+            int symanticEnds = version.indexOf(remainderDelimiter);
+            symanticVersion = symanticEnds < 0
+                    ? version
+                    : version.substring(0, symanticEnds);
+
+            StringTokenizer tokenizer = new StringTokenizer(symanticVersion, ".");
+            Version result = new Version();
+            if (tokenizer.hasMoreTokens()) {
+                fetchParts(tokenizer, result);
+                result.remainder = symanticEnds < 0
+                        ? ""
+                        : version.substring(symanticEnds + 1);
+                return result;
+            } else {
+                return UNKNOWN;
+            }
+        }
+
+        private static void fetchParts(StringTokenizer t, Version r) {
+            int n = Integer.parseInt(t.nextToken());
+            int a[];
+            if (r.parts == null) {
+                a = new int[]{n};
+            } else {
+                a = new int[r.parts.length + 1];
+                System.arraycopy(r.parts, 0, a, 0, r.parts.length);
+                a[r.parts.length] = n;
+            }
+            r.parts = a;
+            if (t.hasMoreTokens()) {
+                fetchParts(t, r);
+            }
+        }
+
+        public boolean isUnknown() {
+            return this == UNKNOWN;
+        }
+
+        @Override
+        public int compareTo(Version t) {
+            if (t == null) {
+                return 1;
+            } else if (this.isUnknown() && t.isUnknown()) {
+                return 0;
+            } else {
+                for (int i = 0; i < parts.length; i++) {
+                    if (t.parts.length < i) {
+                        return 1;
+                    }
+                    int a = parts[i];
+                    int b = t.parts[i];
+                    if (a < b) {
+                        return -1;
+                    } else if (a > b) {
+                        return +1;
+                    }
+                }
+                return t.parts.length > parts.length ? -1 : 0;
+            }
+        }
+
+        public boolean lowerThan(Version that) {
+            return compareTo(that) < 0;
+        }
+
+        /**
+         * Check if MAJOR and MINOR parts are equal
+         *
+         * @param that can be null
+         * @return
+         */
+        public boolean sameMinor(Version that) {
+            return that != null && trim(2).compareTo(that.trim(2)) == 0;
+        }
+
+        private Version trim(int level) {
+            if (isUnknown()) {
+                return this;
+            } else {
+                Version n = new Version();
+                n.remainder = this.remainder;
+                n.parts = new int[level];
+                System.arraycopy(parts, 0, n.parts, 0, Math.min(level, parts.length));
+                return n;
+            }
+        }
+
+        public boolean greaterThan(Version that) {
+            return compareTo(that) > 0;
+        }
+    }
 }

--- a/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -16,17 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package rg.netbeans.modules.subversion.client.cli.commands;
+
+package org.netbeans.modules.subversion.client.cli.commands;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.netbeans.modules.subversion.client.cli.commands.VersionCommand;
 import org.netbeans.modules.subversion.client.cli.commands.VersionCommand.Version;
 
-/**
- *
- * @author lauri
- */
 public class VersionCommandTest {
 
     @Test
@@ -54,7 +50,36 @@ public class VersionCommandTest {
     @Test
     public void testRemainder() {
         assertEquals("(r1827917)", Version.parse("1.10.0 (r1827917)").remainder);
-        assertEquals("r1827917", Version.parse("1.10.0-r1827917", "-").remainder);
+        assertEquals("SNAPSHOT", Version.parse("1.1.1-SNAPSHOT", "-").remainder);
+    }
+
+    @Test
+    public void testArguments() {
+        try {
+            Version.parse(null);
+            fail("Null argument should not be accepted");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            Version.parse(null, null);
+            fail("Null argument should not be accepted");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            Version.parse("1.1.1", null);
+            fail("Null argument should not be accepted");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            Version.parse("a.b.c");
+            fail("Number parsing exception is expected");
+        } catch (NumberFormatException ex) {
+        }
+        try {
+            Version.parse("not a version");
+            fail("Number parsing exception is expected");
+        } catch (NumberFormatException ex) {
+        }
     }
 
     @Test
@@ -70,5 +95,4 @@ public class VersionCommandTest {
         assertFalse(VersionCommand.VERSION_15.sameMinor(v110));
         assertFalse(VersionCommand.VERSION_16.sameMinor(v110));
     }
-
 }

--- a/subversion/test/unit/src/rg/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/subversion/test/unit/src/rg/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package rg.netbeans.modules.subversion.client.cli.commands;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.modules.subversion.client.cli.commands.VersionCommand;
+import org.netbeans.modules.subversion.client.cli.commands.VersionCommand.Version;
+
+/**
+ *
+ * @author lauri
+ */
+public class VersionCommandTest {
+
+    @Test
+    public void testVersionParse() {
+        assertNotNull(Version.parse("1.2"));
+        assertNotNull(Version.parse("1.10.0 (r1827917)"));
+    }
+
+    @Test
+    public void testComparison() {
+        assertTrue(Version.parse("1.2").lowerThan(Version.parse("1.3")));
+        assertTrue(Version.parse("1.2").lowerThan(Version.parse("1.3")));
+        assertTrue(Version.parse("1.2").lowerThan(Version.parse("1.2.1")));
+        assertTrue(Version.parse("1.2").lowerThan(Version.parse("2")));
+        assertTrue(Version.parse("2").greaterThan(Version.parse("1.2")));
+        assertTrue(Version.parse("2").greaterThan(Version.parse("1.2.1")));
+        assertTrue(Version.parse("1.5").greaterThan(Version.parse("1.2.1")));
+        assertTrue(Version.parse("1.10.0 (r1827917)").greaterThan(Version.parse("1.5")));
+
+        assertTrue(Version.parse("1.10.0 (r1827917)").sameMinor(Version.parse("1.10")));
+        assertFalse(Version.parse("1.10.0 (r1827917)").sameMinor(Version.parse("1")));
+        assertFalse(Version.parse("1.10.0 (r1827917)").sameMinor(Version.parse("1")));
+    }
+
+    @Test
+    public void testRemainder() {
+        assertEquals("(r1827917)", Version.parse("1.10.0 (r1827917)").remainder);
+        assertEquals("r1827917", Version.parse("1.10.0-r1827917", "-").remainder);
+    }
+
+    @Test
+    public void testNETBEANS_771() {
+
+        String line = "svn, version 1.10.0 (r1827917)";
+        Version v110 = Version.parse(line.substring(line.indexOf(" version ") + 9)); // this similar to what happens in VersionCommand.java checkForErrors()
+
+        assertTrue(VersionCommand.VERSION_15.lowerThan(v110));
+        assertFalse(v110.lowerThan(VersionCommand.VERSION_15));
+        assertTrue(VersionCommand.VERSION_15.lowerThan(v110));
+        assertTrue(VersionCommand.VERSION_16.lowerThan(v110));
+        assertFalse(VersionCommand.VERSION_15.sameMinor(v110));
+        assertFalse(VersionCommand.VERSION_16.sameMinor(v110));
+    }
+
+}


### PR DESCRIPTION
So comparing verion numbers would be based on numbers, not strings.
I.e. its now possible to determine if 1.2.2 and 1.2.123 have same MAJOR.MINOR version.

Fixes [NETBEANS-771](https://issues.apache.org/jira/browse/NETBEANS-771).

NETBEANS-771 caused by version.indexOf("1.1") > -1 
it was fine for svn 1.9, but is broken since 1.10, as 1.10 is treated as 1.1. That is motivation behind actual parsing of string to version container.