### PR TITLE
Fix the unit test for CC in php.editor

### DIFF
--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -2664,6 +2664,7 @@ public abstract class CslTestBase extends NbTestCase {
             caretOffset = -1;
         }
 
+        final String[] described = new String[1];
         UserTask task = new UserTask() {
             public @Override void run(ResultIterator resultIterator) throws Exception {
                 Parser.Result r = caretOffset == -1 ? resultIterator.getParserResult() : resultIterator.getParserResult(caretOffset);
@@ -2783,17 +2784,18 @@ public abstract class CslTestBase extends NbTestCase {
                     }
                 };
 
-                String described = describeCompletion(caretLine, pr.getSnapshot().getSource().createSnapshot().getText().toString(), caretOffset, true, caseSensitive, type, proposals, includeModifiers, deprecatedHolder, formatter);
-                assertDescriptionMatches(file, described, true, ".completion");
+                described[0] = describeCompletion(caretLine, pr.getSnapshot().getSource().createSnapshot().getText().toString(), caretOffset, true, caseSensitive, type, proposals, includeModifiers, deprecatedHolder, formatter);
             }
         };
         if (classPathsForTest == null || classPathsForTest.isEmpty()) {
             ParserManager.parse(Collections.singleton(testSource), task);
+            assertDescriptionMatches(file, described[0], true, ".completion");
         } else {
             Future<Void> future = ParserManager.parseWhenScanFinished(Collections.singleton(testSource), task);
             if (!future.isDone()) {
                 future.get();
             }
+            assertDescriptionMatches(file, described[0], true, ".completion");
         }
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -286,6 +286,10 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             case GROUP_USE_FUNCTION_KEYWORD:
                 searchPrefix = getPrefix(info, findBaseNamespaceEnd(info, caretOffset), true, PrefixBreaker.WITH_NS_PARTS);
                 break;
+            case EXPRESSION: // no break
+                if (prefix.startsWith("@")) { // NOI18N
+                    prefix = prefix.substring(1);
+                }
             default:
                 searchPrefix = null;
                 break;

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion163432Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion163432Test.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.junit.RandomlyFails;
 import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -39,10 +38,10 @@ public class PHPCodeCompletion163432Test extends PHPCodeCompletionTestBase {
         super(testName);
     }
 
-    @RandomlyFails
     public void test163432() throws Exception {
         checkCompletion("testfiles/completion/lib/test163432/test.php", "@fn^", false);
     }
+
     public void test163432_1() throws Exception {
         checkCompletion("testfiles/completion/lib/test163432/test.php", "@$cls163432->^", false);
     }


### PR DESCRIPTION
- Fix `php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion163432Test.java`
- Fix `CslTestBase.checkCompletion()` method because unit tests may not fail when the `fail()` method is calld in `UserTask.run()` i.e. Don't call the `assertDescriptionMatches` method in the `UserTask.run` method. 
- Remove `@` from the prefix if the context is `EXPRESSION`

@tzezula Is the change for `CslTestBase` OK?