### PR TITLE
[NetBeans-1181]Disable hint 'Use var parameter types' for empty param…

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
@@ -246,16 +246,17 @@ public class Lambda {
             return null;
         }
         // Check invalid lambda parameter declaration
-        if (ctx.getInfo().getTreeUtilities().hasError(ctx.getPath().getLeaf(), LAMBDA_PARAMETER_ERROR_CODES)) {
+        if (ctx.getInfo().getTreeUtilities().hasError(ctx.getPath().getLeaf())) {
             return null;
         }
         // Check var parameter types
         LambdaExpressionTree let = (LambdaExpressionTree) ctx.getPath().getLeaf();
-        if (let.getParameters() != null && let.getParameters().size() > 0) {
-            VariableTree var = let.getParameters().get(0);
-            if (ctx.getInfo().getTreeUtilities().isVarType(new TreePath(ctx.getPath(), var))) {
-                return null;
-            }
+        if (let.getParameters() == null || let.getParameters().isEmpty()) {
+            return null;
+        }
+        VariableTree var = let.getParameters().get(0);
+        if (ctx.getInfo().getTreeUtilities().isVarType(new TreePath(ctx.getPath(), var))) {
+            return null;
         }
 
         return ErrorDescriptionFactory.forName(ctx, ctx.getPath(), NbBundle.getMessage(Lambda.class, "ERR_ConvertVarLambdaParameters"), new AddVarLambdaParameterTypes(ctx.getInfo(), ctx.getPath()).toEditorFix());


### PR DESCRIPTION

Fix for following issues:
1. https://issues.apache.org/jira/browse/NETBEANS-1181
Disable hint 'Use var parameter types' for empty parameter list
2. https://issues.apache.org/jira/browse/NETBEANS-1182
Issues in hint 'Use var Parameter types' with nb-javac 11