### PR TITLE
Issue #271110 - Attempt to pass -DarchetypeRepository to 3.x maven-archetype-plugin

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
@@ -65,7 +65,7 @@ public final class MavenCommandSettings {
                 toRet = "install:install-file";//NOI18N
             }
             else if (COMMAND_CREATE_ARCHETYPENG.equals(command)) {
-                toRet = "archetype:generate"; // NOI18N
+                toRet = "org.apache.maven.plugins:maven-archetype-plugin:2.4:generate"; // NOI18N
             }
             else if (COMMAND_SCM_CHECKOUT.equals(command)) {
                 toRet = "scm:checkout";//NOI18N


### PR DESCRIPTION
The fix of [BZ #271110](https://netbeans.org/bugzilla/show_bug.cgi?id=271110) was pushed to Mercurial by @tstupka a couple months before the initial code donation, but apparently was never ported to Git. I am very disturbed that at least two months’ worth of commit history seems to have been discarded. What else was lost?