### PR TITLE
[NETBEANS-1318] Javadoc timestamp in CSS instead of all HTML files

### DIFF
--- a/nbbuild/javadoctools/javadoc.css
+++ b/nbbuild/javadoctools/javadoc.css
@@ -24,3 +24,6 @@
 @import "netbeans-lite.css";
 /* The rest is the default stylesheet produced by Javadoc 1.4.2: */
 @import "javadoc-generic.css";
+/* Timestamp information for all HTML files in the footer */
+.footnote:before { content: "@CSS_TIMESTAMP@"; }
+

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -245,12 +245,16 @@ cause it to fail.
     </target>
     
     <target name="javadoc-stage-main" depends="javadoc-init,javadoc-check-timestamps,javadoc-exec-files,javadoc-exec-packages" unless="javadoc.should.not.be.generated" >
+        <tstamp>
+            <format property="YEAR" pattern="yyyy"/>
+        </tstamp>
         <copy todir="${javadoc.out.dir}">
             <fileset refid="javadoc.css.files"/>
         </copy>
         <replace dir="${javadoc.out.dir}" >
             <include name="javadoc*.css"/>
             <include name="nb-docs-stability.css"/>
+            <replacefilter token="@CSS_TIMESTAMP@" value="Built on ${TODAY}. Copyright 2017-${YEAR} The Apache Software Foundation. All Rights Reserved." />
             <replacefilter token="@nb-docs-css@" value="${nb-docs.css}"/>
             <replacefilter token="@api-stability-image@" value="${stability.image}"/>
         </replace>
@@ -270,11 +274,8 @@ cause it to fail.
     </target>
 
     <target name="-javadoc-set-footer">
-        <tstamp>
-            <format property="YEAR" pattern="yyyy"/>
-        </tstamp>
-        <property name="javadoc.footer" value='&lt;span class="footnote"&gt;Built on ${TODAY}.&amp;nbsp;&amp;nbsp;|&amp;nbsp;&amp;nbsp;
-        Copyright &amp;#169; 2017-${YEAR} Apache Software Foundation. All Rights Reserved.&lt;/span&gt;'/>
+        <!-- Timestamp is handled in javadoc.css to avoid too many commits on generated HTML files. -->
+        <property name="javadoc.footer" value='&lt;span class="footnote"&gt;&lt;/span&gt;&lt;!-- See javadoc.css for timestamp information --&gt;'/>
     </target>
     
     <target name="javadoc-exec-packages" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title,javadoc-exec-condition,-javadoc-set-footer" unless="javadoc.exec.packages">
@@ -293,6 +294,8 @@ cause it to fail.
             <doctitle>${javadoc.title}&lt;br/&gt;${javadoc.stability.label}</doctitle>
             <header>${javadoc.header}</header>
             <bottom>${javadoc.footer}</bottom>
+            <!-- Avoid timestamp comments in _all_ html generated files, to reduce unnecessary git commits -->
+            <arg value="-notimestamp" />
         </javadoc>
     </target>
     


### PR DESCRIPTION
Instead of adding the timestamp to all HTML files we add it to the ".footnote" CSS class (in javadoc.css).

This makes it easier to add the generated javadoc to a git repository (as planned in NETBEANS-1176) because files that only change because of a timestamp won't generate a commit.