### PR TITLE
[NETBEANS-1074] Module Review groovy.editor

### DIFF
--- a/groovy.editor/licenseinfo.xml
+++ b/groovy.editor/licenseinfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<licenseinfo>
+    <fileset>
+        <file>src/org/netbeans/modules/groovy/editor/resources/FontsAndColorsPreview.groovy</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="GUI_USABILITY"/>
+    </fileset>
+    <fileset>
+        <file>src/org/netbeans/modules/groovy/editor/resources/GroovyFile16x16.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/class.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/duke.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/enum.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/interface.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/new_constructor_16.png</file>
+        <file>src/org/netbeans/modules/groovy/editor/resources/package.gif</file>
+        <file></file>
+        <file></file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="COMMENT_UNSUPPORTED" />
+    </fileset>
+</licenseinfo>

--- a/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/temporary/README.txt
+++ b/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/temporary/README.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Tests created in this package are here just because there is some problem with Classpath when multiple tests are run from
 the same file (some classpath information are lost after the first test and as a result other tests dependent on this
 classpath information will fail). Because at the moment I have no clue where is the problem, I decided to created temporary


### PR DESCRIPTION
- Add the license header to README.txt
- FontsAndColorsPreview.groovy is an example file, so add it to the licenseinfo.xml
- 13 unit tests fail