### PR TITLE
[NETBEANS-1768] CodeCoverage doesn't work when custom outputDirectory is used in a PluginExecution

### DIFF
--- a/java/maven.coverage/src/org/netbeans/modules/maven/coverage/MavenCoverageProvider.java
+++ b/java/maven.coverage/src/org/netbeans/modules/maven/coverage/MavenCoverageProvider.java
@@ -135,6 +135,11 @@ public final class MavenCoverageProvider implements CoverageProvider {
                     return null;
                 }
             }
+            File outputFile = FileUtil.normalizeFile(new File(outputDirectory));
+            if (!outputFile.exists()) {
+                // NETBEANS-1768 checking the plugin executions if the outputDirectory is customised
+                outputDirectory = PluginPropertyUtils.getPluginProperty(p, GROUP_JOCOCO, ARTIFACT_JOCOCO, "outputDirectory", "report", null);
+            }
             return FileUtil.normalizeFile(new File(outputDirectory, "jacoco.xml"));
         } else {
         String outputDirectory = PluginPropertyUtils.getReportPluginProperty(p, GROUP_COBERTURA, ARTIFACT_COBERTURA, "outputDirectory", null);


### PR DESCRIPTION
Adding additional check for plugin executions if the JaCoCo outputDirectory is customised within an execution