### PR TITLE
[NETBEANS-1074] Module review glassfish.javaee

### DIFF
--- a/glassfish.javaee/licenseinfo.xml
+++ b/glassfish.javaee/licenseinfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<licenseinfo>
+    <fileset>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/appclient.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/ConfigFile.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/connector.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/javamail.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/jdbc.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/jms.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/jndi.gif</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/Serverinstanceicon.png</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="COMMENT_UNSUPPORTED" />
+    </fileset>
+</licenseinfo>

--- a/glassfish.javaee/licenseinfo.xml
+++ b/glassfish.javaee/licenseinfo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -7,13 +8,16 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
+
       http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <licenseinfo>
     <fileset>
@@ -24,7 +28,7 @@
         <file>src/org/netbeans/modules/glassfish/javaee/resources/jdbc.gif</file>
         <file>src/org/netbeans/modules/glassfish/javaee/resources/jms.gif</file>
         <file>src/org/netbeans/modules/glassfish/javaee/resources/jndi.gif</file>
-        <file>src/org/netbeans/modules/glassfish/javaee/resources/Serverinstanceicon.png</file>
+        <file>src/org/netbeans/modules/glassfish/javaee/resources/ServerInstanceIcon.png</file>
         <license ref="Apache-2.0-ASF" />
         <comment type="COMMENT_UNSUPPORTED" />
     </fileset>

--- a/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
+++ b/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
@@ -16,10 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  *
- /*
  * @author davisn
- *
- * Portions Copyrighted 2009 Sun Microsystems, Inc.
  */
 
 package org.netbeans.modules.glassfish.javaee.test;

--- a/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
+++ b/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
@@ -15,7 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
+ */
+ 
+ /**
  * @author davisn
  */
 

--- a/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
+++ b/glassfish.javaee/test/qa-functional/src/org/netbeans/modules/glassfish/javaee/test/ServerResourceProperties.java
@@ -1,39 +1,20 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  *
  /*
  * @author davisn
@@ -83,7 +64,7 @@ public class ServerResourceProperties extends NbTestCase {
             fail("JDBC Connection DerbyPool missing!");
         }
     }
-    
+
 
     public void V3ServerProperties() {
         RuntimeTabOperator rto;


### PR DESCRIPTION
- No External Libary
- Checked Rat report: everything has now been relicensed to Apache, as this commit channges header to java file that was licensed to Oracle
- Skimmed through module...no additional problems found
- Added licenseinfo.xml