### PR TITLE
#1074: Review of the ergonomics cluster

### DIFF
--- a/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfoTest.xml
+++ b/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfoTest.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
 <filesystem>
     <folder name="Loaders">

--- a/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.html
+++ b/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.html
@@ -1,1 +1,21 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <body>

--- a/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.nonhtml
+++ b/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.nonhtml
@@ -1,1 +1,21 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <body>

--- a/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/test-layer.xml
+++ b/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/test-layer.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
 <filesystem>
 </filesystem>

--- a/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/newproject/smpl.xml
+++ b/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/newproject/smpl.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
 <filesystem>
     <file name="smpl.tmp"/>

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -26,10 +26,13 @@ clusters.config.platform.list=\
 
 clusters.config.basic.list=\
         ${clusters.config.java.list},\
-        nb.cluster.apisupport
+        nb.cluster.apisupport,\
+        nb.cluster.ergonomics
+# ergonomics must be last
 
 clusters.config.standard.list=\
-        ${clusters.config.basic.list},\
+        ${clusters.config.java.list},\
+        nb.cluster.apisupport,\
         nb.cluster.webcommon,\
         nb.cluster.enterprise
 


### PR DESCRIPTION
Here is a review of the `ergonomics` cluster and its inclusion in the build. `ant rat` passes without complains.

It seems important to include `ergonomics` in the build as it solves UI clutter - by default all features are disabled and only when user uses PHP or Java, the essential modules get enabled. This reduces the likeahood of errors and performance - users pay only for the functionality they really use.

The concept of ergonomics can also solve the **download NbJavac** problem. Instead of showing a dialog, downloading and restarting, we'll be able to (as the Java modules are disabled by default), download first and then **just enable** the Java modules, saving one restart. I leave this for a separate PR, however. 