### PR TITLE
Fixes for the OpenJDK project:

### DIFF
--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/LogicalViewProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/LogicalViewProviderImpl.java
@@ -155,8 +155,28 @@ public class LogicalViewProviderImpl implements LogicalViewProvider  {
 
             javaSourceGroups.addAll(Arrays.asList(sources.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)));
 
+            Set<SourceGroup> testGroups = Collections.newSetFromMap(new IdentityHashMap<SourceGroup, Boolean>());
+
+            testGroups.addAll(Arrays.asList(sources.getSourceGroups(SourcesImpl.SOURCES_TYPE_JDK_PROJECT_TESTS)));
+
             for (SourceGroup sg : sources.getSourceGroups(SourcesImpl.SOURCES_TYPE_JDK_PROJECT)) {
-                if (javaSourceGroups.contains(sg)) {
+                if (testGroups.contains(sg)) {
+                    //for tests, don't create PackageView:
+                    toPopulate.add(new Key(sg) {
+                        @Override public Node createNode() {
+                            try {
+                                DataObject od = DataObject.find(group.getRootFolder());
+                                return new FilterNode(od.getNodeDelegate()) {
+                                    @Override public String getDisplayName() {
+                                        return group.getDisplayName();
+                                    }
+                                };
+                            } catch (DataObjectNotFoundException ex) {
+                                return Node.EMPTY;
+                            }
+                        }
+                    });
+                } else if (javaSourceGroups.contains(sg)) {
                     toPopulate.add(new Key(sg) {
                         @Override public Node createNode() {
                             return PackageView.createPackageView(group);

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ModuleDescription.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ModuleDescription.java
@@ -233,11 +233,7 @@ public class ModuleDescription {
                 }
             }
 
-            if (current.getNameExt().equals("test") && current.getFileObject("TEST.ROOT") != null) {
-                continue; //do not look inside test folders
-            }
-
-            if (current.getParent().getNameExt().equals("test") && current.getFileObject("TEST.ROOT") != null) {
+            if (current.getFileObject("TEST.ROOT") != null) {
                 continue; //do not look inside test folders
             }
 

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/SourcesImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/SourcesImpl.java
@@ -60,6 +60,7 @@ import org.openide.util.Utilities;
 public class SourcesImpl implements Sources, FileChangeListener, ChangeListener {
 
     public static final String SOURCES_TYPE_JDK_PROJECT = "jdk-project-sources";
+    public static final String SOURCES_TYPE_JDK_PROJECT_TESTS = "jdk-project-sources-tests";
 
     private final ChangeSupport cs = new ChangeSupport(this);
     private final JDKProject project;
@@ -125,6 +126,10 @@ public class SourcesImpl implements Sources, FileChangeListener, ChangeListener 
 
                 if (root.kind != RootKind.NATIVE_SOURCES) {
                     addSourceGroup(JavaProjectConstants.SOURCES_TYPE_JAVA, sg);
+                }
+
+                if (root.kind == RootKind.TEST_SOURCES) {
+                    addSourceGroup(SOURCES_TYPE_JDK_PROJECT_TESTS, sg);
                 }
 
                 addSourceGroup(SOURCES_TYPE_JDK_PROJECT, sg);

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImplTest.java
@@ -105,6 +105,22 @@ public class ClassPathProviderImplTest extends NbTestCase {
         Assert.assertTrue(compileCP.entries().isEmpty());
     }
 
+    public void testExternalLibRoots() throws Exception {
+        File workDir = getWorkDir();
+
+        FileUtil.createFolder(new File(workDir, "src/share/classes"));
+        FileObject testRoot = createData("test/TEST.ROOT", "external.lib.roots=../lib1 ../lib2\t../lib3");
+        FileObject testUse = createData("test/use/Use.java", "/**@test\n@library /lib0/0 /1 /2 /3\n*/");
+        FileObject testLib0 = FileUtil.createData(new File(workDir, "test/lib0/0/Lib.java"));
+        FileObject testLib1 = FileUtil.createData(new File(workDir, "lib1/1/Lib.java"));
+        FileObject testLib2 = FileUtil.createData(new File(workDir, "lib2/2/Lib.java"));
+        FileObject testLib3 = FileUtil.createData(new File(workDir, "lib3/3/Lib.java"));
+        ClassPath sourceCP = new ClassPathProviderImpl().findClassPath(testUse, ClassPath.SOURCE);
+
+        Assert.assertEquals(new HashSet<>(Arrays.asList(testUse.getParent(), testLib0.getParent(), testLib1.getParent(), testLib2.getParent(), testLib3.getParent())),
+                            new HashSet<>(Arrays.asList(sourceCP.getRoots())));
+    }
+
     private FileObject createData(String relPath, String content) throws IOException {
         File workDir = getWorkDir();
         FileObject file = FileUtil.createData(new File(workDir, relPath));


### PR DESCRIPTION
-handling of external.lib.roots in TEST.ROOT,
-using tree view for tests,
-avoiding search for modules in (any) tests.

I'd like to backport these fixes to release100 branch/release.