### PR TITLE
[NETBEANS-1419] fix for Assertion Error while editing project libraries

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
@@ -75,7 +75,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
     /** Restore the renderer to a pristine state */
     public void reset() {
-        assert SwingUtilities.isEventDispatchThread();
+        assertEDTAccess();
         parentFocused = false;
         setCentered(false);
         html = null;
@@ -748,6 +748,23 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     public @Override void addPropertyChangeListener(PropertyChangeListener l) {
         if (swingRendering) {
             super.addPropertyChangeListener(l);
+        }
+    }
+    
+    private void assertEDTAccess() {
+        boolean check = false;
+        assert check = true;
+        if (check && !SwingUtilities.isEventDispatchThread() && System.getProperty("nbjunit.workdir") == null) {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            boolean whitespaced = false;
+            for (int i = 0; i < stackTrace.length; ++i) {
+                StackTraceElement elem = stackTrace[i];
+                if ("org.openide.explorer.view.TreeView".equals(elem.getClassName()) && "<init>".equals(elem.getMethodName())) {
+                    whitespaced = true;
+                    break;
+                }
+            }
+            assert whitespaced || SwingUtilities.isEventDispatchThread() : "Should be called in EDT only!";
         }
     }
 }


### PR DESCRIPTION
This error was present from NetBeans 9. I've added the fix based on the following observations : 
- An Event Dispatch Thread cannot be called from the inside of another Event Dispatch Thread. 
- A similar check is done in NodeRenderer.java in the module openide.explorer, checking that either the thread should be an Event Dispatch Thread or, a new TreeView is being initialized in that thread.
