### PR TITLE
[NETBEANS-1463] PHPStan memory-limit

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/PHPStanAnalyzerImpl.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/PHPStanAnalyzerImpl.java
@@ -75,11 +75,10 @@ public class PHPStanAnalyzerImpl implements Analyzer {
             return Collections.emptyList();
         }
 
-        String level = getValidPHPStanLevel();
-        FileObject config = getValidPHPStanConfiguration();
         PHPStanParams phpStanParams = new PHPStanParams()
-                .setLevel(level)
-                .setConfiguration(config);
+                .setLevel(getValidPHPStanLevel())
+                .setConfiguration(getValidPHPStanConfiguration())
+                .setMemoryLimit(getValidPHPStanMemoryLimit());
         Scope scope = context.getScope();
 
         Map<FileObject, Integer> fileCount = AnalysisUtils.countPhpFiles(scope);
@@ -201,6 +200,18 @@ public class PHPStanAnalyzerImpl implements Analyzer {
             return null;
         }
         return FileUtil.toFileObject(new File(phpStanConfiguration));
+    }
+
+    private String getValidPHPStanMemoryLimit() {
+        String memoryLimit;
+        Preferences settings = context.getSettings();
+        if (settings != null) {
+            memoryLimit = settings.get(PHPStanCustomizerPanel.MEMORY_LIMIT, ""); // NOI18N
+        } else {
+            memoryLimit = String.valueOf(AnalysisOptions.getInstance().getPHPStanMemoryLimit());
+        }
+        assert memoryLimit != null;
+        return memoryLimit;
     }
 
     //~ Inner class

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/PHPStanParams.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/PHPStanParams.java
@@ -24,6 +24,7 @@ public final class PHPStanParams {
 
     private String level;
     private FileObject configuration;
+    private String memoryLimit;
 
     public String getLevel() {
         return level;
@@ -40,6 +41,15 @@ public final class PHPStanParams {
 
     public PHPStanParams setConfiguration(FileObject configuration) {
         this.configuration = configuration;
+        return this;
+    }
+
+    public String getMemoryLimit() {
+        return memoryLimit;
+    }
+
+    public PHPStanParams setMemoryLimit(String memoryLimit) {
+        this.memoryLimit = memoryLimit;
         return this;
     }
 }

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
@@ -59,6 +59,7 @@ public final class PHPStan {
     // params
     private static final String CONFIGURATION_PARAM = "--configuration=%s"; // NOI18N
     private static final String LEVEL_PARAM = "--level=%s"; // NOI18N
+    private static final String MEMORY_LIMIT_PARAM = "--memory-limit=%s"; // NOI18N
     private static final String ERROR_FORMAT_PARAM = "--error-format=checkstyle"; // NOI18N Or json, raw, table
     private static final String NO_PROGRESS_PARAM = "--no-progress"; // NOI18N
     private static final String NO_INTERACTION_PARAM = "--no-interaction"; // NOI18N
@@ -182,6 +183,10 @@ public final class PHPStan {
         FileObject configuration = parameters.getConfiguration();
         if (configuration != null) {
             params.add(String.format(CONFIGURATION_PARAM, FileUtil.toFile(configuration).getAbsolutePath()));
+        }
+        String memoryLimit = parameters.getMemoryLimit();
+        if (!StringUtils.isEmpty(memoryLimit)) {
+            params.add(String.format(MEMORY_LIMIT_PARAM, memoryLimit));
         }
         params.add(FileUtil.toFile(file).getAbsolutePath());
         return params;

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptions.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptions.java
@@ -53,6 +53,7 @@ public final class AnalysisOptions {
     private static final String PHPSTAN_PATH = "phpstan.path"; // NOI18N
     private static final String PHPSTAN_LEVEL = "phpstan.level"; // NOI18N
     private static final String PHPSTAN_CONFIGURATION = "phpstan.configuration"; // NOI18N
+    private static final String PHPSTAN_MEMORY_LIMIT = "phpstan.memory.limit"; // NOI18N
 
     private volatile boolean codeSnifferSearched = false;
     private volatile boolean messDetectorSearched = false;
@@ -231,6 +232,14 @@ public final class AnalysisOptions {
 
     public void setPHPStanConfigurationPath(String configuration) {
         getPreferences().put(PHPSTAN_CONFIGURATION, configuration);
+    }
+
+    public String getPHPStanMemoryLimit() {
+        return getPreferences().get(PHPSTAN_MEMORY_LIMIT, ""); // NOI18N
+    }
+
+    public void setPHPStanMemoryLimit(String memoryLimit) {
+        getPreferences().put(PHPSTAN_MEMORY_LIMIT, memoryLimit);
     }
 
     private Preferences getPreferences() {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptionsValidator.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptionsValidator.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.php.analysis.options;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.netbeans.modules.php.analysis.commands.CodeSniffer;
 import org.netbeans.modules.php.analysis.commands.CodingStandardsFixer;
 import org.netbeans.modules.php.analysis.commands.MessDetector;
@@ -30,6 +32,7 @@ import org.openide.util.NbBundle;
 
 public final class AnalysisOptionsValidator {
 
+    private static final Pattern PHPSTAN_MEMORY_LIMIT_PATTERN = Pattern.compile("^\\-?\\d+[kmg]?$", Pattern.CASE_INSENSITIVE); // NOI18N
     private final ValidationResult result = new ValidationResult();
 
     public AnalysisOptionsValidator validateCodeSniffer(String codeSnifferPath, String codeSnifferStandard) {
@@ -49,9 +52,10 @@ public final class AnalysisOptionsValidator {
         return this;
     }
 
-    public AnalysisOptionsValidator validatePHPStan(String phpStanPath, String configuration) {
-        validatePHPStanPath(phpStanPath);
-        validatePHPStanConfiguration(configuration);
+    public AnalysisOptionsValidator validatePHPStan(ValidatorPHPStanParameter param) {
+        validatePHPStanPath(param.getPHPStanPath());
+        validatePHPStanConfiguration(param.getConfiguration());
+        validatePHPStanMemoryLimit(param.getMemoryLimit());
         return this;
     }
 
@@ -100,9 +104,11 @@ public final class AnalysisOptionsValidator {
     }
 
     private AnalysisOptionsValidator validatePHPStanPath(String phpStanPath) {
-        String warning = PHPStan.validate(phpStanPath);
-        if (warning != null) {
-            result.addWarning(new ValidationResult.Message("phpStan.path", warning)); // NOI18N
+        if (phpStanPath != null) {
+            String warning = PHPStan.validate(phpStanPath);
+            if (warning != null) {
+                result.addWarning(new ValidationResult.Message("phpStan.path", warning)); // NOI18N
+            }
         }
         return this;
     }
@@ -112,6 +118,17 @@ public final class AnalysisOptionsValidator {
             String warning = FileUtils.validateFile("Configuration file", configuration, false); // NOI18N
             if (warning != null) {
                 result.addWarning(new ValidationResult.Message("phpStan.configuration", warning)); // NOI18N
+            }
+        }
+        return this;
+    }
+
+    @NbBundle.Messages("AnalysisOptionsValidator.phpStan.memory.limit.invalid=Valid memory limit value must be set.")
+    private AnalysisOptionsValidator validatePHPStanMemoryLimit(String memoryLimit) {
+        if (!StringUtils.isEmpty(memoryLimit)) {
+            Matcher matcher = PHPSTAN_MEMORY_LIMIT_PATTERN.matcher(memoryLimit);
+            if (!matcher.matches()) {
+                result.addWarning(new ValidationResult.Message("phpStan.memory.limit", Bundle.AnalysisOptionsValidator_phpStan_memory_limit_invalid())); // NOI18N
             }
         }
         return this;

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/ValidatorPHPStanParameter.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/ValidatorPHPStanParameter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.analysis.options;
+
+import org.netbeans.modules.php.analysis.ui.analyzer.PHPStanCustomizerPanel;
+import org.netbeans.modules.php.analysis.ui.options.PHPStanOptionsPanel;
+
+public final class ValidatorPHPStanParameter {
+
+    private final String phpStanPath;
+    private final String configuration;
+    private final String memoryLimit;
+
+    public static ValidatorPHPStanParameter create(PHPStanOptionsPanel panel) {
+        return new ValidatorPHPStanParameter(panel);
+    }
+
+    public static ValidatorPHPStanParameter create(PHPStanCustomizerPanel panel) {
+        return new ValidatorPHPStanParameter(panel);
+    }
+
+    private ValidatorPHPStanParameter() {
+        phpStanPath = null;
+        configuration = null;
+        memoryLimit = null;
+    }
+
+    private ValidatorPHPStanParameter(PHPStanOptionsPanel panel) {
+        phpStanPath = panel.getPHPStanPath();
+        configuration = panel.getPHPStanConfigurationPath();
+        memoryLimit = panel.getPHPStanMemoryLimit();
+    }
+
+    private ValidatorPHPStanParameter(PHPStanCustomizerPanel panel) {
+        phpStanPath = null;
+        configuration = panel.getConfiguration();
+        memoryLimit = panel.getMemoryLimit();
+    }
+
+    public String getPHPStanPath() {
+        return phpStanPath;
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    public String getMemoryLimit() {
+        return memoryLimit;
+    }
+
+}

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties
@@ -31,6 +31,6 @@ CodeSnifferCustomizerPanel.enabledCheckBox.text=&Enabled
 MessDetectorCustomizerPanel.enabledCheckBox.text=&Enabled
 PHPStanCustomizerPanel.phpStanConfigurationBrowseButton.text=&Browse...
 PHPStanCustomizerPanel.phpStanLevelLabel.text=&Level:
-PHPStanCustomizerPanel.phpStanConfigurationTextField.text=
 PHPStanCustomizerPanel.phpStanConfigurationLabel.text=&Configuration:
 PHPStanCustomizerPanel.phpStanEnabledCheckBox.text=&Enabled
+PHPStanCustomizerPanel.phpStanMemoryLimitLabel.text=&Memory Limit:

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/PHPStanCustomizerPanel.form
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/PHPStanCustomizerPanel.form
@@ -41,10 +41,11 @@
               <Component id="phpStanEnabledCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
-          <Group type="102" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="phpStanConfigurationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="phpStanLevelLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="phpStanMemoryLimitLabel" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
@@ -54,7 +55,10 @@
                       <Component id="phpStanConfigurationBrowseButton" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" attributes="0">
-                      <Component id="phpStanLevelComboBox" min="-2" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="phpStanLevelComboBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpStanMemoryLimitTextField" min="-2" pref="100" max="-2" attributes="0"/>
+                      </Group>
                       <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
@@ -76,6 +80,11 @@
                   <Component id="phpStanLevelLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="phpStanLevelComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="phpStanMemoryLimitLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="phpStanMemoryLimitTextField" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
           </Group>
       </Group>
     </DimensionLayout>
@@ -90,17 +99,15 @@
     </Component>
     <Component class="javax.swing.JLabel" name="phpStanConfigurationLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanConfigurationTextField"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties" key="PHPStanCustomizerPanel.phpStanConfigurationLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="phpStanConfigurationTextField">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties" key="PHPStanCustomizerPanel.phpStanConfigurationTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
     <Component class="javax.swing.JButton" name="phpStanConfigurationBrowseButton">
       <Properties>
@@ -114,6 +121,9 @@
     </Component>
     <Component class="javax.swing.JLabel" name="phpStanLevelLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanLevelComboBox"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties" key="PHPStanCustomizerPanel.phpStanLevelLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
@@ -137,6 +147,18 @@
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
       </AuxValues>
+    </Component>
+    <Component class="javax.swing.JLabel" name="phpStanMemoryLimitLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanMemoryLimitTextField"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/analyzer/Bundle.properties" key="PHPStanCustomizerPanel.phpStanMemoryLimitLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="phpStanMemoryLimitTextField">
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/Bundle.properties
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/Bundle.properties
@@ -49,15 +49,13 @@ CodingStandardsFixerOptionsPanel.codingStandardsFixerOptionsLabel.text=Default &
 CodingStandardsFixerOptionsPanel.codingStandardsFixerOptionsTextField.text=
 CodingStandardsFixerOptionsPanel.codingStandardsFixerVersionLabel.text=Default &Version:
 PHPStanOptionsPanel.phpStanLabel.text=&PHPStan:
-PHPStanOptionsPanel.phpStanTextField.text=
 PHPStanOptionsPanel.phpStanBrowseButton.text=&Browse...
 PHPStanOptionsPanel.phpStanSearchButton.text=&Search...
-PHPStanOptionsPanel.phpStanHintLabel.text=HINT
 PHPStanOptionsPanel.phpStanLevelLabel.text=&Level:
 PHPStanOptionsPanel.phpStanConfigurationLabel.text=&Configuration:
-PHPStanOptionsPanel.phpStanConfigurationTextField.text=
 PHPStanOptionsPanel.phpStanConfiturationBrowseButton.text=B&rowse...
 PHPStanOptionsPanel.phpStanNoteLabel.text=<html><i>Note:</i></html>
 PHPStanOptionsPanel.phpStanMinVersionInfoLabel.text=PHPStan 0.10.3 or newer is supported.
 PHPStanOptionsPanel.phpStanLearnMoreLabel.text=<html><a href="#">Learn more about PHPStan</a></html>
-PHPStanOptionsPanel.jLabel1.text=Full configuration file path(typically, phpstan.neon or phpstan.neon.dist)
+PHPStanOptionsPanel.phpStanMemoryLimitLabel.text=&Memory Limit:
+PHPStanOptionsPanel.phpStanConfigurationInfoLabel.text=Full configuration file path(typically, phpstan.neon or phpstan.neon.dist)

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.form
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.form
@@ -38,10 +38,6 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
-              <Component id="phpStanNoteLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-          </Group>
-          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="phpStanMinVersionInfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -54,6 +50,8 @@
                   <Component id="phpStanConfigurationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="phpStanLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="phpStanLevelLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="phpStanNoteLabel" min="-2" max="-2" attributes="0"/>
+                  <Component id="phpStanMemoryLimitLabel" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
@@ -77,10 +75,11 @@
                   </Group>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                          <Component id="phpStanLevelComboBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpStanConfigurationInfoLabel" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpStanLevelComboBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpStanMemoryLimitTextField" alignment="0" min="-2" pref="100" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="24" max="32767" attributes="0"/>
                   </Group>
               </Group>
           </Group>
@@ -104,13 +103,18 @@
                   <Component id="phpStanConfiturationBrowseButton" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+              <Component id="phpStanConfigurationInfoLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="phpStanLevelLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="phpStanLevelComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="phpStanMemoryLimitLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="phpStanMemoryLimitTextField" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="separate" min="-2" max="-2" attributes="0"/>
               <Component id="phpStanNoteLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="phpStanMinVersionInfoLabel" min="-2" max="-2" attributes="0"/>
@@ -123,17 +127,15 @@
   <SubComponents>
     <Component class="javax.swing.JLabel" name="phpStanLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanTextField"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="phpStanTextField">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
     <Component class="javax.swing.JButton" name="phpStanBrowseButton">
       <Properties>
@@ -157,13 +159,14 @@
     </Component>
     <Component class="javax.swing.JLabel" name="phpStanHintLabel">
       <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanHintLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
+        <Property name="text" type="java.lang.String" value="HINT" noResource="true"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JLabel" name="phpStanLevelLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanLevelComboBox"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanLevelLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
@@ -188,17 +191,34 @@
         <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
       </AuxValues>
     </Component>
+    <Component class="javax.swing.JLabel" name="phpStanMemoryLimitLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanMemoryLimitTextField"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanMemoryLimitLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="phpStanMemoryLimitTextField">
+    </Component>
     <Component class="javax.swing.JLabel" name="phpStanConfigurationLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="phpStanConfigurationTextField"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanConfigurationLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="phpStanConfigurationTextField">
+    </Component>
+    <Component class="javax.swing.JLabel" name="phpStanConfigurationInfoLabel">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanConfigurationTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.phpStanConfigurationInfoLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
@@ -236,13 +256,6 @@
         <EventHandler event="mousePressed" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="phpStanLearnMoreLabelMousePressed"/>
         <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="phpStanLearnMoreLabelMouseEntered"/>
       </Events>
-    </Component>
-    <Component class="javax.swing.JLabel" name="jLabel1">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/analysis/ui/options/Bundle.properties" key="PHPStanOptionsPanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.java
@@ -30,6 +30,7 @@ import org.netbeans.modules.php.analysis.commands.PHPStan;
 import org.netbeans.modules.php.analysis.options.AnalysisOptions;
 import org.netbeans.modules.php.analysis.options.AnalysisOptionsValidator;
 import org.netbeans.modules.php.analysis.ui.PHPStanLevelListCellRenderer;
+import org.netbeans.modules.php.analysis.options.ValidatorPHPStanParameter;
 import org.netbeans.modules.php.api.util.FileUtils;
 import org.netbeans.modules.php.api.util.UiUtils;
 import org.netbeans.modules.php.api.validation.ValidationResult;
@@ -67,6 +68,7 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
         DefaultDocumentListener defaultDocumentListener = new DefaultDocumentListener();
         phpStanTextField.getDocument().addDocumentListener(defaultDocumentListener);
         phpStanConfigurationTextField.getDocument().addDocumentListener(defaultDocumentListener);
+        phpStanMemoryLimitTextField.getDocument().addDocumentListener(defaultDocumentListener);
         phpStanLevelComboBox.addActionListener(e -> fireChange());
     }
 
@@ -86,17 +88,18 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
         phpStanHintLabel = new javax.swing.JLabel();
         phpStanLevelLabel = new javax.swing.JLabel();
         phpStanLevelComboBox = new javax.swing.JComboBox<>();
+        phpStanMemoryLimitLabel = new javax.swing.JLabel();
+        phpStanMemoryLimitTextField = new javax.swing.JTextField();
         phpStanConfigurationLabel = new javax.swing.JLabel();
         phpStanConfigurationTextField = new javax.swing.JTextField();
+        phpStanConfigurationInfoLabel = new javax.swing.JLabel();
         phpStanConfiturationBrowseButton = new javax.swing.JButton();
         phpStanNoteLabel = new javax.swing.JLabel();
         phpStanMinVersionInfoLabel = new javax.swing.JLabel();
         phpStanLearnMoreLabel = new javax.swing.JLabel();
-        jLabel1 = new javax.swing.JLabel();
 
+        phpStanLabel.setLabelFor(phpStanTextField);
         org.openide.awt.Mnemonics.setLocalizedText(phpStanLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanLabel.text")); // NOI18N
-
-        phpStanTextField.setText(org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanTextField.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(phpStanBrowseButton, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanBrowseButton.text")); // NOI18N
         phpStanBrowseButton.addActionListener(new java.awt.event.ActionListener() {
@@ -112,15 +115,20 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
             }
         });
 
-        org.openide.awt.Mnemonics.setLocalizedText(phpStanHintLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanHintLabel.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(phpStanHintLabel, "HINT"); // NOI18N
 
+        phpStanLevelLabel.setLabelFor(phpStanLevelComboBox);
         org.openide.awt.Mnemonics.setLocalizedText(phpStanLevelLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanLevelLabel.text")); // NOI18N
 
         phpStanLevelComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "0", "1", "2", "3", "4", "5", "6", "7" }));
 
+        phpStanMemoryLimitLabel.setLabelFor(phpStanMemoryLimitTextField);
+        org.openide.awt.Mnemonics.setLocalizedText(phpStanMemoryLimitLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanMemoryLimitLabel.text")); // NOI18N
+
+        phpStanConfigurationLabel.setLabelFor(phpStanConfigurationTextField);
         org.openide.awt.Mnemonics.setLocalizedText(phpStanConfigurationLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanConfigurationLabel.text")); // NOI18N
 
-        phpStanConfigurationTextField.setText(org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanConfigurationTextField.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(phpStanConfigurationInfoLabel, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanConfigurationInfoLabel.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(phpStanConfiturationBrowseButton, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.phpStanConfiturationBrowseButton.text")); // NOI18N
         phpStanConfiturationBrowseButton.addActionListener(new java.awt.event.ActionListener() {
@@ -143,15 +151,10 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
             }
         });
 
-        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(PHPStanOptionsPanel.class, "PHPStanOptionsPanel.jLabel1.text")); // NOI18N
-
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addComponent(phpStanNoteLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -162,7 +165,9 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(phpStanConfigurationLabel)
                     .addComponent(phpStanLabel)
-                    .addComponent(phpStanLevelLabel))
+                    .addComponent(phpStanLevelLabel)
+                    .addComponent(phpStanNoteLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(phpStanMemoryLimitLabel))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
@@ -181,9 +186,10 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
                         .addComponent(phpStanConfiturationBrowseButton))
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jLabel1)
-                            .addComponent(phpStanLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                        .addGap(0, 0, Short.MAX_VALUE))))
+                            .addComponent(phpStanConfigurationInfoLabel)
+                            .addComponent(phpStanLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(phpStanMemoryLimitTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(0, 24, Short.MAX_VALUE))))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -201,11 +207,15 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
                     .addComponent(phpStanConfigurationTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(phpStanConfiturationBrowseButton))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jLabel1)
+                .addComponent(phpStanConfigurationInfoLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(phpStanLevelLabel)
                     .addComponent(phpStanLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(phpStanMemoryLimitLabel)
+                    .addComponent(phpStanMemoryLimitTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(18, 18, 18)
                 .addComponent(phpStanNoteLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -291,8 +301,8 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JLabel jLabel1;
     private javax.swing.JButton phpStanBrowseButton;
+    private javax.swing.JLabel phpStanConfigurationInfoLabel;
     private javax.swing.JLabel phpStanConfigurationLabel;
     private javax.swing.JTextField phpStanConfigurationTextField;
     private javax.swing.JButton phpStanConfiturationBrowseButton;
@@ -301,6 +311,8 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
     private javax.swing.JLabel phpStanLearnMoreLabel;
     private javax.swing.JComboBox<String> phpStanLevelComboBox;
     private javax.swing.JLabel phpStanLevelLabel;
+    private javax.swing.JLabel phpStanMemoryLimitLabel;
+    private javax.swing.JTextField phpStanMemoryLimitTextField;
     private javax.swing.JLabel phpStanMinVersionInfoLabel;
     private javax.swing.JLabel phpStanNoteLabel;
     private javax.swing.JButton phpStanSearchButton;
@@ -329,6 +341,7 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
         setPHPStanPath(options.getPHPStanPath());
         setPHPStanConfigurationPath(options.getPHPStanConfigurationPath());
         setPHPStanLevel(options.getPHPStanLevel());
+        setPHPStanMemoryLimit(options.getPHPStanMemoryLimit());
     }
 
     @Override
@@ -337,6 +350,7 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
         options.setPHPStanPath(getPHPStanPath());
         options.setPHPStanConfigurationPath(getPHPStanConfigurationPath());
         options.setPHPStanLevel(getPHPStanLevel());
+        options.setPHPStanMemoryLimit(getPHPStanMemoryLimit());
     }
 
     @Override
@@ -359,7 +373,7 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
     @Override
     public ValidationResult getValidationResult() {
         return new AnalysisOptionsValidator()
-                .validatePHPStan(getPHPStanPath(), getPHPStanConfigurationPath())
+                .validatePHPStan(ValidatorPHPStanParameter.create(this))
                 .getResult();
     }
 
@@ -389,6 +403,14 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
 
     private void setPHPStanLevel(int level) {
         phpStanLevelComboBox.setSelectedItem(String.valueOf(level));
+    }
+
+    public String getPHPStanMemoryLimit() {
+        return phpStanMemoryLimitTextField.getText().trim();
+    }
+
+    private void setPHPStanMemoryLimit(String memoryLimit) {
+        phpStanMemoryLimitTextField.setText(memoryLimit);
     }
 
     //~ Inner classes


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1463

- Add --memory-limit option
- Add validations in the PHPStanCustomizerPanel

We should also add this to the release100 branch because there is no workaround if the user would like to use `--memory-limit` option.