### PR TITLE
[NETBEANS-1241] Remove Blogs panel from Welcome screen

### DIFF
--- a/nb/welcome/src/org/netbeans/modules/welcome/ui/WhatsNewTab.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/ui/WhatsNewTab.java
@@ -45,8 +45,8 @@ class WhatsNewTab extends AbstractTab {
         main.add( new ContentSection( BundleSupport.getLabel( "SectionNewsAndTutorials" ), //NOI18N
                 new ArticlesAndNews(), true ));
         
-        main.add( new ContentSection( BundleSupport.getLabel( "SectionBlogs" ), //NOI18N
-                new Blogs(), true ) );
+       // main.add( new ContentSection( BundleSupport.getLabel( "SectionBlogs" ), //NOI18N
+       //         new Blogs(), true ) );
 
         return main;
     }


### PR DESCRIPTION
The Oracle server that provides planetnetbeans.org is down.

It is unlikely it will come back up – there are security issues involved and it will probably be retired,

planetnetbeans.org is being donated to Apache, both the domain and the application.

However, both these tasks are incomplete. Probably this will not be completed in time for the November release.

I propose we simply remove the Blogs panel from the Welcome screen, which still looks great without it, since the News & Tutorials panel then automatically takes up the whole area of the Welcome screen.