### PR TITLE
[NETBEANS-1074] Module Review web.core.syntax

### DIFF
--- a/web.core.syntax/external/binaries-list
+++ b/web.core.syntax/external/binaries-list
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 F6E990DF59BD1FD2058320002A853A5411A45CD4 syntaxref20.zip
 41990E587485D3C6360FFF0EC8F8D2D3F53EC874 jsf12-tlddoc.zip
 9D80B456AFA21D92147F4BC4BB532335ADAC2C03 jstl11-doc.zip

--- a/web.core.syntax/l10n.list
+++ b/web.core.syntax/l10n.list
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # web/jspsyntax
 read global
 web/external/syntaxref20.zip

--- a/web.core.syntax/licenseinfo.xml
+++ b/web.core.syntax/licenseinfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<licenseinfo>
+    <fileset>
+        <file>src/org/netbeans/modules/web/core/syntax/completion/resources/class_16.png</file>
+        <file>src/org/netbeans/modules/web/core/syntax/completion/resources/bean_16.png</file>
+        <file>src/org/netbeans/modules/web/core/syntax/completion/resources/function_16.png</file>
+        <file>src/org/netbeans/modules/web/core/syntax/completion/resources/property_16.png</file>
+        <file>src/org/netbeans/modules/web/core/syntax/completion/resources/map_16.png</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="COMMENT_UNSUPPORTED" />
+    </fileset>
+    <fileset>
+        <file>src/org/netbeans/modules/web/core/syntax/resources/ELExample</file>
+        <file>src/org/netbeans/modules/web/core/syntax/resources/JSPExample</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP"/>        
+    </fileset>   
+</licenseinfo>

--- a/web.core.syntax/licenseinfo.xml
+++ b/web.core.syntax/licenseinfo.xml
@@ -33,6 +33,6 @@
         <file>src/org/netbeans/modules/web/core/syntax/resources/ELExample</file>
         <file>src/org/netbeans/modules/web/core/syntax/resources/JSPExample</file>
         <license ref="Apache-2.0-ASF" />
-        <comment type="TEMPLATE_MINIMAL_IP"/>        
+        <comment type="GUI_USABILITY"/>        
     </fileset>   
 </licenseinfo>


### PR DESCRIPTION
Checked the rat-report.txt file, don't know what to do with these files:
- cddl_11_license.txt
- struts-tags_apache20_license.txt

Add the license header for binaries-list and l10n.list
Could not find maven replacement for the binaries-list (old html references)
Add the licenseinfo.xml 

Skimmed through module, I see in the test folder there are src and data ones. The src one, the files have the license. In the data folder there are several examples and no license.