### PR TITLE
[NETBEANS-1481] Fix handling of eager module fragments (regression netbeans 9.0)

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1681,7 +1681,9 @@ public final class ModuleManager extends Modules {
     
     private void maybeAddToEnableList(Set<Module> willEnable, Set<Module> mightEnable, Module m, boolean okToFail) {
         if (! missingDependencies(m).isEmpty()) {
-            assert okToFail : "Module " + m + " had unexpected problems: " + missingDependencies(m) + " (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")";
+            if (!okToFail) {
+                Util.err.warning("Module " + m + " had unexpected problems: " + missingDependencies(m) + " (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")");
+            }
             // Cannot satisfy its dependencies, exclude it.
             return;
         }
@@ -1747,7 +1749,7 @@ public final class ModuleManager extends Modules {
         Collection<Module> frags = getAttachedFragments(m);
         for (Module fragMod : frags) {
             if (! fragMod.isEnabled()) {
-                maybeAddToEnableList(willEnable, mightEnable, fragMod, false);
+                maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isEager());
             }
         }
     }

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment.missing.token
+OpenIDE-Module-Fragment-Host: org.foo.host
+OpenIDE-Module-Name: Fragment Content Module with missing token
+OpenIDE-Module-Requires: missing.token

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token/org/foo2/FragmentContent.java
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token/org/foo2/FragmentContent.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.foo;
+// Does not do anything, just needs to be here & loadable.
+public class FragmentContent {
+    protected String something() {
+        return "I am an added fragment with missing token";
+    }
+}

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
@@ -2760,6 +2760,44 @@ public class ModuleManagerTest extends SetupHid {
         Module client = mgr.create(jar, null, false, false, false);
         assertEquals(1, client.getProblems().size());
     }
+
+    public void testEnableHostWithEagerFragment() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+
+        Module host = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
+        Module fragment = mgr.create(new File(jars, "fragment-module.jar"), null, false, false, true);
+
+        assertTrue("Host is known", mgr.getModules().contains(host));
+        assertTrue("Fragment is known", mgr.getModules().contains(fragment));
+
+        mgr.enable(host);
+
+        assertTrue("Host must be enabled", mgr.getEnabledModules().contains(host));
+        assertTrue("Fragment must be enabled", mgr.getEnabledModules().contains(fragment));
+    }
+
+    public void testEnableHostWithEagerFragmentUnsatisfied() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+
+        createTestJAR(data, jars, "fragment-module-missing-token", null);
+
+        Module host = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
+        Module fragment = mgr.create(new File(jars, "fragment-module-missing-token.jar"), null, false, false, true);
+
+        assertTrue("Host is known", mgr.getModules().contains(host));
+        assertTrue("Fragment is known", mgr.getModules().contains(fragment));
+
+        mgr.enable(host);
+
+        assertTrue("Host must be enabled", mgr.getEnabledModules().contains(host));
+        assertTrue("Fragment must not be enabled", !mgr.getEnabledModules().contains(fragment));
+    }
     
     public void testEnableFragmentBeforeItsHost() throws Exception {
         MockModuleInstaller installer = new MockModuleInstaller();


### PR DESCRIPTION
This pull request fixes regressions against netbeans 9.0 introduced by #847 (NETBEANS-1147).

Broken use case:
Multiple eager OS specific fragments (Linux, MacOS, Windows) not working any more.

Main problem was a thrown AssertionError in case of an eager fragment with unsatisfied required token. 

For details see related issue: NETBEANS-1481.