### PR TITLE
Enable source=1.8 for Java Frontend Web Application

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -1003,9 +1003,9 @@ public class JavacParser extends Parser {
                                new Object[]{srcClassPath, sourceLevel, bootClassPath}); //NOI18N
                 }
                 if (source.compareTo(SourceLevelUtils.JDK1_8) >= 0 &&
-                    !hasResource("java/util/stream/Streams", new ClassPath[] {bootClassPath}, new ClassPath[] {classPath}, new ClassPath[] {srcClassPath})) { //NOI18N
+                    !hasResource("java/lang/invoke/LambdaMetafactory", new ClassPath[] {bootClassPath}, new ClassPath[] {classPath}, new ClassPath[] {srcClassPath})) { //NOI18N
                     LOGGER.log(warnLevel,
-                               "Even though the source level of {0} is set to: {1}, java.util.stream.Streams cannot be found on the bootclasspath: {2}\n" +   //NOI18N
+                               "Even though the source level of {0} is set to: {1}, java.lang.invoke.LambdaMetafactory cannot be found on the bootclasspath: {2}\n" +   //NOI18N
                                "Changing source level to 1.7",  //NOI18N
                                new Object[]{srcClassPath, sourceLevel, bootClassPath}); //NOI18N
                     return SourceLevelUtils.JDK1_7;


### PR DESCRIPTION
Apache NetBeans 9.0 provides **Java Frontend Application** which can be deployed to desktop, Android, iOS and also Web. When compiling for web, only a subset of JDK8 APIs is available. To make sure the IDE and the runtime agree on the same classes, it is useful to configure compiler plugin like this:
```xml
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>
    </properties>
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <version>3.8.0</version>
                <configuration>
                    <compilerArguments>
                        <bootclasspath>netbeans.ignore.jdk.bootclasspath</bootclasspath>
                    </compilerArguments>
                </configuration>
            </plugin>
```
Then `rt.jar` is ignored and only libraries from dependencies are placed on `javac` compilation paths. However in such mode the IDE complains that lamda functions aren't supported. This is what appears in the log file:
```
Even though the source level of code/src/main/resources is set to: 1.8, 
java.util.stream.Streams cannot be found on the bootclasspath: 
incubator-netbeans/netbeans.ignore.jdk.bootclasspath
Changing source level to 1.7
```
That is correct - `Streams` class isn't present in the web emulation layer. However that should not be a reason for disabling 1.8 features. All that is needed is presence of `LambdaMetafactory` and then support for lamda functions may remain on.

This PR changes the detection system.