### PR TITLE
Include webcommon into the release

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -35,4 +35,4 @@ ide/o.apache.commons.lang/external/commons-lang-2.6.jar java/maven.embedder/exte
 nbbuild/external/langtools-9.zip nbbuild/external/langtools-9.zip
 
 # JFlex is used by multiple modules.
-javascript2.jade/external/jflex-1.4.3.jar javascript2.lexer/external/jflex-1.4.3.jar
+webcommon/javascript2.jade/external/jflex-1.4.3.jar webcommon/javascript2.lexer/external/jflex-1.4.3.jar

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -16,8 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cluster.config=basic
+cluster.config=release
 clusters.prefix=libnb
+
+clusters.config.release.list=\
+        ${clusters.config.java.list},\
+        nb.cluster.apisupport,\
+        nb.cluster.webcommon,\
+        nb.cluster.ergonomics
+# ergonomics must be last
 
 clusters.config.platform.list=\
         nb.cluster.harness,\


### PR DESCRIPTION
Webcommon cluster has been reviewed and separated into its cluster directory, the next step is to include it in the Apache Netbeans release
