### PR TITLE
[NETBEANS-1074] Module Review glassfish.javaee

### DIFF
--- a/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
+++ b/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
@@ -1,39 +1,20 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  *
  /*
  * @author davisn
@@ -83,7 +64,7 @@ public class ServerResourceProperties extends NbTestCase {
             fail("JDBC Connection DerbyPool missing!");
         }
     }
-    
+
 
     public void V3ServerProperties() {
         RuntimeTabOperator rto;

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFish.properties-dist
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFish.properties-dist
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 host=localhost
 adminUser=admin
 adminPassword=admin123

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFishHttp.properties-dist
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFishHttp.properties-dist
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 name=GlassFish Server 3.1.2.2
 serverHome=/users/tomas/WS/gfr3122/glassfish
 domainsFolder=/users/tomas/WS/gfr3122/glassfish/domains

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFishRest.properties-dist
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFishRest.properties-dist
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 name=GlassFish Server 4
 serverHome=/users/tomas/WS/gf4/glassfish
 domainsFolder=/users/tomas/WS/gf4/glassfish/domains

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/Java.properties-dist
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/Java.properties-dist
@@ -1,1 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 javaHome=/usr/jdk/jdk1.7.0_15

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/response/list-jdbc-resources.xml
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/response/list-jdbc-resources.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <map>
   <entry key="extraProperties">
     <map>

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/response/version.xml
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/response/version.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <map>
   <entry key="extraProperties">
     <map>

--- a/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
+++ b/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
@@ -1,41 +1,20 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 2012-2013 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * https://java.net/projects/gf-tooling/pages/License or LICENSE.TXT.
- * See the License for the specific language governing permissions
- * and limitations under the License.  When distributing the software,
- * include this License Header Notice in each file and include the License
- * file at LICENSE.TXT. Oracle designates this particular file as subject
- * to the "Classpath" exception as provided by Oracle in the GPL Version 2
- * section of the License file that accompanied this code. If applicable,
- * add the following below the License Header, with the fields enclosed
- * by brackets [] replaced by your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- * 
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
- * 
- * Contributor(s):
- * 
- * Portions Copyrighted 2008 Sun Microsystems, Inc.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.netbeans.modules.glassfish.tooling.data;
 
@@ -81,7 +60,7 @@ public class GlassFishVersionTest {
             assertTrue(version.toString() != null);
         }
     }
-    
+
     /**
      * Test that <code>toValue</code> handles all <code>enum</code> values
      * and that sequence of <code>toString</code> and <code>toValue</code>
@@ -140,7 +119,7 @@ public class GlassFishVersionTest {
             assertTrue(versions[i].equals(version));
         }
     }
-    
+
     /**
      * Verify <code>toFullString</code> method.
      */
@@ -165,7 +144,7 @@ public class GlassFishVersionTest {
             } catch (NumberFormatException nfe) {
                 fail("Could not parse version number");
             }
-            
+
         }
     }
 


### PR DESCRIPTION
- no external library
- checked Rat Report: everything relicensed to Apache, this commit changes header to java file containing Oracle licensing
- skimmed module, did not notice additional problems