### PR TITLE
[NETBEANS-369] Code-complete outputs unwanted newline characters

### DIFF
--- a/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -621,8 +621,6 @@ public class Reformatter implements ReformatTask {
                     continue;
                 if (TreeUtilities.CLASS_TREE_KINDS.contains(typeDecl.getKind())) {
                     blankLines(cs.getBlankLinesBeforeClass());
-                } else {
-                    blankLines(typeDecl.getKind() == Tree.Kind.MODULE ? 0 : 1);
                 }
                 scan(typeDecl, p);
                 int index = tokens.index();


### PR DESCRIPTION
The formatting change was introduced by the change to support reformatting
module declarations via mercurial changeset 4cbf6ecb92bc

http://hg.netbeans.org/main-golden/rev/4cbf6ecb92bc

The change in Reformatter.Pretty.visitCompilationUnit(CompilationUnitTree, Void)
was then conditionalized to only be applied to non-modules 
(git commit: 53ee08901ff0e4c2706b4050a54bc4672ab7994b)

https://github.com/apache/incubator-netbeans/commit/53ee08901ff0e4c2706b4050a54bc4672ab7994b

That changeset left the regression for the general formatting in place
and removed the original use case for modules (for module declarations
the extra empty line is not introduced).

This changeset changes the situation back to the state before 4cbf6ecb92bc.