### PR TITLE
[NETBEANS-1727] Native Execution does not correctly sanitize username for temp directory

### DIFF
--- a/ide/dlight.nativeexecution/release/bin/nativeexecution/hostinfo.sh
+++ b/ide/dlight.nativeexecution/release/bin/nativeexecution/hostinfo.sh
@@ -116,7 +116,7 @@ wx_fail() {
 
 USER=${USER:-`logname 2>/dev/null`}
 USER=${USER:-${USERNAME}}
-USER_D=`echo ${USER} | sed "s/\\\/_/"`
+USER_D=`echo ${USER} | sed "s/[\\/]/_/g"`
 TMPBASE=${TMPBASE:-/var/tmp}
 
 SUFFIX=0


### PR DESCRIPTION
The sed call in line 119 of hostinfo.sh does not correctly handle
backslashes in the escape sequence. The call to sed fails with:

sed: -e expression #1, char 6: unterminated `s' command

and the variable USER_D is set to the empty string.