### PR TITLE
[NETBEANS-1171] Ensure tlddoc can be build if invoked outside project…

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -364,19 +364,20 @@ public class VerifyLibsAndLicenses extends Task {
                         }
                     }
                 }
-                if(! headers.getOrDefault("Type", "").equals("generated")) {
-                    // Generated files are created by the build system, for
-                    // example by post-procession other downloaded files
-                    String files = headers.get("Files");
-                    if (files != null) {
-                        for (String file : files.split("[, ]+")) {
-                            referencedBinaries.add(file);
-                            String nested = null;
-                            if (file.contains("!/")) {
-                                final int nestedStart = file.indexOf("!/");
-                                nested = file.substring(nestedStart + 2);
-                                file = file.substring(0, nestedStart);
-                            }
+
+                String files = headers.get("Files");
+                if (files != null) {
+                    for (String file : files.split("[, ]+")) {
+                        referencedBinaries.add(file);
+                        String nested = null;
+                        if (file.contains("!/")) {
+                            final int nestedStart = file.indexOf("!/");
+                            nested = file.substring(nestedStart + 2);
+                            file = file.substring(0, nestedStart);
+                        }
+                        if (!headers.getOrDefault("Type", "").equals("generated")) {
+                            // Generated files are created by the build system, for
+                            // example by post-procession other downloaded files
                             if (!hgFiles.contains(file)) {
                                 msg.append("\n" + path + " mentions a nonexistent binary in Files: " + file);
                             } else if (nested != null) {
@@ -388,16 +389,21 @@ public class VerifyLibsAndLicenses extends Task {
                                 }
                             }
                         }
-                    } else {
-                        String matchingJar = n.replaceFirst("-license\\.txt$", ".jar");
-                        String matchingZip = n.replaceFirst("-license\\.txt$", ".zip");
-                        referencedBinaries.add(matchingJar);
-                        referencedBinaries.add(matchingZip);
+                    }
+                } else {
+                    String matchingJar = n.replaceFirst("-license\\.txt$", ".jar");
+                    String matchingZip = n.replaceFirst("-license\\.txt$", ".zip");
+                    referencedBinaries.add(matchingJar);
+                    referencedBinaries.add(matchingZip);
+                    if (!headers.getOrDefault("Type", "").equals("generated")) {
+                        // Generated files are created by the build system, for
+                        // example by post-procession other downloaded files
                         if (!hgFiles.contains(matchingJar) && !hgFiles.contains(matchingZip)) {
                             msg.append("\n" + path + " has no Files header and no corresponding " + matchingJar + " or " + matchingZip + " could be found");
                         }
                     }
                 }
+
             }
             for (String n : hgFiles) {
                 if (!n.endsWith(".jar") && !n.endsWith(".zip")) {

--- a/web.core.syntax/build.xml
+++ b/web.core.syntax/build.xml
@@ -21,12 +21,12 @@
 -->
 <project name="web.core.syntax" default="netbeans" basedir=".">
 
-    <import file="../j2ee.kit/register_server.xml"/> 
+    <import file="../j2ee.kit/register_server.xml"/>
     <import file="../nbbuild/templates/projectized.xml"/>
 
-    <!-- Hook into harness "basic-init" task -->
+    <!-- Hook into harness "-process.release.files" task -->
     <target name="-process.release.files" depends="prepare-doc"/>
-    
+
     <!-- Check if taglib doc was already generated -->
     <target name="-check-prepared-doc">
         <condition property="web.core.syntax.doccreated" value="present">
@@ -37,13 +37,13 @@
             </and>
         </condition>
     </target>
-    
-    <target name="prepare-doc" depends="-check-prepared-doc,-define-FileCRC32Calculator" unless="web.core.syntax.doccreated">
+
+    <target name="prepare-doc" depends="-check-prepared-doc" unless="web.core.syntax.doccreated">
         <!--
-        
+
         This task prepares the tld doc, that are downloaded as pre-build
         binaries. The procedure:
-        
+
         - the Tag Library Documentation Generator is loaded via the external binaries task
         - the jars the docs are build for are also downloaded by the same mechanism
         - the generator expects in each generation invocation, that the short
@@ -51,7 +51,7 @@
           names are modified below
         - the generated files are the zipped and need to be manually uploaded
           to the netbeans binaries server
-        
+
         -->
         <delete dir="build/tlddoc-build" />
         <mkdir dir="build/tlddoc-build/jstl11" />
@@ -82,43 +82,43 @@
                 <pathelement location="external/tlddoc-1.3.jar" />
             </classpath>
             <arg value="-d" />
-            <arg value="build/tlddoc-build/jstl11-out" />
+            <arg value="${basedir}/build/tlddoc-build/jstl11-out" />
             <arg value="-xslt" />
-            <arg value="tlddoc/xslt/" />
+            <arg value="${basedir}/tlddoc/xslt/" />
             <arg value="-doctitle" />
             <arg value="JavaServer Pages Standard Tag Library 1.1 Tag Reference" />
             <arg value="-windowtitle" />
             <arg value="JSPL 1.1 - Generated Documentation" />
-            <arg value="build/tlddoc-build/jstl11-input.jar" />
+            <arg value="${basedir}/build/tlddoc-build/jstl11-input.jar" />
         </java>
         <java classname="com.sun.tlddoc.TLDDoc">
             <classpath>
                 <pathelement location="external/tlddoc-1.3.jar" />
             </classpath>
             <arg value="-d" />
-            <arg value="build/tlddoc-build/jsf12-out" />
+            <arg value="${basedir}/build/tlddoc-build/jsf12-out" />
             <arg value="-xslt" />
-            <arg value="tlddoc/xslt/" />
+            <arg value="${basedir}/tlddoc/xslt/" />
             <arg value="-doctitle" />
             <arg value="JavaServer Faces 1.2" />
             <arg value="-windowtitle" />
             <arg value="JSF 1.2 - Generated Documentation" />
-            <arg value="external/jsf-impl-1.2-20.jar" />
+            <arg value="${basedir}/external/jsf-impl-1.2-20.jar" />
         </java>
         <java classname="com.sun.tlddoc.TLDDoc">
             <classpath>
                 <pathelement location="external/tlddoc-1.3.jar" />
             </classpath>
             <arg value="-d" />
-            <arg value="build/tlddoc-build/struts.out" />
+            <arg value="${basedir}/build/tlddoc-build/struts.out" />
             <arg value="-xslt" />
-            <arg value="tlddoc/xslt/" />
+            <arg value="${basedir}/tlddoc/xslt/" />
             <arg value="-doctitle" />
             <arg value="The Struts Framework Project" />
             <arg value="-windowtitle" />
             <arg value="Struts - Generated Documentation" />
-            <arg value="external/struts-taglib-1.3.10.jar" />
-            <arg value="external/struts-tiles-1.3.10.jar" />
+            <arg value="${basedir}/external/struts-taglib-1.3.10.jar" />
+            <arg value="${basedir}/external/struts-tiles-1.3.10.jar" />
         </java>
 
         <jar destfile="external/generated-jstl11-doc-1.1.2.zip">


### PR DESCRIPTION
… directory

The build procedure for the tlddocs was tested from within the 
web.core.syntax module. The build fails if called from another
directory, which happens when invoked from the global build.

Adding the ${basedir} ensures, that the correct directory is used
for the build.