### PR TITLE
[NETBEANS-1064] Default System Browser not detected

### DIFF
--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
@@ -58,7 +58,11 @@ public class SystemDefaultBrowser extends ExtWebBrowser {
                 ACTIVE = Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE);
             }
         } else {
-            ACTIVE = false;
+            if (Utilities.isWindows()) {
+                ACTIVE = Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE);
+            } else {
+                ACTIVE = false;
+            }
         }
     }
 


### PR DESCRIPTION
Default System Browser always show IE in window system. 
Steps: Help -> Start Page -> Take a Tour --> The URL will open in IE irrespective of default system browser set in window system.

Apache Jira issue path: https://issues.apache.org/jira/projects/NETBEANS/issues/NETBEANS-1064