### PR TITLE
[NETBEANS-1242] What's New link

### DIFF
--- a/nb/welcome/src/org/netbeans/modules/welcome/resources/whatsnew.url
+++ b/nb/welcome/src/org/netbeans/modules/welcome/resources/whatsnew.url
@@ -1,1 +1,1 @@
-http://wiki.netbeans.org/NewAndNoteWorthy?utm_source=netbeans&utm_campaign=welcomepage
+https://netbeans.apache.org/download/index.html


### PR DESCRIPTION
The Welcome screen's What's New link point to netbeans.org, could point here instead:

https://netbeans.apache.org/download/index.html