### PR TITLE
[NETBEANS-1074] Module Review libs.plist

### DIFF
--- a/libs.plist/external/binaries-list
+++ b/libs.plist/external/binaries-list
@@ -1,1 +1,17 @@
-59631804B5A7FF3CEAA3F0E113584AF7E1BB6E9B dd-plist.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+F1FFEA79B6034718AC4298D60F98F10B878EC476 com.googlecode.plist:dd-plist:1.3

--- a/libs.plist/external/dd-plist-1.3-license.txt
+++ b/libs.plist/external/dd-plist-1.3-license.txt
@@ -1,0 +1,26 @@
+Name: plist
+Version: 1.3
+Description: An open source library to parse and generate property lists
+License: MIT-dd-plist
+Origin: https://github.com/3breadt/dd-plist
+
+dd-plist - An open source library to parse and generate property lists
+Copyright (C) 2016 Daniel Dreibrodt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs.plist/manifest.mf
+++ b/libs.plist/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.plist
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/plist/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.8
+OpenIDE-Module-Specification-Version: 1.9
 

--- a/libs.plist/nbproject/project.properties
+++ b/libs.plist/nbproject/project.properties
@@ -17,7 +17,7 @@
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
-release.external/dd-plist.jar=modules/ext/dd-plist.jar
+release.external/dd-plist-1.3.jar=modules/ext/dd-plist.jar
 
 sigtest.gen.fail.on.error=false
 

--- a/nbbuild/licenses/MIT-dd-plist
+++ b/nbbuild/licenses/MIT-dd-plist
@@ -1,11 +1,5 @@
-Name: plist
-Version: 99
-Description: An open source library to parse and generate property lists
-License: MIT-plist
-Origin: http://code.google.com/p/plist/
-Files: dd-plist.jar
-
-Copyright (C) 2012 Daniel Dreibrodt
+dd-plist - An open source library to parse and generate property lists
+Copyright (C) 2016 Daniel Dreibrodt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nbbuild/licenses/names.properties
+++ b/nbbuild/licenses/names.properties
@@ -43,6 +43,7 @@ CDDL-GPL-2-CP=Dual license consisting of the CDDL v1.1 and GPL v2 with Classpath
 Apache-2.0+BSD-INRIA=Apache Version 2.0 and BSD license with INRIA copyright
 MIT-jvyamlb=MIT license jvyamlb variant
 HTML5DOC=HTML5DOC license
+MIT-dd-plist=MIT license dd-plist variant
 MIT-html5-parser=MIT license html5 parser variant
 MIT-icu4j=MIT license icu4j variant
 MIT-isorelax=MIT license isorelax variant


### PR DESCRIPTION
- Add the license header to binaries-list
- Add maven coordinate (Change the version from 1.1-SNAPSHOT to 1.3)
- Add MIT-dd-plist to nbbuild/licenses

I've added [version 1.3](https://search.maven.org/artifact/com.googlecode.plist/dd-plist/1.3/jar) instead of 1.1-SNAPSHOT because version 1.1 does not exist in the maven central. (The latest version is 1.21)