### PR TITLE
Relicensed leftover file, excluded cordova testing data

### DIFF
--- a/webcommon/cordova.platforms.ios/licenseinfo.xml
+++ b/webcommon/cordova.platforms.ios/licenseinfo.xml
@@ -21,13 +21,6 @@
 -->
 <licenseinfo>
     <fileset>
-        <!-- Test data, should not contain comments -->
-        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml</file>
-        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml</file>
-        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml</file>
-        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml</file>
-        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml</file>
-        
         <file>iDeviceNativeBinding/nbproject/Makefile-Debug.mk</file>
         <file>iDeviceNativeBinding/nbproject/Makefile-Release.mk</file>
         <file>iDeviceNativeBinding/nbproject/Makefile-impl.mk</file>

--- a/webcommon/cordova.platforms.ios/licenseinfo.xml
+++ b/webcommon/cordova.platforms.ios/licenseinfo.xml
@@ -22,11 +22,11 @@
 <licenseinfo>
     <fileset>
         <!-- Test data, should not contain comments -->
-        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml</file>
-        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml</file>
-        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml</file>
-        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml</file>
-        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml</file>
+        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml</file>
+        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml</file>
+        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml</file>
+        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml</file>
+        <file>test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml</file>
         
         <file>iDeviceNativeBinding/nbproject/Makefile-Debug.mk</file>
         <file>iDeviceNativeBinding/nbproject/Makefile-Release.mk</file>

--- a/webcommon/cordova.platforms.ios/licenseinfo.xml
+++ b/webcommon/cordova.platforms.ios/licenseinfo.xml
@@ -21,6 +21,13 @@
 -->
 <licenseinfo>
     <fileset>
+        <!-- Test data, should not contain comments -->
+        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml</file>
+        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml</file>
+        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml</file>
+        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml</file>
+        <file>cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml</file>
+        
         <file>iDeviceNativeBinding/nbproject/Makefile-Debug.mk</file>
         <file>iDeviceNativeBinding/nbproject/Makefile-Release.mk</file>
         <file>iDeviceNativeBinding/nbproject/Makefile-impl.mk</file>

--- a/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml
+++ b/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/disconnected.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml
+++ b/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/jsoncommand.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml
+++ b/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/listing.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml
+++ b/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/toback.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml
+++ b/webcommon/cordova.platforms.ios/test/unit/src/org/netbeans/modules/cordova/platforms/ios/tofront.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/api/KODataBindTokenId.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/api/KODataBindTokenId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/api/KODataBindTokenId.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/api/KODataBindTokenId.java
@@ -1,45 +1,20 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * Contributor(s):
- *
- * The Original Software is NetBeans. The Initial Developer of the Original
- * Software is Sun Microsystems, Inc. Portions Copyright 1997-2006 Sun
- * Microsystems, Inc. All Rights Reserved.
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version , indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a
- * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.netbeans.modules.html.knockout.api;
 


### PR DESCRIPTION
Reliensed the leftover file.

Cordova test data files reported by RAT are apache2, since they were donated as part of the codebase, but since the files are request/response data, I would rather not put licenses directly in them (although any sane XML parser should accept that).