### PR TITLE
For OpenJDK projects, register the expanded JDK as a Java Platform, u…

### DIFF
--- a/java/java.openjdk.project/nbproject/project.xml
+++ b/java/java.openjdk.project/nbproject/project.xml
@@ -95,6 +95,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.platform</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.45</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.project</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
…nless already done.

So that the user can use the built JDK directly in e.g. J2SE Project for testing.