### PR TITLE
[NETBEANS-406] Fix a potential memory leak involving DocumentUtilitie…

### DIFF
--- a/ide/editor.lib2/nbproject/project.properties
+++ b/ide/editor.lib2/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 javac.source=1.7
 javac.compilerargs=-Xlint:unchecked
-spec.version.base=2.20.0
+spec.version.base=2.21.0
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/editor.lib2/nbproject/project.xml
+++ b/ide/editor.lib2/nbproject/project.xml
@@ -66,7 +66,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.64</specification-version>
+                        <specification-version>1.68</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -909,7 +909,7 @@ public final class DocumentViewOp
             Document doc = docView.getDocument();
             updateTextLimitLine(doc);
             clearStatusBits(AVAILABLE_WIDTH_VALID);
-            DocumentUtilities.addPropertyChangeListener(doc, WeakListeners.propertyChange(this, doc));
+            DocumentUtilities.addWeakPropertyChangeListener(doc, this);
         }
     }
     

--- a/ide/editor.util/apichanges.xml
+++ b/ide/editor.util/apichanges.xml
@@ -83,6 +83,24 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="DocumentUtilities.addWeakPropertyChangeListener">
+          <summary>Added support for adding weak property change listeners to documents</summary>
+          <version major="1" minor="68"/>
+          <date day="6" month="9" year="2018"/>
+          <author login="matthiasblaesing"/>
+          <compatibility addition="yes" binary="compatible" semantic="compatible" />
+          <description>
+              <p>
+                  Added support for adding weak property change listeners to documents
+                  by providing
+                  <code>DocumentUtilities.addWeakPropertyChangeListener(doc, listenerImplementation)</code>.
+                  The supplied <code>listenerImplementation</code> is not held via
+                  a strong reference, but a weak reference and so can be GCed
+                  independendly of the referencing document.
+              </p>
+          </description>
+          <issue number="NETBEANS-406"/>
+      </change>
       <change id="GapListAddAll">
           <summary>Added methods to append elements to a GapList</summary>
           <version major="1" minor="64"/>

--- a/ide/editor.util/manifest.mf
+++ b/ide/editor.util/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.editor.util/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/editor/util/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 1.67
+OpenIDE-Module-Specification-Version: 1.68

--- a/ide/editor.util/nbproject/project.xml
+++ b/ide/editor.util/nbproject/project.xml
@@ -24,7 +24,16 @@
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
             <code-name-base>org.netbeans.modules.editor.util</code-name-base>
-            <module-dependencies/>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.10</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
             <test-dependencies>
                 <test-type>
                     <name>unit</name>


### PR DESCRIPTION
…s.addPropertyChangeListener.

WeakListeners.propertyChange(lister, source) expected, that it can
detach from the supplied source by invoking removePropertyChangeListener
on it. This contract is violated in this construct:

DocumentUtilities.addPropertyChangeListener(doc, WeakListeners.propertyChange(this, doc));

DocumentUtilities does not attach the PropertyChangeListener to the
document, but to a PropertyChangeLister contained in it. The Document
itself does not support removePropertyChangeListener.

The solution is to add a new api method addWeakPropertyChangeListener,
that hides the complexity from the user.

The issue was raised and diagnosed by Eirik Bakke.

Closes: #515 