### PR TITLE
[NETBEANS-1440] Fixed BadLocationException on triple click to select …

### DIFF
--- a/ide/editor.document/src/org/netbeans/modules/editor/document/TextSearchUtils.java
+++ b/ide/editor.document/src/org/netbeans/modules/editor/document/TextSearchUtils.java
@@ -93,8 +93,8 @@ public class TextSearchUtils {
         for (int i = offset; i < limitOffset; i++) {
             char ch = text.charAt(i);
             if (ch == '\n') {
-                // If first char skip right above it
-                return (i == offset) ? i + 1 : i;
+                // If first char and offset is not at EOF skip right above it
+                return (i == offset && i + 1 < limitOffset) ? i + 1 : i;
             }
             if (classifier.isWhitespace(ch)) {
                 if (inIdentifier) { // End of identifier

--- a/ide/editor.document/test/unit/src/org/netbeans/modules/editor/document/TextSearchUtilsTest.java
+++ b/ide/editor.document/test/unit/src/org/netbeans/modules/editor/document/TextSearchUtilsTest.java
@@ -40,6 +40,7 @@ public class TextSearchUtilsTest {
     //                                             01234 567890123 4567890
     private static final String MULTI_LINE_TEXT = " ab \n/** jdoc\n * 2nd";
     
+    private static final String MULTI_LINE_TEXT1 = "Hello\nWorld\n";
     /**
      * Test of getWordStart method, of class TextSearchUtils.
      */
@@ -62,6 +63,10 @@ public class TextSearchUtilsTest {
 
         assertEquals(13, TextSearchUtils.getWordEnd(INT_I_TEXT, DC, 10));
         assertEquals(10, TextSearchUtils.getWordEnd(INT_I_TEXT, DC, 8));
+
+        assertEquals(11, TextSearchUtils.getWordEnd(MULTI_LINE_TEXT1, DC, 11));
+        assertEquals(6, TextSearchUtils.getWordEnd(MULTI_LINE_TEXT1, DC, 5));
+        assertEquals(5, TextSearchUtils.getWordEnd(MULTI_LINE_TEXT1, DC, 4));
     }
 
     /**


### PR DESCRIPTION
…text at EOF

Jira Link:https://issues.apache.org/jira/browse/NETBEANS-1440

Steps to reproduce the issue
1.let the very last line in the editor is empty
2.have the editor caret at the very last line
3.have the mouse cursor over the last line as well
4.double click, but don't release on the second click (i.e. down-up-down)
move the mouse to right