### PR TITLE
Maven first in New Project Wizard

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/resources/layer.xml
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/resources/layer.xml
@@ -263,9 +263,11 @@
             </file>
         </folder>
         <folder name="Project">
-            <folder name="APISupport">
-                <attr name="displayName" bundlevalue="org.netbeans.modules.apisupport.project.ui.wizard.Bundle#Templates/Project/APISupport"/>
-                <attr name="position" intvalue="900"/>
+            <folder name="AntJava">
+                <folder name="APISupport">
+                    <attr name="displayName" bundlevalue="org.netbeans.modules.apisupport.project.ui.wizard.Bundle#Templates/Project/APISupport"/>
+                    <attr name="position" intvalue="900"/>
+                </folder>
             </folder>
         </folder>
     </folder>

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
@@ -52,7 +52,7 @@ import org.openide.util.NbBundle.Messages;
  */
 public class NewNbModuleWizardIterator implements WizardDescriptor.AsynchronousInstantiatingIterator<WizardDescriptor> {
     
-    private static final String FOLDER = "Project/APISupport";
+    private static final String FOLDER = "Project/AntJava/APISupport";
     private static final String MODULE_ICON = "org/netbeans/modules/apisupport/project/resources/module.png";
     private static final String SUITE_ICON = "org/netbeans/modules/apisupport/project/suite/resources/suite.png";
 

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/resources/Bundle.properties
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/resources/Bundle.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-Templates/Project/Standard/j2sefreeform.xml=Java Free-Form Project
+Templates/Project/AntJava/j2sefreeform.xml=Java Free-Form Project

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/resources/layer.xml
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/resources/layer.xml
@@ -23,9 +23,9 @@
 <filesystem>
     <folder name="Templates">
         <folder name="Project">
-            <folder name="Standard">
+            <folder name="AntJava">
                 <file name="j2sefreeform.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.java.freeform.resources.Bundle#Templates/Project/Standard/j2sefreeform.xml"/>
+                    <attr name="displayName" bundlevalue="org.netbeans.modules.java.freeform.resources.Bundle#Templates/Project/AntJava/j2sefreeform.xml"/>
                     <attr name="iconBase" stringvalue="org/netbeans/modules/ant/freeform/resources/freeform-project.png"/>
                     <attr name="position" intvalue="400"/>
                     <attr name="template" boolvalue="true"/>

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewJ2SEModularProjectWizardIterator.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/NewJ2SEModularProjectWizardIterator.java
@@ -59,7 +59,7 @@ public class NewJ2SEModularProjectWizardIterator implements WizardDescriptor.Pro
     private NewJ2SEModularProjectWizardIterator() {
     }
 
-    @TemplateRegistration(folder="Project/Standard", position=350, displayName="#template_multimodule", iconBase="org/netbeans/modules/java/j2semodule/ui/resources/j2seModuleProject.png", description="../resources/emptyModuleProject.html")
+    @TemplateRegistration(folder="Project/AntJava", position=350, displayName="#template_multimodule", iconBase="org/netbeans/modules/java/j2semodule/ui/resources/j2seModuleProject.png", description="../resources/emptyModuleProject.html")
     @Messages("template_multimodule=Java Modular Project")
     public static NewJ2SEModularProjectWizardIterator multiModule() {
         return new NewJ2SEModularProjectWizardIterator();

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/resources/desktop.html
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/resources/desktop.html
@@ -24,6 +24,6 @@
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 </head>
   <BODY>
-    The Java Desktop Application Projects.
+    Ant based Java Application Projects.
   </BODY>
 </HTML>

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/resources/layer.xml
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/resources/layer.xml
@@ -24,10 +24,10 @@
 
     <folder name="Templates">
         <folder name="Project">
-            <folder name="Standard">
-                <attr name="displayName" bundlevalue="org.netbeans.modules.java.j2seproject.ui.wizards.Bundle#Templates/Project/Standard"/>
+            <folder name="AntJava">
+                <attr name="displayName" bundlevalue="org.netbeans.modules.java.j2seproject.ui.wizards.Bundle#Templates/Project/AntJava"/>
                 <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/java/j2seproject/ui/resources/desktop.html"/>
-                <attr name="position" intvalue="100"/>
+                <attr name="position" intvalue="990"/>
             </folder>
         </folder>
     </folder>

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/Bundle.properties
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/Bundle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-Templates/Project/Standard=Java
+Templates/Project/AntJava=Ant Java
 #New project wizard
 TXT_DefaultPackageName=mypkg
 

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/NewJ2SEProjectWizardIterator.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/NewJ2SEProjectWizardIterator.java
@@ -68,19 +68,19 @@ public class NewJ2SEProjectWizardIterator implements WizardDescriptor.ProgressIn
         this.type = type;
     }
 
-    @TemplateRegistration(folder="Project/Standard", position=100, displayName="#template_app", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/emptyProject.html")
+    @TemplateRegistration(folder="Project/AntJava", position=100, displayName="#template_app", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/emptyProject.html")
     @Messages("template_app=Java Application")
     public static NewJ2SEProjectWizardIterator app() {
         return new NewJ2SEProjectWizardIterator(WizardType.APP);
     }
 
-    @TemplateRegistration(folder="Project/Standard", position=200, displayName="#template_library", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/emptyLibrary.html")
+    @TemplateRegistration(folder="Project/AntJava", position=200, displayName="#template_library", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/emptyLibrary.html")
     @Messages("template_library=Java Class Library")
     public static NewJ2SEProjectWizardIterator library() {
         return new NewJ2SEProjectWizardIterator(WizardType.LIB);
     }
 
-    @TemplateRegistration(folder="Project/Standard", position=300, displayName="#template_existing", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/existingProject.html")
+    @TemplateRegistration(folder="Project/AntJava", position=300, displayName="#template_existing", iconBase="org/netbeans/modules/java/j2seproject/ui/resources/j2seProject.png", description="../resources/existingProject.html")
     @Messages("template_existing=Java Project with Existing Sources")
     public static NewJ2SEProjectWizardIterator existing() {
         return new NewJ2SEProjectWizardIterator(WizardType.EXT);

--- a/java/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
+++ b/java/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
@@ -56,10 +56,10 @@ import org.openide.util.RequestProcessor;
 })
 public class DukeScriptWizard {
     @TemplateRegistration(
-            position = 133,
+            position = 120,
             page = "dukeScriptWizard.html",
             content = "dukescript.archetype",
-            folder = "Project/Standard",
+            folder = "Project/Maven2",
             displayName = "#DukeScriptWizard_displayName",
             iconBase = "org/netbeans/modules/maven/htmlui/DukeHTML.png",
             description = "description.html"

--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -32,7 +32,7 @@
         <folder name="Project">
             <folder name="Maven2">
                 <attr name="displayName" bundlevalue="org.netbeans.modules.maven.newproject.Bundle#Templates/Project/Maven2"/>
-                <attr name="position" intvalue="513"/>
+                <attr name="position" intvalue="100"/>
             </folder>
         </folder>
     </folder>

--- a/java/maven/src/org/netbeans/modules/maven/newproject/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/Bundle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-Templates/Project/Maven2=Maven
+Templates/Project/Maven2=Java
 UseOpenPanel.jTextArea1.text=Any Maven-based project can be opened and used within the IDE without any import procedure.\n\nClick Finish to open a project using the Open Project dialog.\n\n
 LBL_Description=&Description\:
 LBL_ProjectName=Project &Name\:

--- a/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
@@ -73,7 +73,7 @@ public class MavenWizardIterator implements WizardDescriptor.BackgroundInstantia
 //        return ArchetypeWizards.definedArchetype("org.apache.maven.archetypes", "maven-archetype-quickstart", "1.1", null, LBL_Maven_Quickstart_Archetype());
 //    }
     
-    @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position=120, displayName="#LBL_Maven_JavaFx_Archetype", iconBase="org/netbeans/modules/maven/resources/jaricon.png", description="javafx.html")
+    @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position=920, displayName="#LBL_Maven_JavaFx_Archetype", iconBase="org/netbeans/modules/maven/resources/jaricon.png", description="javafx.html")
     @Messages("LBL_Maven_JavaFx_Archetype=JavaFX Application")
     public static WizardDescriptor.InstantiatingIterator<?> javafx() {
         return ArchetypeWizards.definedArchetype("org.codehaus.mojo.archetypes", "javafx", "0.6", null, LBL_Maven_JavaFx_Archetype());

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/layer.xml
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/layer.xml
@@ -39,54 +39,56 @@
         </folder>
 
         <folder name="Project">
-            <folder name="JavaFX">
-                <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX"/>
-                <attr name="position" intvalue="195"/>
+            <folder name="AntJava">
+                <folder name="JavaFX">
+                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX"/>
+                    <attr name="position" intvalue="195"/>
 
-                <file name="javafxApp.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxApp.xml"/>
-                    <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
-                    <attr name="position" intvalue="105"/>
-                    <attr name="template" boolvalue="true"/>
-                    <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXApp.html"/>
-                    <attr name="instantiatingIterator" newvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator"/>
-                </file>
+                    <file name="javafxApp.xml">
+                        <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxApp.xml"/>
+                        <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
+                        <attr name="position" intvalue="105"/>
+                        <attr name="template" boolvalue="true"/>
+                        <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXApp.html"/>
+                        <attr name="instantiatingIterator" newvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator"/>
+                    </file>
 
-                <file name="preloaderApp.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/preloaderApp.xml"/>
-                    <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
-                    <attr name="position" intvalue="205"/>
-                    <attr name="template" boolvalue="true"/>
-                    <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXPreloaderApp.html"/>
-                    <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.preloader"/>
-                </file>
+                    <file name="preloaderApp.xml">
+                        <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/preloaderApp.xml"/>
+                        <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
+                        <attr name="position" intvalue="205"/>
+                        <attr name="template" boolvalue="true"/>
+                        <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXPreloaderApp.html"/>
+                        <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.preloader"/>
+                    </file>
 
-                <file name="fxml.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.fxml.Bundle#Templates/Project/JavaFX/fxml.xml"/>
-                    <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
-                    <attr name="position" intvalue="305"/>
-                    <attr name="template" boolvalue="true"/>
-                    <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXMLApp.html"/>
-                    <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.fxml"/>
-                </file>
+                    <file name="fxml.xml">
+                        <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.fxml.Bundle#Templates/Project/JavaFX/fxml.xml"/>
+                        <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
+                        <attr name="position" intvalue="305"/>
+                        <attr name="template" boolvalue="true"/>
+                        <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXMLApp.html"/>
+                        <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.fxml"/>
+                    </file>
 
-                <file name="javafxSwingApp.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxSwingApp.xml"/>
-                    <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
-                    <attr name="position" intvalue="405"/>
-                    <attr name="template" boolvalue="true"/>
-                    <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXSwingApp.html"/>
-                    <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.swing"/>
-                </file>
+                    <file name="javafxSwingApp.xml">
+                        <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxSwingApp.xml"/>
+                        <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
+                        <attr name="position" intvalue="405"/>
+                        <attr name="template" boolvalue="true"/>
+                        <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXSwingApp.html"/>
+                        <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.swing"/>
+                    </file>
 
-                <file name="javafxExisting.xml">
-                    <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxExisting.xml"/>
-                    <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
-                    <attr name="position" intvalue="505"/>
-                    <attr name="template" boolvalue="true"/>
-                    <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXExistingSources.html"/>
-                    <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.existing"/>
-                </file>
+                    <file name="javafxExisting.xml">
+                        <attr name="displayName" bundlevalue="org.netbeans.modules.javafx2.project.Bundle#Templates/Project/JavaFX/javafxExisting.xml"/>
+                        <attr name="iconBase" stringvalue="org/netbeans/modules/javafx2/project/ui/resources/jfx_project.png"/>
+                        <attr name="position" intvalue="505"/>
+                        <attr name="template" boolvalue="true"/>
+                        <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/javafx2/project/templates/JavaFXExistingSources.html"/>
+                        <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.existing"/>
+                    </file>
+                </folder>
             </folder>
         </folder>
 


### PR DESCRIPTION
There's a [discussion in the netbeans-dev mailing list ](https://lists.apache.org/thread.html/e0c9493f19fd291590180ac1cbb304ee556b1812b0229cfb12cac9a0@%3Cdev.netbeans.apache.org%3E)about changing the layout of the "New project" wizard. 

Currently the "Java" Category creates an ANT-based project. As ANT is old and only few projects use it, this Category should use Maven. This can be done by simply rearranging the projects a bit, mostly via branding. 





