### PR TITLE
NETBEANS-1698: Listview only performs action on left-doubleclick. Con…

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/MouseUtils.java
+++ b/platform/openide.awt/src/org/openide/awt/MouseUtils.java
@@ -76,6 +76,10 @@ public class MouseUtils extends Object {
         if ((e.getID() != MouseEvent.MOUSE_CLICKED) || (e.getClickCount() == 0)) {
             return false;
         }
+        // do not report already consumed events
+        if (e.isConsumed()) {
+            return false;
+        }
 
         return ((e.getClickCount() % 2) == 0) || isDoubleClickImpl(e);
     }

--- a/platform/openide.explorer/src/org/openide/explorer/view/ListView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/ListView.java
@@ -1301,7 +1301,7 @@ public class ListView extends JScrollPane implements Externalizable {
 
         @Override
         public void mouseClicked(MouseEvent e) {
-            if (MouseUtils.isDoubleClick(e)) {
+            if (SwingUtilities.isLeftMouseButton(e) && MouseUtils.isDoubleClick(e)) {
                 int index = list.locationToIndex(e.getPoint());
                 performObjectAt(index, e.getModifiers());
             }


### PR DESCRIPTION
During testing, I found that NB platform still interprets an already consumed mouse event as a proper doubleclick. The method used to check whether a mouse event is a doubleclick is MouseUtils.isDoubleClick. 

A brief scan through usages of isDoubleClick revealed that virtually none of the handlers check for event's isConsumed. Given that a double-click usually triggers some heavyweight action (open, execute, ...) I would like to **propose that isDoubleClick returns false** so that all those methods which use the helper will remain silent when another listener already handled (and consumed) the event.

In addition I'd like to fix `ListView` to only perform action on left-doubleclick, since it would happily execute preferred action on middle-doubleclick as well.
