### PR TITLE
[NETBEANS-1372] Snap Descriptor 

### DIFF
--- a/nbbuild/packaging/snap/gui/netbeans.desktop
+++ b/nbbuild/packaging/snap/gui/netbeans.desktop
@@ -17,8 +17,8 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=NetBeans 10.0
-Comment=Apache NetBeans, The Smarter Way to Code
+Name=Apache NetBeans 10.0 (incubating)
+Comment=Apache NetBeans (incubating), The Smarter Way to Code
 Exec=netbeans %F
 Categories=Application;Development;Java;PHP;JS;JavaScript;IDE
 Icon=${SNAP}/meta/gui/icon.png

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
         # Make the default cache and data directory relative to Snap user directory
         sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dapple.laf.useScreenMenuBar=true -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
+        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans
 

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -16,16 +16,17 @@
 
 name: netbeans
 version: "10.0"
-summary: NetBeans Java IDE
+summary: Apache NetBeans IDE (incubating)
 description: |
-  NetBeans IDE lets you quickly and easily develop Java desktop, mobile, and 
-  web applications, as well as HTML5 applications with HTML, JavaScript, and
-  CSS. The IDE also provides a great set of tools for PHP and C/C++ developers.
+  Apache NetBeans IDE (incubating) lets you quickly and easily develop Java 
+  desktop and web applications, as well as HTML5 applications with 
+  HTML, JavaScript, and CSS. The IDE also provides a great set of tools for PHP
+  developers.
   It is free and open source and has a large community of users and developers
   around the world. 
 icon: ../../platform/core.startup/src/org/netbeans/core/startup/frame512.png
 confinement: classic
-grade: devel
+grade: stable
 architectures: [ amd64 ]
 
 parts:


### PR DESCRIPTION
As we can provide convenience binary in form of a Snap package for Linux, the descriptor shall not mention "NetBeans IDE" but "Apache NetBeans IDE (incubating)". 
It has also marked as stable, so it can be distributed in latest/stable channel on snapcraft.io. 