### PR TITLE
[NETBEANS-1481] Fix handling of module fragments (regression 9.0)

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1678,10 +1678,12 @@ public final class ModuleManager extends Modules {
         }
         return false;
     }
-    
+
     private void maybeAddToEnableList(Set<Module> willEnable, Set<Module> mightEnable, Module m, boolean okToFail) {
-        if (! missingDependencies(m).isEmpty()) {
-            assert okToFail : "Module " + m + " had unexpected problems: " + missingDependencies(m) + " (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")";
+        if (!missingDependencies(m).isEmpty()) {
+            if (!okToFail) {
+                Util.err.info("Module " + m + " had unexpected problems: " + missingDependencies(m) + " (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")");
+            }
             // Cannot satisfy its dependencies, exclude it.
             return;
         }
@@ -1746,8 +1748,8 @@ public final class ModuleManager extends Modules {
         }
         Collection<Module> frags = getAttachedFragments(m);
         for (Module fragMod : frags) {
-            if (! fragMod.isEnabled()) {
-                maybeAddToEnableList(willEnable, mightEnable, fragMod, false);
+            if (!fragMod.isEnabled() && !fragMod.isAutoload()) {
+                maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isEager());
             }
         }
     }

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment.missing.token
+OpenIDE-Module-Fragment-Host: org.foo.host
+OpenIDE-Module-Name: Fragment Content Module with missing token
+OpenIDE-Module-Requires: missing.token

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token/org/foo2/FragmentContent.java
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token/org/foo2/FragmentContent.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.foo;
+// Does not do anything, just needs to be here & loadable.
+public class FragmentContent {
+    protected String something() {
+        return "I am an added fragment with missing token";
+    }
+}

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-user.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-user.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment.user
+OpenIDE-Module-Name: Depends on a module fragment
+OpenIDE-Module-Module-Dependencies: org.foo.fragment
+

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -326,7 +326,7 @@ public abstract class SetupHid extends NbTestCase {
             throw new IOException("compilation failed");
         }
     }
-    private File createTestJAR(String name, String srcdir, File... classpath) throws IOException {
+    protected File createTestJAR(String name, String srcdir, File... classpath) throws IOException {
         return createTestJAR(data, jars, name, srcdir, classpath);
     }
     public static File createTestJAR(File data, File jars, String name, String srcdir, File... classpath) throws IOException {


### PR DESCRIPTION
This pull request fixes regressions against netbeans 9.0 introduced by #847 ([NETBEANS-1147](https://issues.apache.org/jira/browse/NETBEANS-1147)).

Broken use case: 
Multiple eager OS specific fragments (Linux, MacOS, Windows) not working any more.

Main problem was a thrown AssertionError in case of an eager fragment with unsatisfied required token. After writing regression tests against netbeans 9.0 release sources I found another regression.  The current code base always activates fragments without respecting the autoload contract.



For details see related issue: [NETBEANS-1481](https://issues.apache.org/jira/browse/NETBEANS-1481). 


 
