### PR TITLE
[NETBEANS-1419] Fix assertion error on Java Projects when Edit JDK from popup menu.

### DIFF
--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/EditRootAction.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/EditRootAction.java
@@ -64,6 +64,11 @@ final class EditRootAction extends NodeAction {
         return new HelpCtx(PlatformNode.class);
     }
 
+    @Override
+    protected boolean asynchronous() {
+        return false;
+    }
+
 }
 
 


### PR DESCRIPTION
Well this is the proper fix for NETBEANS-1419. This does not need to be cherry picked as assertions are only enabled on non-release branch.