### PR TITLE
[NETBEANS-1261] Avoid a rendering artifact under Aqua tabs on Retina

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
@@ -205,8 +205,9 @@ final class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
             //just a plain rectangle
             p.addPoint(x, y + ins.top);
             p.addPoint(x + width, y + ins.top);
-            p.addPoint(x + width, y + height - 1);
-            p.addPoint(x, y + height - 1);
+            // NETBEANS-1261: Don't subtract 1 from the Y coordinates here.
+            p.addPoint(x + width, y + height);
+            p.addPoint(x, y + height);
             return p;
         }
 
@@ -309,8 +310,9 @@ final class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
             //just a plain rectangle
             p.addPoint(x, y + ins.top);
             p.addPoint(x + width, y + ins.top);
-            p.addPoint(x + width, y + height - 1);
-            p.addPoint(x, y + height - 1);
+            // NETBEANS-1261: Don't subtract 1 from the Y coordinates here.
+            p.addPoint(x + width, y + height);
+            p.addPoint(x, y + height);
             return p;
         }
 
@@ -396,8 +398,9 @@ final class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
             //just a plain rectangle
             p.addPoint(x, y + ins.top);
             p.addPoint(x + width, y + ins.top);
-            p.addPoint(x + width, y + height - 1);
-            p.addPoint(x, y + height - 1);
+            // NETBEANS-1261: Don't subtract 1 from the Y coordinates here.
+            p.addPoint(x + width, y + height);
+            p.addPoint(x, y + height);
             return p;
         }
 


### PR DESCRIPTION
This commit gets rid of a thin grey line that appears under the active
tabcontrol tab when using the default Aqua LAF on MacOS retina (2x scaled)
screens. See screenshot attached to the JIRA ticket and pull request.

<img width="257" alt="thin grey line fixed" src="https://user-images.githubusercontent.com/886243/45712372-26f76b80-bb5a-11e8-9191-fb1f0d9f611e.png">

AquaEditorTabCellRenderer.AquaPainter.getInteriorPolygon previously returned a
rectangle whose bottom two points were at Y coordinate (y + height - 1).
Presumably this was meant to ensure that a point at (0, y + height) would not be
considered "inside" the rectangle. That's already the case when the bottom two
points are added at (y + height) and in the order used here, however. And on
Retina displays, subtracting 1 causes trouble in painting because each logical
pixel corresponds to two, not one, physical pixel. Looking through call sites of
getInteriorPolygon, it should be safe to remove the "-1" adjustment. There are
other LAFs that don't include it, too.

Tested on MacOS both with and without Retina enabled, to make sure there are no
new tab control bugs resulting from the fix. Tested clicking around the tab
control tab, and dragging and dropping tabs.