### PR TITLE
Weaker dependency on IOS platform plugin (removed from webcommon clus…

### DIFF
--- a/webcommon/cordova/manifest.mf
+++ b/webcommon/cordova/manifest.mf
@@ -3,3 +3,5 @@ OpenIDE-Module: org.netbeans.modules.cordova
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/cordova/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.36
 OpenIDE-Module-Layer: org/netbeans/modules/cordova/resources/layer.xml
+OpenIDE-Module-Recommends: cnb.org.netbeans.modules.cordova.platforms.ios
+

--- a/webcommon/cordova/nbproject/project.xml
+++ b/webcommon/cordova/nbproject/project.xml
@@ -101,12 +101,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.cordova.platforms.ios</code-name-base>
-                    <run-dependency>
-                        <specification-version>1.11</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.extexecution</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
…ter in std. build)

Following #856 Netbeans complain about not having `cordova.platform.ios` on startup. The module is not needed for compilation, so I changed the dependency to `OpenIDE-Module-Recommends`. The IDE wills start without any messages and if `cordova.platform.ios` happens to be installed (i.e. another distribution), it will be enabled.