### PR TITLE
[NETBEANS-1074] Module Review libs.groovy

### DIFF
--- a/libs.groovy/external/binaries-list
+++ b/libs.groovy/external/binaries-list
@@ -1,1 +1,17 @@
-01730F61E9C9E59FD1B814371265334D7BE0B8D2 groovy-all-2.4.5.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+01730F61E9C9E59FD1B814371265334D7BE0B8D2 org.codehaus.groovy:groovy-all:2.4.5

--- a/libs.groovy/external/groovy-all-2.4.5-notice.txt
+++ b/libs.groovy/external/groovy-all-2.4.5-notice.txt
@@ -1,0 +1,10 @@
+Apache Groovy
+Copyright 2003-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product bundles icons from the famfamfam.com silk icons set
+http://www.famfamfam.com/lab/icons/silk/
+Licensed under the Creative Commons Attribution Licence v2.5
+http://creativecommons.org/licenses/by/2.5/

--- a/nbbuild/licenses/Apache-2.0-groovy
+++ b/nbbuild/licenses/Apache-2.0-groovy
@@ -1,8 +1,3 @@
-Name: Groovy
-Version: 2.4.5
-Description: Groovy Language distribution.
-License: Apache-2.0-groovy
-Origin: http://groovy-lang.org/
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
- Add the license header and maven coordinate to binaries-list
- Add the groovy-all-2.4.5-notice.txt
- Add the Apache-2.0-groovy license file to nbbuild/licenses
- Fix the groovy-all-2.4.5-license.txt

License: https://github.com/apache/groovy/blob/master/LICENSE
Notice: https://github.com/apache/groovy/blob/master/NOTICE

cc: @brunoflavio-com