### PR TITLE
Trust every shown dialog

### DIFF
--- a/platform/core.execution/src/org/netbeans/core/execution/SecMan.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/SecMan.java
@@ -96,7 +96,9 @@ public class SecMan extends SecurityManager {
         if ("showWindowWithoutWarningBanner".equals(perm.getName())) { // NOI18N
             checkTopLevelWindow(context);
         }
-        super.checkPermission(perm, context);
+        if (context instanceof AccessControlContext) {
+            super.checkPermission(perm, context);
+        }
     }
 
     public boolean checkTopLevelWindow(Object window) {


### PR DESCRIPTION
Fine tuning of #790. Shown dialogs were associated with a warning. By returning `true` from the `checkTopLevelWindow` method of `SecMan` instance, the warning disappears.