### PR TITLE
[NETBEANS-1352][NETBEANS-586] Filter out non-Java files before passin…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.processing.Processor;
 import javax.swing.event.ChangeEvent;
@@ -871,6 +872,11 @@ public class JavacParser extends Parser {
             options.add("--add-modules");       //NOI18N
             options.add(additionalModules.stream().collect(Collectors.joining(",")));   //NOI18N
         }
+
+        //filter out classfiles:
+        files = StreamSupport.stream(files.spliterator(), false)
+                             .filter(file -> file.getKind() == Kind.SOURCE)
+                             .collect(Collectors.toList());
 
         Context context = new Context();
         //need to preregister the Messages here, because the getTask below requires Log instance:


### PR DESCRIPTION
…g them to javac.

Unclear to me if the behavior is really sound (if a JavaSource is created for a classfile, the CompilationInfo/"parse" result should exactly match the provided classfiles, while it may in reality represent the content of like-named classfile on the classpath), but I hope/think that after this fix, the behavior is the same as for NB 8.2. Test for this is ClassParserTest in java.source.base.