### PR TITLE
[NETBEANS-1243] Community link

### DIFF
--- a/nb/welcome/src/org/netbeans/modules/welcome/resources/community.url
+++ b/nb/welcome/src/org/netbeans/modules/welcome/resources/community.url
@@ -1,1 +1,1 @@
-http://netbeans.org/community/index.html?utm_source=netbeans&utm_campaign=welcomepage
+https://netbeans.apache.org/community/index.html


### PR DESCRIPTION
On the Welcome Screen, the Community link points here:

https://netbeans.org/community/index.html?utm_source=netbeans&utm_campaign=welcomepage

...should maybe point here instead:

https://netbeans.apache.org/community/index.html