### PR TITLE
[NETBEANS-803] Uptake nb-javac 11 jars for java tests runtime

### DIFF
--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C118C62F36DEA3EDCBC53B95DDA3275B012B4DFC nb-javac-9-api.jar
+5315CCC2626F13C8EB620D21EF25C2501BD2D6AF nb-javac-9-api.jar

--- a/java/libs.javacimpl/external/binaries-list
+++ b/java/libs.javacimpl/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-58FB802FDDA63D542093356F44F6CC896AF109E1 nb-javac-9-impl.jar
+F5ABB7CA56096B881173E987AC62F13C9DB7A64D nb-javac-9-impl.jar


### PR DESCRIPTION
Updated with nb-javac jars synced with JDK 11 code.
Test results are in corresponding jira bug.