### PR TITLE
[NETBEANS-1074] Module Review glassfish.eecommon

### DIFF
--- a/glassfish.eecommon/test/unit/src/org/netbeans/modules/glassfish/eecommon/api/FindJspServletHelperTest.java
+++ b/glassfish.eecommon/test/unit/src/org/netbeans/modules/glassfish/eecommon/api/FindJspServletHelperTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.netbeans.modules.glassfish.eecommon.api;
 
 


### PR DESCRIPTION
-no external library
-checked Rat report: everything has been relicensed to Apache, as this commit adds header to a java file that was missing header
-skimmed through module, did not notice additional problems