### PR TITLE
[NETBEANS-1342] Hide the panel for iOS in the Mobile Platforms Options

### DIFF
--- a/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
@@ -171,6 +171,7 @@ public class CordovaPerformer implements BuildPerformer {
         if (provider != null &&
                 "ios_1".equals(provider.getActiveBrowser().getId()) && 
                 (target.equals(BuildPerformer.RUN_IOS) || target.equals(BuildPerformer.BUILD_IOS)) &&
+                PlatformManager.getPlatform(PlatformManager.IOS_TYPE) != null &&
                 PlatformManager.getPlatform(PlatformManager.IOS_TYPE).getProvisioningProfilePath() == null
                 ) {
             throw new IllegalStateException(Bundle.ERR_NO_Provisioning());
@@ -324,15 +325,16 @@ public class CordovaPerformer implements BuildPerformer {
         props.put(PROP_ANDROID_PROJECT_ACTIVITY, activity);//NOI18N
         
         MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
+        if (iosPlatform != null) {
+            final String provisioningProfilePath = iosPlatform.getProvisioningProfilePath();
+            if (provisioningProfilePath != null) {
+                props.put(PROP_PROVISIONING_PROFILE, provisioningProfilePath);
+            }
+            final String codeSignIdentity = iosPlatform.getCodeSignIdentity();
 
-        final String provisioningProfilePath = iosPlatform.getProvisioningProfilePath();
-        if (provisioningProfilePath != null) {
-            props.put(PROP_PROVISIONING_PROFILE, provisioningProfilePath);
-        }
-        final String codeSignIdentity = iosPlatform.getCodeSignIdentity();
-
-        if (codeSignIdentity != null) {
-            props.put(PROP_CERTIFICATE_NAME, codeSignIdentity);
+            if (codeSignIdentity != null) {
+                props.put(PROP_CERTIFICATE_NAME, codeSignIdentity);
+            }
         }
 
         //workaround for some strange behavior of ant execution in netbeans
@@ -349,7 +351,7 @@ public class CordovaPerformer implements BuildPerformer {
 
             props.put(PROP_CONFIG, mobileConfig.getId());
             mobileConfig.getDevice().addProperties(props);
-            if (mobileConfig.getId().equals("ios")) { // NOI18N
+            if (mobileConfig.getId().equals("ios") && iosPlatform != null) { // NOI18N
                 boolean sdkVerified = false;
                 try {
                     for (SDK sdk:iosPlatform.getSDKs()) {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/options/MobilePlatformsPanel.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/options/MobilePlatformsPanel.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Collections;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
@@ -49,7 +50,7 @@ final class MobilePlatformsPanel extends javax.swing.JPanel {
     private final MobilePlatformsOptionsPanelController controller;
     private DocumentListener documentL;
     private String codeSignIdentity;
-    private Collection<? extends ProvisioningProfile> provisioningProfiles;
+    private Collection<? extends ProvisioningProfile> provisioningProfiles = Collections.emptyList();
     private String provisioningProfilePath;
     private boolean inited = false;
     private RequestProcessor.Task versionTask;
@@ -273,9 +274,11 @@ final class MobilePlatformsPanel extends javax.swing.JPanel {
 
     void load() {
         final MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
-        codeSignIdentity = iosPlatform.getCodeSignIdentity();
-        provisioningProfiles = iosPlatform.getProvisioningProfiles();
-        provisioningProfilePath = iosPlatform.getProvisioningProfilePath();
+        if (iosPlatform != null) {
+            codeSignIdentity = iosPlatform.getCodeSignIdentity();
+            provisioningProfiles = iosPlatform.getProvisioningProfiles();
+            provisioningProfilePath = iosPlatform.getProvisioningProfilePath();
+        }
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -309,8 +312,12 @@ final class MobilePlatformsPanel extends javax.swing.JPanel {
     void setupComponenets() {
         if (!inited) {
             removeAll();
-            initComponents();            
-            
+            initComponents();
+            MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
+            if (iosPlatform == null) {
+                iOSPanel.setVisible(false);
+            }
+
             cordovaPathField.getDocument().addDocumentListener(new DocumentListener() {
                 @Override
                 public void insertUpdate(DocumentEvent e) {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/project/CordovaPanel.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/project/CordovaPanel.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.netbeans.modules.cordova.CordovaPerformer;
+import org.netbeans.modules.cordova.platforms.api.PlatformManager;
+import org.netbeans.modules.cordova.platforms.spi.MobilePlatform;
 import org.netbeans.modules.cordova.updatetask.SourceConfig;
 import org.netbeans.modules.cordova.wizard.CordovaTemplate;
 import org.openide.util.NbBundle;
@@ -71,6 +73,10 @@ public class CordovaPanel extends javax.swing.JPanel {
     public CordovaPanel() {
         this(null);
         platformsPane.setVisible(true);
+        MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
+        if (iosPlatform == null) {
+            iOSPanel.setVisible(false);
+        }
     }
     
     public void setControlsEnabled(boolean enabled) {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/wizard/CordovaProjectExtender.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/wizard/CordovaProjectExtender.java
@@ -22,6 +22,7 @@ import org.netbeans.modules.cordova.platforms.api.PlatformManager;
 import org.netbeans.modules.cordova.platforms.spi.Device;
 import java.io.File;
 import java.io.IOException;
+import org.netbeans.modules.cordova.platforms.spi.MobilePlatform;
 import org.netbeans.modules.cordova.project.ConfigUtils;
 import org.netbeans.modules.web.clientproject.api.ClientSideModule;
 import org.netbeans.modules.web.clientproject.spi.ClientProjectExtender;
@@ -67,7 +68,8 @@ public class CordovaProjectExtender implements ClientProjectExtender {
             ios.put(ConfigUtils.DISPLAY_NAME_PROP, Bundle.LBL_iPhoneSimulator());
             ios.put(Device.TYPE_PROP, PlatformManager.IOS_TYPE);
             ios.put(Device.DEVICE_PROP, Device.EMULATOR);
-            ios.put("ios.build.sdk", PlatformManager.getPlatform(PlatformManager.IOS_TYPE).getPrefferedTarget().getIdentifier()); // NOI18N
+            MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
+            ios.put("ios.build.sdk", iosPlatform == null ? "" : iosPlatform.getPrefferedTarget().getIdentifier()); // NOI18N
             ios.put("ios.build.arch", "i386"); // NOI18N
 
             ConfigUtils.createConfigFile(projectRoot, PlatformManager.IOS_TYPE, ios);//NOI18N
@@ -82,7 +84,8 @@ public class CordovaProjectExtender implements ClientProjectExtender {
             iosdev.put(ConfigUtils.DISPLAY_NAME_PROP, Bundle.LBL_iPhoneDevice());
             iosdev.put(Device.TYPE_PROP, PlatformManager.IOS_TYPE);
             iosdev.put(Device.DEVICE_PROP, Device.DEVICE);
-            String sim = PlatformManager.getPlatform(PlatformManager.IOS_TYPE).getPrefferedTarget().getIdentifier();
+            MobilePlatform iosPlatform = PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
+            String sim = iosPlatform == null ? "" : iosPlatform.getPrefferedTarget().getIdentifier();
             iosdev.put("ios.build.sdk", sim.replace("iphonesimulator", "iphoneos")); // NOI18N
             iosdev.put("ios.build.arch", sim.startsWith("iphonesimulator6")?"armv6 armv7":"armv7 armv7s"); // NOI18N
 

--- a/webcommon/cordova/test/unit/src/org/netbeans/modules/web/clientproject/cordova/AndroidPlatformTest.java
+++ b/webcommon/cordova/test/unit/src/org/netbeans/modules/web/clientproject/cordova/AndroidPlatformTest.java
@@ -180,8 +180,10 @@ public SyncPipe(InputStream istrm, OutputStream ostrm) {
     @Test
     public void testListSdks() throws Exception {
         MobilePlatform instance = org.netbeans.modules.cordova.platforms.api.PlatformManager.getPlatform(PlatformManager.IOS_TYPE);
-        for (SDK sdks: instance.getSDKs()) {
-            System.out.println(sdks);
+        if (instance != null) {
+            for (SDK sdks : instance.getSDKs()) {
+                System.out.println(sdks);
+            }
         }
     }
     


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1342

Just hide the panel because the cordova.platforms.ios module is not available (see #856)

![netbeans-1342-options-panel-after](https://user-images.githubusercontent.com/738383/46576529-ce9fe500-ca06-11e8-9370-822e48cbfc3f.png)
