### PR TITLE
Make invokeWhenUIReady work in headless mode

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.*;
+import org.netbeans.core.IDESettings;
 import org.netbeans.core.windows.actions.ActionUtils;
 import org.netbeans.core.windows.options.WinSysPrefs;
 import org.netbeans.core.windows.persistence.PersistenceManager;
@@ -1527,8 +1528,12 @@ public final class WindowManagerImpl extends WindowManager implements Workspace 
 
         @Override
         public void run() {
-            if (!WindowManagerImpl.getInstance().isVisible()) {
-                return;
+            if (IDESettings.isGui()) {
+                // running in GUI mode, but
+                if (!WindowManagerImpl.getInstance().isVisible()) {
+                    // window manager isn't yet visible => exit for now
+                    return;
+                }
             }
             
             synchronized (this) {

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/InvokeWhenUIReadInHeadlessModeTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/InvokeWhenUIReadInHeadlessModeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.core.windows;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.windows.WindowManager;
+
+public class InvokeWhenUIReadInHeadlessModeTest extends NbTestCase {
+
+    public InvokeWhenUIReadInHeadlessModeTest(String name) {
+        super(name);
+    }
+
+    public static junit.framework.Test suite() {
+        return NbModuleSuite.emptyConfiguration().
+            gui(false).
+            addTest(InvokeWhenUIReadInHeadlessModeTest.class).
+            suite();
+    }
+
+
+    public void testInvokeWhenReadInHeadlessMode() throws Exception {
+        final CountDownLatch cdl = new CountDownLatch(1);
+        WindowManager.getDefault().invokeWhenUIReady(new Runnable() {
+            @Override
+            public void run() {
+                cdl.countDown();
+            }
+        });
+        cdl.await(15, TimeUnit.SECONDS);
+        assertEquals("Eventually the runnable is invoked", 0, cdl.getCount());
+    }
+}

--- a/platform/o.n.core/src/org/netbeans/core/IDESettings.java
+++ b/platform/o.n.core/src/org/netbeans/core/IDESettings.java
@@ -22,6 +22,7 @@ package org.netbeans.core;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
+import org.netbeans.core.startup.CLIOptions;
 import org.openide.awt.HtmlBrowser;
 import org.openide.cookies.InstanceCookie;
 import org.openide.filesystems.FileObject;
@@ -92,6 +93,14 @@ public class IDESettings  {
      */
     public static void setExternalWWWBrowser (HtmlBrowser.Factory brow) {
         setBrowser( PROP_EXTERNAL_WWWBROWSER, brow );
+    }
+
+    /** Are we running in GUI or headless mode?
+     * 
+     * @return true if the GUI mode is on
+     */
+    public static boolean isGui() {
+        return CLIOptions.isGui();
     }
 
     private static void setBrowser (String prefId, HtmlBrowser.Factory brow) {


### PR DESCRIPTION
Make sure `invokeWhenUIReady` runnables are eventually invoked even in headless mode.

Tests that run in `NbSuiteModule` mode and use parsing never finish. The problem is that parsing is delayed until the main window is shown using `WindowManager.getDefault().invokeWhenUIReady`. However the tests are executed with `gui(false)` option and thus the main window is never shown, which implies the parsing never starts.

This change detects the headless mode and if so, invokes the provided `Runnable` implementations immediately (via `EventQueue.invokeLater`).