### PR TITLE
[NETBEANS-1147] Better enablement of fragment modules.

### DIFF
--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
@@ -545,11 +545,7 @@ public class AutoupdateCatalogParser extends DefaultHandler {
             String autoload = module.getValue (MODULE_ATTR_AUTOLOAD);
             String preferred = module.getValue(MODULE_ATTR_IS_PREFERRED_UPDATE);
                         
-            if (isFragment) {
-                needsRestart = true;
-            } else {
-                needsRestart = needsrestart == null || needsrestart.trim ().length () == 0 ? null : Boolean.valueOf (needsrestart);
-            }
+            needsRestart = isFragment || needsrestart == null || needsrestart.trim ().length () == 0 ? null : Boolean.valueOf (needsrestart);
             isGlobal = global == null || global.trim ().length () == 0 ? null : Boolean.valueOf (global);
             isEager = Boolean.parseBoolean (eager);
             isAutoload = Boolean.parseBoolean (autoload);

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogParser.java
@@ -545,7 +545,11 @@ public class AutoupdateCatalogParser extends DefaultHandler {
             String autoload = module.getValue (MODULE_ATTR_AUTOLOAD);
             String preferred = module.getValue(MODULE_ATTR_IS_PREFERRED_UPDATE);
                         
-            needsRestart = isFragment || needsrestart == null || needsrestart.trim ().length () == 0 ? null : Boolean.valueOf (needsrestart);
+            if (isFragment) {
+                needsRestart = true;
+            } else {
+                needsRestart = needsrestart == null || needsrestart.trim ().length () == 0 ? null : Boolean.valueOf (needsrestart);
+            }
             isGlobal = global == null || global.trim ().length () == 0 ? null : Boolean.valueOf (global);
             isEager = Boolean.parseBoolean (eager);
             isAutoload = Boolean.parseBoolean (autoload);

--- a/platform/core.startup/nbproject/project.xml
+++ b/platform/core.startup/nbproject/project.xml
@@ -31,7 +31,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.61</specification-version>
+                        <specification-version>2.81</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/o.n.bootstrap/manifest.mf
+++ b/platform/o.n.bootstrap/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.bootstrap/1
-OpenIDE-Module-Specification-Version: 2.80
+OpenIDE-Module-Specification-Version: 2.81
 OpenIDE-Module-Localizing-Bundle: org/netbeans/Bundle.properties
 OpenIDE-Module-Recommends: org.netbeans.NetigsoFramework
 

--- a/platform/o.n.bootstrap/src/org/netbeans/Module.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Module.java
@@ -240,7 +240,10 @@ public abstract class Module extends ModuleInfo {
     }
     
     String getFragmentHostCodeName() {
-        String fragmentHostCodeName;
+        String fragmentHostCodeName = mgr.fragmentFor(getJarFile());
+        if (fragmentHostCodeName != null) {
+            return fragmentHostCodeName.isEmpty() ? null : fragmentHostCodeName;
+        }
         try {
             fragmentHostCodeName = data().getFragmentHostCodeName();
         } catch (IllegalStateException ex) {

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -256,9 +256,7 @@ public final class Util {
                     List<Module> providers = providersOf.get(dep.getName());
 
                     if (providers != null) {
-                        if (l == null) {
-                            l = new LinkedList<Module>();
-                        }
+                        l = fillMapSlot(m, m1);
                         l.addAll(providers);
                     }
                 }
@@ -267,9 +265,7 @@ public final class Util {
                     Module m2 = modulesByName.get(cnb);
 
                     if (m2 != null && modulesSet.contains(m2)) {
-                        if (l == null) {
-                            l = new LinkedList<Module>();
-                        }
+                        l = fillMapSlot(m, m1);
                         l.add(m2);
                     }
                 }
@@ -283,14 +279,14 @@ public final class Util {
                 frags.retainAll(modules);
             
                 for (Module f : frags) {
+                    List<Module> fragmentDep = fillMapSlot(m, f);
+                    fragmentDep.add(m1);
                     for (Dependency dep : f.getDependenciesArray()) {
                         if (dep.getType() == Dependency.TYPE_REQUIRES) {
                             List<Module> providers = providersOf.get(dep.getName());
 
                             if (providers != null) {
-                                if (l == null) {
-                                    l = new LinkedList<Module>();
-                                }
+                                l = fillMapSlot(m, m1);
                                 l.addAll(providers);
                             }
                         }
@@ -299,9 +295,7 @@ public final class Util {
                             Module m2 = modulesByName.get(cnb);
 
                             if (m2 != null && modulesSet.contains(m2)) {
-                                if (l == null) {
-                                    l = new LinkedList<Module>();
-                                }
+                                l = fillMapSlot(m, m1);
                                 l.add(m2);
                             }
                         }
@@ -316,6 +310,15 @@ public final class Util {
             }
         }
         return m;
+    }
+
+    private static List<Module> fillMapSlot(Map<Module, List<Module>> map, Module module) {
+        List<Module> l = map.get(module);
+        if (l == null) {
+            l = new LinkedList<>();
+            map.put(module, l);
+        }
+        return l;
     }
     
     /**

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment
+OpenIDE-Module-Fragment-Host: org.foo.host
+OpenIDE-Module-Name: Fragment Content Module
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module/org/foo/FragmentContent.java
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module/org/foo/FragmentContent.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.foo;
+// Does not do anything, just needs to be here & loadable.
+public class FragmentContent {
+    protected String something() {
+        return "I am an added fragment";
+    }
+}

--- a/platform/o.n.bootstrap/test/unit/data/jars/host-module.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/host-module.mf
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.host
+OpenIDE-Module-Name: Fragment Host module
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/host-module/org/foo/Something.java
+++ b/platform/o.n.bootstrap/test/unit/data/jars/host-module/org/foo/Something.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.foo;
+// Does not do anything, just needs to be here & loadable.
+public class Something {
+    protected String something() {
+        return "I am a fragment host module";
+    }
+}

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -233,6 +233,9 @@ public abstract class SetupHid extends NbTestCase {
         createTestJAR("medium-manifest", null);
         createTestJAR("big-manifest", null);
         createTestJAR("patchable", null);
+        
+        createTestJAR("fragment-module", null);
+        createTestJAR("host-module", null);
         { // Make the patch JAR specially:
             File src = new File(data, "patch");
             String srcS = src.getAbsolutePath();


### PR DESCRIPTION
Inspired by #715 change with additional tests provided.

Originally the branch should only add tests, but as it showed up, some corner cases were not handled (I think) still well.

I wanted to cover 3 cases: 
1. the user enables a module which is a fragment; which should imply enabling the host module as well. 2.  if the user enables the hosting module which just happens to have some fragments around, all those will be enabled and injected (if dependencies are satisfied)
3. if a fragment is enabled, but its host module is **already loaded and live**, the fragment cannot (reliably) join the constructed classloader. Exception should be thrown.

- I found a place in `AutoupdateCatalogParser` where the `needsRestart` condition is probably wrong: if the module is a fragment, then the restart is always needed. Maybe could be refined more in that the host module must be already installed & enabled.

- in original code, the fragments were registered at the start of `ModuleManager.enable`, so that `simulateEnable` would not report them. I changed that so `ModuleManager` collects fragment list immediately as fragment `Module` objects are created. Then it can always find all fragments for a module.
