### PR TITLE
Don't add whitespaces to java guarded sections

### DIFF
--- a/java/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedReader.java
+++ b/java/java.guards/src/org/netbeans/modules/java/guards/JavaGuardedReader.java
@@ -173,8 +173,8 @@ final class JavaGuardedReader {
                     charBuffPtr -= MAGICLEN;
                     i += match.length();
                     int toNl = toNewLine(i, readBuff);
-                    int sectionSize = MAGICLEN+match.length()+toNl;
-                    
+                    int sectionSize = KEEP_GUARD_COMMENTS ? MAGICLEN + match.length() + toNl : 0;
+
 //                    if (!justFilter) {
 //                        System.out.println("## MATCH: '" + match.substring(0, match.length() - 1) + "'");
                         SectionDescriptor desc = new SectionDescriptor(
@@ -194,8 +194,9 @@ final class JavaGuardedReader {
                         charBuffPtr += MAGICLEN;
                     } else {
                         i += toNl;
-                        Arrays.fill(charBuff,charBuffPtr,charBuffPtr+sectionSize,' ');
-                        charBuffPtr+=sectionSize;
+                        char[] tmpCharBuff = new char[charBuff.length];
+                        System.arraycopy(charBuff, 0, tmpCharBuff, 0, charBuffPtr);
+                        charBuff = tmpCharBuff;
                     }
                 }
             }

--- a/java/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedReaderTest.java
+++ b/java/java.guards/test/unit/src/org/netbeans/modules/java/guards/JavaGuardedReaderTest.java
@@ -87,7 +87,7 @@ public class JavaGuardedReaderTest extends TestCase {
         
         String readStr = "\nclass A {//" + "GEN-LINE:hu\n}\n";
         editor.setStringContent(readStr);
-        String expStr =  "\nclass A {  " + "           \n}\n";
+        String expStr =  "\nclass A {\n}\n";
         char[] readBuff = readStr.toCharArray();
         
         char[] result = instance.translateToCharBuff(readBuff);
@@ -132,7 +132,7 @@ public class JavaGuardedReaderTest extends TestCase {
         
         String readStr = "\nclass A {//" + "GEN-BEGIN:hu\n\n}//" + "GEN-END:hu\n";
         editor.setStringContent(readStr);
-        String expStr =  "\nclass A {  " + "            \n\n}  " + "          \n";
+        String expStr =  "\nclass A {\n\n}\n";
         char[] readBuff = readStr.toCharArray();
         
         JavaGuardedReader.setKeepGuardCommentsForTest(false);
@@ -155,7 +155,7 @@ public class JavaGuardedReaderTest extends TestCase {
         
         String readStr = "\nclass A {//" + "GEN-FIRST:hu\n  statement;\n}//" + "GEN-LAST:hu\n";
         editor.setStringContent(readStr);
-        String expStr =  "\nclass A {  " + "            \n  statement;\n}  " + "           \n";
+        String expStr =  "\nclass A {\n  statement;\n}\n";
         char[] readBuff = readStr.toCharArray();
         
         char[] result = instance.translateToCharBuff(readBuff);
@@ -180,7 +180,7 @@ public class JavaGuardedReaderTest extends TestCase {
         
         String readStr = "\nclass A //" + "GEN-FIRST:hu\n{//" + "GEN-HEADEREND:hu\n  statement;\n}//" + "GEN-LAST:hu\n";
         editor.setStringContent(readStr);
-        String expStr =  "\nclass A   " + "            \n{  " + "                \n  statement;\n}  " + "           \n";
+        String expStr =  "\nclass A \n{\n  statement;\n}\n";
         char[] readBuff = readStr.toCharArray();
         
         char[] result = instance.translateToCharBuff(readBuff);


### PR DESCRIPTION
Currently, `//GEN-*` is replaced with ` `(whitespaces). So, trailing whitespaces are added to generated codes. We can remove them manually temporarily but they are added again if we edit files.

IMHO, We should create a new array instead of adding them.

![nb-java-guarded-code-trailing-whitespaces](https://user-images.githubusercontent.com/738383/48236699-d20ffd00-e406-11e8-8851-f9ee57758e2a.png)
