### PR TITLE
Fixed enable evaluation for cloned PropertyMonitors. Defined default …

### DIFF
--- a/openide.awt/src/org/openide/awt/ActionState.java
+++ b/openide.awt/src/org/openide/awt/ActionState.java
@@ -59,6 +59,9 @@ import org.openide.util.actions.Presenter;
  * <li>if {@link #checkValue} is {@link #NON_NULL_VALUE}, the action is checked if and only if
  * the value is not {@code null}. 
  * <li>if the value type is an enum, its {@link Enum#name} is compared to {@link #checkValue}
+ * <li>if the value is a {@link Collection} or {@link Map}, state evaluates to the {@link Collection#isEmpty} or
+ * {@link Map#isEmpty}, respectively.
+ * <li>if the value is a {@link Number}, state will be true if value evaluates to <b>a positive integer</b>.
  * <li>the state will be {@code false} (unchecked) otherwise.
  * <p/>
  * If {@link #type} is set to {@link Action}.class, the annotated element <b>must

--- a/openide.awt/src/org/openide/awt/PropertyMonitor.java
+++ b/openide.awt/src/org/openide/awt/PropertyMonitor.java
@@ -26,6 +26,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EventListener;
 import java.util.List;
@@ -520,6 +521,14 @@ class PropertyMonitor<T> implements ContextAction.StatefulMonitor<T>, PropertyCh
             }
         }
         if (checkedValue == null) {
+            // v is not null;
+            if (v instanceof Collection) {
+                return !((Collection) v).isEmpty();
+            } else if (v instanceof Map) {
+                return !((Map) v).isEmpty();
+            } else if (Number.class.isInstance(v)) {
+                return ((Number)v).intValue() > 0;
+            }
             return false;
         }
         if (checkedValue == ActionState.NON_NULL_VALUE) {
@@ -551,6 +560,7 @@ class PropertyMonitor<T> implements ContextAction.StatefulMonitor<T>, PropertyCh
         this.listenerType = other.listenerType;
         this.refGetter = other.refGetter;
         this.valueFactory = other.valueFactory;
+        this.valType = other.valType;
         this.refAddListener = other.refAddListener;
         this.refRemoveListener = other.refRemoveListener;
         this.listenerInterface = other.listenerInterface;

--- a/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/StatefulActionProcessorTest.java
+++ b/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/StatefulActionProcessorTest.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.DefaultListModel;
+import javax.swing.DefaultListSelectionModel;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -1376,5 +1378,45 @@ public class StatefulActionProcessorTest extends NbTestCase implements ContextGl
         public void actionPerformed(ActionEvent e) {
             received = e;
         }
+    }
+    
+    public void testCustomContextAwareInstance() {
+        Action a = Actions.forID("Foo", "test.ListAction");
+        DefaultListSelectionModel model = new DefaultListSelectionModel();
+        
+        InstanceContent localContent1 = new InstanceContent();
+        AbstractLookup localLookup1 = new AbstractLookup(localContent1);
+        
+        Action la = ((ContextAwareAction)a).createContextAwareInstance(localLookup1);
+        
+        assertFalse(a.isEnabled());
+        assertFalse(la.isEnabled());
+        
+        localContent1.add(model);
+        
+        assertFalse(a.isEnabled());
+        assertTrue(la.isEnabled());
+        assertFalse((Boolean)la.getValue(Action.SELECTED_KEY));
+        
+        // checks that the context-bound instance changes its selected state
+        // if the model changes (relevant property change event is fired)
+        model.setSelectionInterval(1, 2);
+        assertTrue((Boolean)la.getValue(Action.SELECTED_KEY));
+    }
+    
+    public void testCustomListenerAction() {
+        Action a = Actions.forID("Foo", "test.ListAction");
+        DefaultListSelectionModel model = new DefaultListSelectionModel();
+        
+        assertFalse(a.isEnabled());
+        assertFalse((Boolean)a.getValue(Action.SELECTED_KEY));
+        
+        lookupContent.add(model);
+        assertTrue(a.isEnabled());
+        assertFalse((Boolean)a.getValue(Action.SELECTED_KEY));
+        
+        model.addSelectionInterval(1, 1);
+        assertTrue(a.isEnabled());
+        assertTrue((Boolean)a.getValue(Action.SELECTED_KEY));
     }
 }


### PR DESCRIPTION
…behaviour for collections and numbers

I have found a subtle bug in the `@ActionState` implementation: when an action was cloned as `ContextAwareAction` (i.e. into a toolbar or menu,...), it did not completely clone the `PropertyMonitor` watching for property changes.
So after initial inspection for `enable` and `checked` status, the context-bound action state never changed.

This is fixed by `PropertyMonitor:564` one-liner.

It's ugly, but I have also incorporated slight convenience improvement for most common data types: if no equal value is specified using `@ActionState.checkedValue`, the enable/checked state will evaluate to true for non-empty Collections/Maps and positive numbers. See change `PropertyMonitor:524-531`.

Relevant test cases added.