### PR TITLE
Left/Right arrows are too generic for switching tabs.

### DIFF
--- a/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -848,10 +848,10 @@ public class OptionsPanel extends JPanel {
         if (getActionMap ().get("PREVIOUS") == null) {//NOI18N
             InputMap inputMap = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
             
-            inputMap.put (KeyStroke.getKeyStroke (KeyEvent.VK_LEFT, 0), "PREVIOUS");//NOI18N
+            inputMap.put (KeyStroke.getKeyStroke (KeyEvent.VK_TAB, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK), "PREVIOUS");//NOI18N
             getActionMap ().put ("PREVIOUS", new PreviousAction ());//NOI18N
             
-            inputMap.put (KeyStroke.getKeyStroke (KeyEvent.VK_RIGHT, 0),"NEXT");//NOI18N
+            inputMap.put (KeyStroke.getKeyStroke (KeyEvent.VK_TAB, KeyEvent.CTRL_DOWN_MASK),"NEXT");//NOI18N
             getActionMap ().put ("NEXT", new NextAction ());//NOI18N
         }
     }


### PR DESCRIPTION
There is a (strange) registration for VK_LEFT and VK_RIGHT in OptionsPanel. I haven't found a way to trigger the registration from a Swing component - neither in the NetBeans IDE nor products build on top of it.

It makes little sense to bind such lowlevel arrow keys to such high-level task. Thus this change proposes Ctrl-Tab and Ctrl-Shift-Tab instead for switching the categories.

With this change I can easily switch categories in the IDE as well as eliminate the switching on left/right arrow press in a JFXPanel - an issue that motivated this change.