### PR TITLE
NETBEANS-1752: Fix broken hyperlink in test output when testing a Mav…

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
@@ -87,7 +87,7 @@ public class TestOutputListenerProvider implements OutputProcessor {
         runningPattern = Pattern.compile("(?:\\[surefire\\] )?Running (.*)", Pattern.DOTALL); //NOI18N
         outDirPattern = Pattern.compile(".*(?:Surefire)?(?:Failsafe)? report directory\\: (.*)", Pattern.DOTALL); //NOI18N
         outDirPattern2 = Pattern.compile(".*Setting reports dir\\: (.*)", Pattern.DOTALL); //NOI18N
-        runningPattern2 = Pattern.compile("^---\\smaven-surefire-plugin:\\d+\\.\\d+:test\\s.*$", Pattern.DOTALL);
+        runningPattern2 = Pattern.compile("^---\\smaven-surefire-plugin:(\\d+\\.)+\\d+:test\\s.*$", Pattern.DOTALL);
     }
     
     public String[] getWatchedGoals() {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/output/TestOutputListenerProviderTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/output/TestOutputListenerProviderTest.java
@@ -19,11 +19,6 @@
 package org.netbeans.modules.maven.output;
 
 import junit.framework.*;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 import org.netbeans.modules.maven.api.output.OutputVisitor;
 
 /**
@@ -98,7 +93,7 @@ public class TestOutputListenerProviderTest extends TestCase {
         
     }
     
-    public void testFailfafeSeparateTestOuput() {
+    public void testFailsafeSeparateTestOuput() {
         OutputVisitor visitor = new OutputVisitor();
         visitor.resetVisitor();
         provider.sequenceStart("mojo-execute#failsafe:integration-test", visitor);


### PR DESCRIPTION
…en project where the Surefire version has 3 digits

See https://issues.apache.org/jira/browse/NETBEANS-1752.

I'd be happy to add a test for this, but it doesn't look like Netbeans has anything like Mockito or Easymock as a dependency, and the test would be hitting code (https://github.com/srdo/incubator-netbeans/blob/a10d38a2772a38a73206fd62551dc378d2384a79/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java#L127) that I don't want to stub by hand.