### PR TITLE
[NETBEANS-1285] Fix an incorrect error

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/PHP73UnhandledError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/PHP73UnhandledError.java
@@ -237,6 +237,11 @@ public class PHP73UnhandledError extends UnhandledErrorRule {
             List<PHPTokenId> lookforEndTokens = Arrays.asList(PHPTokenId.PHP_HEREDOC_TAG_END, PHPTokenId.PHP_NOWDOC_TAG_END);
             while (ts.movePrevious()
                     && (endTag = LexUtilities.findPreviousToken(ts, lookforEndTokens)) != null) {
+                if (endTag.id() != PHPTokenId.PHP_HEREDOC_TAG_END
+                        && endTag.id() != PHPTokenId.PHP_NOWDOC_TAG_END) {
+                    // NETBEANS-1285 the last token may be returned
+                    continue;
+                }
                 String endId = endTag.text().toString();
                 // indentation of closing marker
                 int offset = ts.offset();


### PR DESCRIPTION
https://issues.apache.org/jira/projects/NETBEANS/issues/NETBEANS-1285

- Check whether the token id is tag end for Heredoc and Nowdoc because LexUtilities.findPreviousToken() may return the last token