### PR TITLE
Adjusted locations of test data after moving into cluster subdirs

### DIFF
--- a/ide/httpserver/nbproject/project.properties
+++ b/ide/httpserver/nbproject/project.properties
@@ -19,8 +19,8 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.6
 spec.version.base=2.39.0
 release.external/webserver-3.2.4.jar=modules/ext/webserver.jar
-test-unit-sys-prop.xtest.data=${nb_all}/httpserver/test/unit/testfs
-test.unit.data.dir=${nb_all}/httpserver/test/unit/testfs
+test-unit-sys-prop.xtest.data=${nb_all}/ide/httpserver/test/unit/testfs
+test.unit.data.dir=${nb_all}/ide/httpserver/test/unit/testfs
 disable.qa-functional.tests=true
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/java.freeform/nbproject/project.properties
+++ b/java/java.freeform/nbproject/project.properties
@@ -22,8 +22,8 @@ javadoc.apichanges=${basedir}/apichanges.xml
 
 # XXX using a data dir from another module means that test4u will not be able to run these tests!
 # Better to fix by not using a data dir (just generator), or copying required files into java/freeform/test/unit/data
-test-unit-sys-prop.xtest.data=${nb_all}/ant.freeform/test/unit/data
-test.unit.data.dir=${nb_all}/ant.freeform/test/unit/data
+test-unit-sys-prop.xtest.data=${nb_all}/java/ant.freeform/test/unit/data
+test.unit.data.dir=${nb_all}/java/ant.freeform/test/unit/data
 # masterfs needed for the usual reasons
 # core needed for ArchiveURLMapper
 test-unit-sys-prop.test.ant.home=${o.apache.tools.ant.module.dir}/ant


### PR DESCRIPTION
I found several tests which fail because their data dir points to base dir's subdirectory rather than to the location in cluster subdirectory.