### PR TITLE
[Backport] Enhance AU to install missing feature parts (PR-1044)

### DIFF
--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/Bundle.properties
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/Bundle.properties
@@ -75,7 +75,7 @@ CAP_Action=Executing Action
 # {0} short name of the folder
 MSG_BrokenProject={0} (broken)
 MSG_BrokenActionInfo=Resolve Problems...
-
+MSG_BrokenAction_FeatureIncomplete=Feature {0} is incomplete: some module(s) are missing: {1}
 
 ConfigurationPanel.errorLabel.text=dummy
 

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
@@ -70,7 +70,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
 
     public ConfigurationPanel(String displayName, final Callable<JComponent> callable, FeatureInfo info) {
         this(callable);
-        setInfo(info, displayName, Collections.<UpdateElement>emptyList(), Collections.<String>emptyList());
+        setInfo(info, displayName, Collections.<UpdateElement>emptyList(), Collections.emptyList());
     }
     
     public ConfigurationPanel(final Callable<JComponent> callable) {
@@ -83,7 +83,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
     }
 
     public void setInfo(FeatureInfo info, String displayName, Collection<UpdateElement> toInstall, 
-            Collection<String> missingModules) {
+            Collection<FeatureInfo.ExtraModuleInfo> missingModules) {
         this.featureInfo = info;
         this.featureInstall = toInstall;
         boolean activateNow = toInstall.isEmpty() && missingModules.isEmpty();
@@ -101,12 +101,13 @@ public class ConfigurationPanel extends JPanel implements Runnable {
             downloadButton.setVisible(true);
             SpecificationVersion jdk = new SpecificationVersion(System.getProperty("java.specification.version"));
             String lblDownloadMsg;
-            
+
             boolean required = false;
-            
-            if (info.getExtraModulesRecommendedMinJDK() != null && 
-                jdk.compareTo(new SpecificationVersion(info.getExtraModulesRecommendedMinJDK())) < 0) {
-                required = true;
+
+            for (FeatureInfo.ExtraModuleInfo mi : info.getExtraModules()) {
+                if (mi.recMinJDK != null && jdk.compareTo(mi.recMinJDK) < 0) {
+                    required = true;
+                }
             }
             if (info.getExtraModulesRequiredText() != null && info.getExtraModulesRecommendedText() == null) {
                 required = true;
@@ -122,7 +123,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
             String list = "";
             if (!missingModules.isEmpty()) {
                 StringBuilder sb = new StringBuilder();
-                for (String s : missingModules) {
+                for (FeatureInfo.ExtraModuleInfo s : missingModules) {
                     if (sb.length() > 0) {
                         sb.append(", "); // NOI18N
                     }
@@ -139,7 +140,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
             } else {
                 downloadButton.setEnabled(true);
             }
-            
+
             String lblActivateMsg = NbBundle.getMessage(ConfigurationPanel.class, "LBL_EnableInfo", displayName);
             String btnActivateMsg = NbBundle.getMessage(ConfigurationPanel.class, "LBL_Enable");
             String btnDownloadMsg = NbBundle.getMessage(ConfigurationPanel.class, "LBL_Download");

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
@@ -27,7 +27,7 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -47,7 +47,6 @@ import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.modules.autoupdate.ui.api.PluginManager;
 import org.openide.awt.Mnemonics;
-import org.openide.modules.SpecificationVersion;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor.Task;
@@ -70,7 +69,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
 
     public ConfigurationPanel(String displayName, final Callable<JComponent> callable, FeatureInfo info) {
         this(callable);
-        setInfo(info, displayName, Collections.<UpdateElement>emptyList(), Collections.emptyList());
+        setInfo(info, displayName, Collections.<UpdateElement>emptyList(), Collections.emptyList(), Collections.emptyMap(), false);
     }
     
     public ConfigurationPanel(final Callable<JComponent> callable) {
@@ -83,7 +82,8 @@ public class ConfigurationPanel extends JPanel implements Runnable {
     }
 
     public void setInfo(FeatureInfo info, String displayName, Collection<UpdateElement> toInstall, 
-            Collection<FeatureInfo.ExtraModuleInfo> missingModules) {
+            Collection<FeatureInfo.ExtraModuleInfo> missingModules, 
+            Map<FeatureInfo.ExtraModuleInfo, FeatureInfo> extrasMap, boolean required) {
         this.featureInfo = info;
         this.featureInstall = toInstall;
         boolean activateNow = toInstall.isEmpty() && missingModules.isEmpty();
@@ -99,26 +99,27 @@ public class ConfigurationPanel extends JPanel implements Runnable {
             downloadLabel.setVisible(true);
             activateButton.setVisible(true);
             downloadButton.setVisible(true);
-            SpecificationVersion jdk = new SpecificationVersion(System.getProperty("java.specification.version"));
-            String lblDownloadMsg;
+            StringBuilder sbDownload = new StringBuilder();
 
-            boolean required = false;
-
-            for (FeatureInfo.ExtraModuleInfo mi : info.getExtraModules()) {
-                if (mi.recMinJDK != null && jdk.compareTo(mi.recMinJDK) < 0) {
-                    required = true;
+            // collect descriptions from features contributing installed extras
+            for (FeatureInfo fi : extrasMap.values()) {
+                String s = required ? 
+                        fi.getExtraModulesRequiredText() : 
+                        fi.getExtraModulesRecommendedText();
+                if (s != null) {
+                    if (sbDownload.length() > 0) {
+                        sbDownload.append("\n");
+                    }
+                    sbDownload.append(s);
                 }
             }
-            if (info.getExtraModulesRequiredText() != null && info.getExtraModulesRecommendedText() == null) {
-                required = true;
-            }
             if (required) {
-                lblDownloadMsg = info.getExtraModulesRequiredText();
                 activateButton.setEnabled(false);
             } else {
-                lblDownloadMsg = info.getExtraModulesRecommendedText();
                 activateButton.setEnabled(true);
             }
+            
+            String lblDownloadMsg = sbDownload.toString();
 
             String list = "";
             if (!missingModules.isEmpty()) {
@@ -127,7 +128,7 @@ public class ConfigurationPanel extends JPanel implements Runnable {
                     if (sb.length() > 0) {
                         sb.append(", "); // NOI18N
                     }
-                    sb.append(s);
+                    sb.append(s.displayName());
                 }
                 list = sb.toString();
                 if (required) {

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
@@ -238,6 +238,24 @@ public final class FeatureInfo {
             this.cnb = Pattern.compile(cnbPattern);
             this.recMinJDK = recommended != null ? new SpecificationVersion(recommended) : null;
         }
+        
+        /**
+         * Returns the codename, if the pattern is actually a literal.
+         * Literal pattern should not contain any metacharacters, except '.' and '/'.
+         * @return codename or {@code null}
+         */
+        String explicitCodebase() {
+            String pat = cnb.pattern();
+            for (int a = pat.length() - 1; a >= 0; a--) {
+                char c = pat.charAt(a);
+                if (!(Character.isAlphabetic(c) || Character.isDigit(c))) {
+                    if (c != '.' && c != '/') {
+                        return null;
+                    }
+                }
+            }
+            return pat;
+        }
 
         boolean matches(String cnb) {
             return this.cnb.matcher(cnb).matches();

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
@@ -239,6 +239,10 @@ public final class FeatureInfo {
             this.recMinJDK = recommended != null ? new SpecificationVersion(recommended) : null;
         }
         
+        String displayName() {
+            return cnb.pattern();
+        }
+        
         /**
          * Returns the codename, if the pattern is actually a literal.
          * Literal pattern should not contain any metacharacters, except '.' and '/'.

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
@@ -65,7 +65,7 @@ public final class FindComponentModules extends Task {
     /**
      * Features, whose 'extra' modules were not found.
      */
-    private Map<FeatureInfo, List<String>>   incompleteFeatures = new HashMap<>();
+    private Map<FeatureInfo, List<FeatureInfo.ExtraModuleInfo>>   incompleteFeatures = new HashMap<>();
     
     /**
      * Errors encountered during updating component descriptions
@@ -103,13 +103,13 @@ public final class FindComponentModules extends Task {
         return incompleteFeatures.keySet();
     }
     
-    void markIncompleteFeature(FeatureInfo fi, String cnb) {
+    void markIncompleteFeature(FeatureInfo fi, FeatureInfo.ExtraModuleInfo moduleInfo) {
         incompleteFeatures.computeIfAbsent(fi, (f) -> new ArrayList<>())
-                .add(cnb);
+                .add(moduleInfo);
     }
     
-    public Collection<String> getMissingModules(FeatureInfo info) {
-        return incompleteFeatures.getOrDefault(info, Collections.<String>emptyList());
+    public Collection<FeatureInfo.ExtraModuleInfo> getMissingModules(FeatureInfo info) {
+        return incompleteFeatures.getOrDefault(info, Collections.emptyList());
     }
     
     public Collection<IOException> getUpdateErrors() {
@@ -247,10 +247,10 @@ public final class FindComponentModules extends Task {
         }
         boolean decr = true;
         for (FeatureInfo fi : this.infos) {
-            Set<String> extraModules = fi.getExtraModules();
-            FOUND: for (String cnb : extraModules) {
+            Set<FeatureInfo.ExtraModuleInfo> extraModules = fi.getExtraModules();
+            FOUND: for (FeatureInfo.ExtraModuleInfo moduleInfo : extraModules) {
                 for (UpdateUnit unit : allUnits) {
-                    if (cnb.equals(unit.getCodeName())) {
+                    if (moduleInfo.matches(unit.getCodeName())) {
                         if (unit.getInstalled() != null) {
                             continue FOUND;
                         } else {
@@ -270,7 +270,7 @@ public final class FindComponentModules extends Task {
                     decr = false;
                 }
                 // extra module(s) for the feature weren't found
-                markIncompleteFeature(fi, cnb);
+                markIncompleteFeature(fi, moduleInfo);
             }
         }
         refresh[0] = 0;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
@@ -20,10 +20,12 @@
 package org.netbeans.modules.ide.ergonomics.fod;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,12 +38,14 @@ import java.util.logging.Level;
 import java.util.prefs.Preferences;
 import org.netbeans.api.autoupdate.InstallSupport;
 import org.netbeans.api.autoupdate.OperationContainer;
+import org.netbeans.api.autoupdate.OperationContainer.OperationInfo;
 import org.netbeans.api.autoupdate.OperationSupport;
 import org.netbeans.api.autoupdate.UpdateElement;
 import org.netbeans.api.autoupdate.UpdateManager;
 import org.netbeans.api.autoupdate.UpdateUnit;
 import org.netbeans.api.autoupdate.UpdateUnitProvider;
 import org.netbeans.api.autoupdate.UpdateUnitProviderFactory;
+import org.openide.modules.SpecificationVersion;
 import org.openide.util.Exceptions;
 import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
@@ -65,12 +69,36 @@ public final class FindComponentModules extends Task {
     /**
      * Features, whose 'extra' modules were not found.
      */
-    private Map<FeatureInfo, List<FeatureInfo.ExtraModuleInfo>>   incompleteFeatures = new HashMap<>();
+    private Map<FeatureInfo, Collection<FeatureInfo.ExtraModuleInfo>>   incompleteFeatures = new HashMap<>();
+    
+    /**
+     * Maps individual codebase names to owning feature infos. Built at the start of findComponentModules
+     */
+    private Map<String, FeatureInfo> codebaseOwners = new HashMap<>();
+    
+    /**
+     * Index to search through update units; reset every time an update is attempted.
+     */
+    private Map<String, UpdateUnit> availUnits = null;
     
     /**
      * Errors encountered during updating component descriptions
      */
     private List<IOException> updateErrors = new ArrayList<>();
+    
+    /**
+     * ExtraInfos which need to be downloaded, if they are missing or not.
+     * Map to their owning FeatureInfo for descriptive labels
+     */
+    private Map<FeatureInfo.ExtraModuleInfo, FeatureInfo> extrasToDownload = new HashMap<>();
+    
+    /**
+     * Indicates that the user cannot proceed without a download.
+     * Accumulated during {@link #getMissingModules(org.netbeans.modules.ide.ergonomics.fod.FeatureInfo)}
+     */
+    private boolean downloadRequired;
+    
+    private final SpecificationVersion jdk = new SpecificationVersion(System.getProperty("java.specification.version"));
     
     public FindComponentModules(FeatureInfo info, FeatureInfo... additional) {
         ArrayList<FeatureInfo> l = new ArrayList<FeatureInfo>();
@@ -91,11 +119,11 @@ public final class FindComponentModules extends Task {
 
     public Collection<UpdateElement> getModulesForInstall () {
         findingTask.waitFinished();
-        return forInstall;
+        return forInstall == null ? Collections.emptyList() : forInstall;
     }
     public Collection<UpdateElement> getModulesForEnable () {
         findingTask.waitFinished();
-        return forEnable;
+        return forEnable == null ? Collections.emptyList() : forEnable;
     }
     
     public Collection<FeatureInfo> getIncompleteFeatures() {
@@ -104,7 +132,7 @@ public final class FindComponentModules extends Task {
     }
     
     void markIncompleteFeature(FeatureInfo fi, FeatureInfo.ExtraModuleInfo moduleInfo) {
-        incompleteFeatures.computeIfAbsent(fi, (f) -> new ArrayList<>())
+        incompleteFeatures.computeIfAbsent(fi, (f) -> new HashSet<>())
                 .add(moduleInfo);
     }
     
@@ -207,11 +235,33 @@ public final class FindComponentModules extends Task {
             findComponentModules ();
         }
     };
-
+    
+    private void buildCodebaseIndex() {
+        for (FeatureInfo fi : FeatureManager.features()) {
+            for (String cnb : fi.getCodeNames()) {
+                codebaseOwners.put(cnb, fi);
+            }
+        }
+    }
+    
+    private void buildUpdateUnitIndex() {
+        if (availUnits != null) {
+            return;
+        }
+        Collection<UpdateUnit> units = UpdateManager.getDefault ().getUpdateUnits (UpdateManager.TYPE.MODULE);
+        Map<String, UpdateUnit> uumap = new HashMap<>();
+        for (UpdateUnit u : units) {
+            uumap.put(u.getCodeName(), u);
+        }
+        availUnits = uumap;
+    }
+    
     private void findComponentModules () {
         long start = System.currentTimeMillis();
         Collection<UpdateUnit> units = null;
         Collection<UpdateElement> elementsForInstall = null;
+        buildCodebaseIndex();
+        
         for (int[] refresh = { 2 }; refresh[0] > 0; ) {
             if (units != null) {
                 List<UpdateUnitProvider> providers = UpdateUnitProviderFactory.getDefault().getUpdateUnitProviders(true);
@@ -223,8 +273,9 @@ public final class FindComponentModules extends Task {
                         Exceptions.attachSeverity(ex, Level.INFO).printStackTrace();
                     }
                 }
-                
+                availUnits = null;
             }
+            buildUpdateUnitIndex();
             units = UpdateManager.getDefault ().getUpdateUnits (UpdateManager.TYPE.MODULE);
             // install missing modules
             elementsForInstall = getMissingModules(units, refresh);
@@ -234,6 +285,27 @@ public final class FindComponentModules extends Task {
         // install disabled modules
         Collection<UpdateElement> elementsForEnable = getDisabledModules (units);
         forEnable = getAllForEnable (elementsForEnable, units);
+    }
+    
+    public Map<FeatureInfo.ExtraModuleInfo, FeatureInfo>  getExtrasToDownload() {
+        return extrasToDownload;
+    }
+    
+    private void registerExtraDownloadable(FeatureInfo fi, FeatureInfo.ExtraModuleInfo fmi) {
+        boolean required = false;
+        if (fmi.recMinJDK != null && jdk.compareTo(fmi.recMinJDK) < 0) {
+            required = true;
+        }
+        if (fi.getExtraModulesRequiredText() != null && fi.getExtraModulesRecommendedText() == null) {
+            required = true;
+        }
+        downloadRequired |= required;
+        extrasToDownload.put(fmi, fi);
+    }
+    
+    public boolean isDownloadRequired() {
+        findingTask.waitFinished();
+        return downloadRequired;
     }
     
     private Collection<UpdateElement> getMissingModules(Collection<UpdateUnit> allUnits, int[] refresh) {
@@ -246,33 +318,104 @@ public final class FindComponentModules extends Task {
             }
         }
         boolean decr = true;
-        for (FeatureInfo fi : this.infos) {
-            Set<FeatureInfo.ExtraModuleInfo> extraModules = fi.getExtraModules();
-            FOUND: for (FeatureInfo.ExtraModuleInfo moduleInfo : extraModules) {
-                for (UpdateUnit unit : allUnits) {
-                    if (moduleInfo.matches(unit.getCodeName())) {
-                        if (unit.getInstalled() != null) {
-                            continue FOUND;
-                        } else {
-                            res.add(unit.getAvailableUpdates().get(0));
-                            continue FOUND;
+        Set<String> codebasesSeen = new HashSet<>();
+        OperationContainer<OperationSupport> ocForEnable = OperationContainer.createForEnable();
+        OperationContainer<InstallSupport> ocForInstall = OperationContainer.createForInstall();
+        boolean firstPass = true;
+
+        for (FeatureInfo startFi : infos) {
+            Deque<FeatureInfo> closure = new ArrayDeque<>();
+            closure.add(startFi);
+            codebasesSeen.add(startFi.getFeatureCodeNameBase());
+            
+            while (!closure.isEmpty()) {
+                FeatureInfo fi = closure.poll();
+                Set<FeatureInfo.ExtraModuleInfo> extraModules = fi.getExtraModules();
+                FOUND:
+                for (FeatureInfo.ExtraModuleInfo moduleInfo : extraModules) {
+                    boolean found = false;
+                    for (UpdateUnit unit : allUnits) {
+                        if (moduleInfo.matches(unit.getCodeName())) {
+                            if (unit.getInstalled() != null) {
+                                // PENDING: if the cnb spec is a regexp that matches MULTIPLE modules,
+                                // then the wrong one (i.e. with broken deps) can be matched.
+                                continue FOUND;
+                            } else if (!unit.getAvailableUpdates().isEmpty()) {
+                                registerExtraDownloadable(fi, moduleInfo);
+                                res.add(unit.getAvailableUpdates().get(0));
+                                found = true;
+                            }
                         }
                     }
-                }
-                
-                // not found
-                if (decr) {
-                    if (--refresh[0] > 0) {
-                        // try to refresh
-                        return res;
+                    if (found) {
+                        continue FOUND;
                     }
-                    // decrement just once
-                    decr = false;
+
+                    // not found
+                    if (decr) {
+                        if (--refresh[0] > 0) {
+                            // try to refresh
+                            return res;
+                        }
+                        // decrement just once
+                        decr = false;
+                    }
+                    // extra module(s) for the feature weren't found
+                    markIncompleteFeature(fi, moduleInfo);
+                    // mark the originating feature as incomplete, too
+                    markIncompleteFeature(startFi, moduleInfo);
+                    // and compute the overall 'required' status
+                    registerExtraDownloadable(fi, moduleInfo);
                 }
-                // extra module(s) for the feature weren't found
-                markIncompleteFeature(fi, moduleInfo);
+                if (firstPass) {
+                    for (String cb : fi.getCodeNames()) {
+                        UpdateUnit cbuu = availUnits.get(cb);
+                        if (cbuu == null) {
+                            // sorry
+                            continue;
+                        }
+                        UpdateElement cbel = cbuu.getInstalled();
+                        OperationInfo thisInfo;
+
+                        if (cbel != null && ocForEnable.canBeAdded(cbuu, cbel)) {
+                            thisInfo = ocForEnable.add(cbuu, cbel);
+                        } else {
+                            if (cbuu.getAvailableUpdates().isEmpty()) {
+                                if (decr) {
+                                    if (--refresh[0] > 0) {
+                                        // try to refresh
+                                        return res;
+                                    }
+                                    // decrement just once
+                                    decr = false;
+                                }
+                                continue;
+                            }
+                            UpdateElement ie = cbuu.getAvailableUpdates().get(0);
+                            // not installed
+                            if (!ocForInstall.canBeAdded(cbuu, ie)) {
+                                continue;
+                            }
+                            thisInfo = ocForInstall.add(cbuu, ie);
+
+                        }
+                        Collection<UpdateElement> deps = thisInfo.getRequiredElements();
+                        for (UpdateElement d : deps) {
+                            UpdateUnit du = d.getUpdateUnit();
+                            if (du.getInstalled() == null) {
+                                res.add(d);
+                            }
+                            FeatureInfo depF = this.codebaseOwners.get(du.getCodeName());
+                            if (depF != null && codebasesSeen.add(depF.getFeatureCodeNameBase())) {
+                                closure.add(depF);
+                            }
+                        }
+                    }
+                    firstPass = false;
+                }
             }
         }
+
         refresh[0] = 0;
         return res;
     }
@@ -288,6 +431,8 @@ public final class FindComponentModules extends Task {
                 }
                 Set<UpdateElement> reqs = info.getRequiredElements ();
                 ocForInstall.add (reqs);
+                // PENDING: broken dependencies may mean the feature contains a platform/java-specific
+                // module, but could be used even without that one.
                 Set<String> breaks = info.getBrokenDependencies ();
                 if (breaks.isEmpty ()) {
                     all.add (el);

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
@@ -163,11 +163,12 @@ public class DescriptionStep implements WizardDescriptor.Panel<WizardDescriptor>
             }
             final  Collection<UpdateElement> toInstall = f.getModulesForInstall();
             final  Collection<UpdateElement> elems = f.getModulesForEnable ();
-            if ((elems != null && !elems.isEmpty ()) || f.getIncompleteFeatures().contains(info) || !f.getUpdateErrors().isEmpty()) {
+            if (!elems.isEmpty ()|| f.getIncompleteFeatures().contains(info) || !f.getUpdateErrors().isEmpty()) {
                 Collection<UpdateElement> visible = f.getVisibleUpdateElements (elems);
                 final String name = ModulesInstaller.presentUpdateElements (visible);
                 configPanel.setUpdateErrors(f.getUpdateErrors());
-                configPanel.setInfo(info, name, toInstall, f.getMissingModules(info));
+                configPanel.setInfo(info, name, toInstall, f.getMissingModules(info), 
+                        f.getExtrasToDownload(), f.isDownloadRequired());
                 panel.replaceComponents(configPanel);
                 forEnable = elems;
                 fireChange ();

--- a/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/DynamicVerifyTest.java
+++ b/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/DynamicVerifyTest.java
@@ -29,6 +29,7 @@ import org.netbeans.modules.ide.ergonomics.fod.FeatureManager;
 import org.netbeans.modules.ide.ergonomics.fod.FoDUpdateUnitProvider;
 import org.netbeans.spi.autoupdate.UpdateItem;
 import org.netbeans.spi.project.ProjectFactory;
+import org.openide.modules.ModuleInfo;
 import org.openide.util.Lookup;
 
 /**
@@ -97,9 +98,18 @@ public class DynamicVerifyTest extends NbTestCase {
     }
 
     public void testNoUserDefinedFeaturesInStandardBuild() throws Exception {
-        FoDUpdateUnitProvider instance = new FoDUpdateUnitProvider();
+        // remove the javascript parser from the checklist: it has to be user-installed
+        // through AU when HTML5 is enabled
+        FoDUpdateUnitProvider instance = new FoDUpdateUnitProvider() {
+            @Override
+            protected boolean acceptsModule(ModuleInfo mi) {
+                if (!super.acceptsModule(mi)) {
+                    return false;
+                }
+                return !"org.netbeans.libs.oracle.jsparser".equals(mi.getCodeNameBase());
+            }
+        };
         Map<String, UpdateItem> items = instance.getUpdateItems();
-
         assertNull("No user installed modules should be in standard build. If this happens,\n" +
                 "like in case of http://openide.netbeans.org/issues/show_bug.cgi?id=174052\n" +
                 "then you probably added new module and did not categorize it properly,\n" +

--- a/platform/autoupdate.services/apichanges.xml
+++ b/platform/autoupdate.services/apichanges.xml
@@ -33,6 +33,20 @@
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="missing-elements">
+            <api name="general"/>
+            <summary>Report parts of a feature which is not installed yet</summary>
+            <version major="1" minor="57"/>
+            <date day="30" month="11" year="2018"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" binary="compatible" deletion="no" deprecation="no" semantic="compatible" source="compatible"/>
+            <description>
+                A distributed feature may list a module, which is only available on some update center, in NB IDE case because of
+                licensing issues. This token must be reported so the as part of the UpdateElement and Operation so the caller may
+                initiate the download operation.
+            </description>
+            <class package="org.netbeans.api.autoupdate" name="OperationContainer"/>
+        </change>
         <change id="visible-ancestor">
             <api name="general"/>
             <summary>Find a visible ancestor of UpdateUnit</summary>

--- a/platform/autoupdate.services/manifest.mf
+++ b/platform/autoupdate.services/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.autoupdate.services
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/autoupdate/services/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.55.1
+OpenIDE-Module-Specification-Version: 1.57.1
 OpenIDE-Module-Layer: org/netbeans/modules/autoupdate/services/resources/layer.xml
 AutoUpdate-Show-In-Client: false
 AutoUpdate-Essential-Module: true

--- a/platform/autoupdate.services/nbproject/project.properties
+++ b/platform/autoupdate.services/nbproject/project.properties
@@ -17,7 +17,7 @@
 extra.module.files=modules/ext/updater.jar
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 test.unit.cp.extra=${basedir}/modules/ext/updater.jar

--- a/platform/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
+++ b/platform/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
@@ -376,6 +376,15 @@ public final class OperationContainer<Support> {
          */
         public Set<String> getBrokenDependencies(){return impl.getBrokenDependencies();}
         
+        /**
+         * Reports parts missing from the installation. Will return codenames of required
+         * unknown modules (e.g. from catalogs not fetched yet). Note differences to {@link #getBrokenDependencies()},
+         * which report also broken requirements for packages or java version for specialized / optional modules.
+         * @return set of missing parts (modules). If nothing is missing, returns empty set.
+         * @since 1.57
+         */
+        public Set<String> getMissingParts() { return impl.getMissingParts(); }
+        
         @Override
         public String toString () {
             return "OperationInfo: " + impl.getUpdateElement ().toString (); // NOI18N

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateUnitImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateUnitImpl.java
@@ -165,6 +165,7 @@ public class FeatureUpdateUnitImpl extends UpdateUnitImpl {
                     installedFeatureElement.getSource (),
                     installedModules,
                     installedFeatures,
+                    ((FeatureUpdateElementImpl) Trampoline.API.impl (installedFeatureElement)).getMissingElements(),
                     featureImpl.getType ());
             installedElement = Trampoline.API.createUpdateElement (featureElementImpl);
             featureElementImpl.setUpdateUnit (installedFeatureElement.getUpdateUnit ());
@@ -186,6 +187,7 @@ public class FeatureUpdateUnitImpl extends UpdateUnitImpl {
                         featureElements.get (0).getSource (),
                         availableModules,
                         availableFeatures,
+                        null,
                         featureImpl.getType ());
                 updateElement = Trampoline.API.createUpdateElement (featureElementImpl);
                 featureElementImpl.setUpdateUnit (featureElements.get (0).getUpdateUnit ());

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/InstallSupportImpl.java
@@ -1222,6 +1222,8 @@ public class InstallSupportImpl {
                     break;
                 }
             }
+            // if something was (un)installed, we need to recompute provides-requires info
+            UpdateManagerImpl.getInstance().flushComputedInfo();
         }
 
     }

--- a/platform/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateItem.java
+++ b/platform/autoupdate.services/src/org/netbeans/spi/autoupdate/UpdateItem.java
@@ -142,7 +142,9 @@ public final class UpdateItem {
     /** Creates <code>UpdateItem</code> which represents <code>Feature</code>, it's means group
      * of NetBeans Modules. This <code>Feature</code> is handled in UI as atomic item.
      * UpdateItem is identify by <code>codeName</code> and <code>specificationVersion<code>.
-     * 
+     * <p/>
+     * If some of the tokens in {@code dependencies} is not known, it will be reported
+     * as a missing dependency.
      * 
      * @param codeName code name of feature
      * @param specificationVersion specification version of feature
@@ -151,6 +153,7 @@ public final class UpdateItem {
      * @param description description
      * @param category name of category
      * @return UpdateItem
+     * @since 1.57 specified handling of unknown tokens
      */
     public static UpdateItem createFeature (
                                     String codeName,

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshItemsTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshItemsTest.java
@@ -46,7 +46,7 @@ public class RefreshItemsTest extends DefaultTestCase {
         populateCatalog(TestUtils.class.getResourceAsStream("data/updates-subset.xml"));
         UpdateUnitProviderFactory.getDefault ().refreshProviders(null, true);
         assertEquals(UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).toString(), 
-                updateUnitsCount - 2, UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).size());
+                updateUnitsCount - 3, UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).size());
         
         UpdateUnit toTestAgain = UpdateManagerImpl.getInstance ().getUpdateUnit ("org.yourorghere.refresh_providers_test");
         assertNotNull ("Unit for org.yourorghere.refresh_providers_test found.", toTestAgain);

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshProvidersTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/RefreshProvidersTest.java
@@ -39,7 +39,7 @@ public class RefreshProvidersTest extends DefaultTestCase {
         populateCatalog(TestUtils.class.getResourceAsStream("data/updates-subset.xml"));
         UpdateUnitProviderFactory.getDefault ().refreshProviders(null, true);
         assertEquals(UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).toString(), 
-                updateUnitsCount - 2, UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).size());
+                updateUnitsCount - 3, UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE).size());
     }
 
 }

--- a/platform/autoupdate.ui/nbproject/project.properties
+++ b/platform/autoupdate.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 test.config.xmlinst.includes=\
   org/netbeans/test/autoupdate/xml/xml_0001.class

--- a/platform/autoupdate.ui/nbproject/project.xml
+++ b/platform/autoupdate.ui/nbproject/project.xml
@@ -56,7 +56,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.39</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/PluginManagerUI.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/PluginManagerUI.java
@@ -62,7 +62,7 @@ public class PluginManagerUI extends javax.swing.JPanel  {
     private final Object initLock = new Object();
     private Object helpInstance = null;
     
-    private static RequestProcessor.Task runningTask;
+    private static volatile RequestProcessor.Task runningTask;
     private static Collection<Runnable> runOnCancel = null;
     private boolean wasSettings = false;
     public static final int INDEX_OF_UPDATES_TAB = 0;

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.form
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.form
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Utilities.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/Utilities.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.text.Collator;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -38,6 +39,7 @@ import org.netbeans.modules.autoupdate.ui.actions.Installer;
 import org.netbeans.modules.autoupdate.ui.actions.ShowNotifications;
 import org.openide.awt.HtmlBrowser;
 import org.openide.awt.Mnemonics;
+import org.openide.modules.Places;
 import org.openide.util.*;
 
 /**
@@ -770,6 +772,27 @@ public class Utilities {
     
     private static Preferences getPreferences () {
         return NbPreferences.forModule (Utilities.class);
+    }
+    
+    /**
+     * Hacky way how to determine if the AU catalog providers have built their
+     * caches. Checks just for the default provider cache filenames. Used for decision
+     * that user should perform check for updates to get plugin portal contents.
+     * 
+     * @return true, if caches are present.
+     */
+    public static boolean hasBuiltDefaultCaches() {
+        File cacheDir = Places.getCacheSubdirectory("catalogcache");
+        if (!cacheDir.exists()) {
+            return false;
+        }
+        try {
+            return Files.list(cacheDir.toPath()).anyMatch((p) -> 
+                    p.getName(p.getNameCount() - 1).toString().endsWith("-update-provider")
+            );
+        } catch (IOException ex) {
+            return false;
+        }
     }
 
 }

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/Bundle.properties
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/Bundle.properties
@@ -163,3 +163,5 @@ OperationDescriptionStep_AffectedPlugin=&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{0}<
 InstallStep_DownloadProblem=There were some problems while storing {0}.\nCause: {1}
 InstallStep_DownloadProblem_SomePlugins=selected plugins
 LicenseApprovalPanel.lbPlugins.text=Plugins:
+OperationDescriptionStep_NoteCachesNotBuilt=<br><hr><br>\
+    <b>Note:</b> Missing modules may be published on Update Centers. Please run "<b>Check for Newest</b>" from the "<b>Available Plugins</b>" tab.

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardModel.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallUnitWizardModel.java
@@ -34,7 +34,7 @@ import org.openide.util.Exceptions;
  *
  * @author Jiri Rechtacek
  */
-public final class InstallUnitWizardModel extends OperationWizardModel {
+public class InstallUnitWizardModel extends OperationWizardModel {
     private Installer installer = null;
     private OperationType doOperation;
     private static Set<String> approvedLicences = new HashSet<String> ();
@@ -66,6 +66,11 @@ public final class InstallUnitWizardModel extends OperationWizardModel {
         assert c.getSupport() != null || c.listAll().isEmpty() : "Non empty container[list: " + c.listAll() +
                 ", invalid: " + c.listInvalid() + "]: but support is " + c.getSupport();
         return c;
+    }
+
+    @Override
+    OperationContainer<InstallSupport> getInstallContainer() {
+        return getBaseContainer();
     }
     
     private OperationContainer<InstallSupport> getBaseContainerImpl() {
@@ -179,5 +184,4 @@ public final class InstallUnitWizardModel extends OperationWizardModel {
     public void setPluginManager (PluginManagerUI manager) {
         this.manager = manager;
     }
-    
 }

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallableIteratorBase.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/InstallableIteratorBase.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.autoupdate.ui.wizards;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import javax.swing.event.ChangeListener;
+import org.openide.WizardDescriptor;
+
+/**
+ * Common base for AU wizard iterators, does basic panel handling.
+ * 
+ * @author sdedic
+ */
+abstract class InstallableIteratorBase  implements WizardDescriptor.Iterator<WizardDescriptor> {
+    protected final List<WizardDescriptor.Panel<WizardDescriptor>> panels = new ArrayList<WizardDescriptor.Panel<WizardDescriptor>> ();
+    protected final InstallUnitWizardModel installModel;
+    
+    protected int index;
+    private WizardDescriptor.Panel<WizardDescriptor> licenseApprovalStep = null;
+    private WizardDescriptor.Panel<WizardDescriptor> customHandleStep = null;
+    private WizardDescriptor.Panel<WizardDescriptor> installStep = null;
+    private boolean isCompact = false;
+    private boolean clearLazyUnits = false;
+    private final boolean allowRunInBackground;
+    private final boolean runInBackground;
+
+    public InstallableIteratorBase (InstallUnitWizardModel model) {
+        this (model, false);
+    }
+    
+    public InstallableIteratorBase (InstallUnitWizardModel model, boolean clearLazyUnits) {
+        this(model, clearLazyUnits, true, true);
+    }
+    
+    public InstallableIteratorBase (InstallUnitWizardModel model, boolean clearLazyUnits, boolean allowRunInBackground) {
+        this(model, clearLazyUnits, allowRunInBackground, false);
+    }
+    
+    public InstallableIteratorBase (InstallUnitWizardModel model, boolean clearLazyUnits, boolean allowRunInBackground, boolean runInBackground) {
+        this.installModel = model;
+        this.clearLazyUnits = clearLazyUnits;
+        this.allowRunInBackground = allowRunInBackground;
+        this.runInBackground = runInBackground;
+        index = 0;
+    }
+
+    public InstallUnitWizardModel getModel () {
+        assert installModel != null;
+        return installModel;
+    }
+    
+    @Override
+    public WizardDescriptor.Panel<WizardDescriptor> current () {
+        assert panels != null;
+        return panels.get (index);
+    }
+    
+    @Override
+    public boolean hasNext () {
+        compactPanels ();
+        return index < panels.size () - 1;
+    }
+    
+    @Override
+    public void nextPanel () {
+        compactPanels ();
+        if (!hasNext ()) {
+            throw new NoSuchElementException ();
+        }
+        index++;
+    }
+    
+    @Override
+    public void previousPanel () {
+        compactPanels ();
+        if (!hasPrevious()) {
+            throw new NoSuchElementException ();
+        }
+        index--;
+    }
+    
+    @Override
+    public boolean hasPrevious () {
+        compactPanels ();
+        return index > 0;
+    }
+
+    // If nothing unusual changes in the middle of the wizard, simply:
+    @Override
+    public void addChangeListener (ChangeListener l) {}
+    @Override
+    public void removeChangeListener (ChangeListener l) {}
+    
+    /**
+     * Inserts install-related panels at a specific index
+     * @param index 
+     */
+    protected void insertPanels(int index) {
+        licenseApprovalStep = new LicenseApprovalStep (installModel);
+        panels.add (index++, licenseApprovalStep);
+        customHandleStep = new CustomHandleStep (installModel);
+        panels.add (index++, customHandleStep);
+        installStep = new InstallStep (installModel, clearLazyUnits, allowRunInBackground, runInBackground);
+        panels.add (index++, installStep);
+    }
+    
+    /**
+     * Removes previously registered install panels
+     */
+    protected void removeInstallPanels() {
+        panels.remove(licenseApprovalStep);
+        panels.remove(installStep);
+        panels.remove(customHandleStep);
+    }
+    
+    protected void compactPanels () {
+        if (isCompact) {
+            return ;
+        }
+        boolean allLicensesTouched = getModel().allLicensesTouched();
+        if (allLicensesTouched && getModel ().allLicensesApproved ()) {            
+            panels.remove (licenseApprovalStep);
+        }
+        if (! getModel ().hasCustomComponents ()) {
+            panels.remove (customHandleStep);
+        }
+        if (! getModel ().hasStandardComponents ()) {
+            panels.remove (installStep);
+        }
+        isCompact = allLicensesTouched;
+    }
+}

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalStep.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/LicenseApprovalStep.java
@@ -43,7 +43,7 @@ import org.openide.util.RequestProcessor;
  *
  * @author Jiri Rechtacek
  */
-public class LicenseApprovalStep implements WizardDescriptor.FinishablePanel<WizardDescriptor> {
+class LicenseApprovalStep implements WizardDescriptor.FinishablePanel<WizardDescriptor> {
     private LicenseApprovalPanel panel;
     private PanelBodyContainer component;
     private InstallUnitWizardModel model = null;
@@ -70,7 +70,8 @@ public class LicenseApprovalStep implements WizardDescriptor.FinishablePanel<Wiz
             component = new PanelBodyContainer (getBundle (HEAD), getBundle (CONTENT), tmp);
             component.setPreferredSize (OperationWizardModel.PREFFERED_DIMENSION);
             if (wd != null) {
-                model.modifyOptionsForDoOperation (wd);
+                // have "Activate" text during 'enable' phase.
+                model.modifyOptionsForDoOperation (wd, 2);
             }
             component.setWaitingState (true);
             appendLoadingLazy ();
@@ -111,7 +112,8 @@ public class LicenseApprovalStep implements WizardDescriptor.FinishablePanel<Wiz
     public void readSettings (WizardDescriptor wd) {
         this.wd = wd;
         if (panel != null) {
-            model.modifyOptionsForDoOperation (wd);
+            // have "Activate" text during 'enable' phase.
+            model.modifyOptionsForDoOperation (wd, 2);
         }
     }
 

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardIterator.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardIterator.java
@@ -19,9 +19,7 @@
 
 package org.netbeans.modules.autoupdate.ui.wizards;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.openide.WizardDescriptor;
 import org.openide.util.NbBundle;
@@ -30,65 +28,87 @@ import org.openide.util.NbBundle;
  *
  * @author Jiri Rechtacek
  */
-public final class UninstallUnitWizardIterator implements WizardDescriptor.Iterator<WizardDescriptor> {
+public final class UninstallUnitWizardIterator extends InstallableIteratorBase implements ChangeListener {
     
-    private int index;
-    private List<WizardDescriptor.Panel<WizardDescriptor>> panels = new ArrayList<WizardDescriptor.Panel<WizardDescriptor>> ();
     private UninstallUnitWizardModel uninstallModel;
+    private OperationDescriptionStep descStep;
+    private boolean installAdded;
     
     public UninstallUnitWizardIterator (UninstallUnitWizardModel model) {
+        super(model.createInstallModel(), false, false, false);
         uninstallModel = model;
         createPanels ();
         index = 0;
     }
     
-    public UninstallUnitWizardModel getModel () {
-        assert uninstallModel != null;
-        return uninstallModel;
-    }
-    
     private void createPanels () {
         assert panels != null && panels.isEmpty() : "Panels are still empty";
-        panels.add (new OperationDescriptionStep (uninstallModel));
+        descStep = new OperationDescriptionStep (uninstallModel);
+        panels.add (descStep);
         if (uninstallModel.hasCustomComponents ()) {
             panels.add (new CustomHandleStep (uninstallModel));
         }
         panels.add (new UninstallStep (uninstallModel));
+        // will react on the change to the final presentation
+        descStep.addChangeListener(this);
     }
     
     public WizardDescriptor.Panel<WizardDescriptor> current () {
         assert panels != null;
         return panels.get (index);
     }
+
+    @Override
+    public void nextPanel() {
+        if (current() instanceof InstallStep) {
+            index = 0;
+            // must reset the data in descStep
+            descStep.reset();
+            removeInstallPanels();
+        } else {
+            super.nextPanel();
+        }
+    }
     
     public String name () {
         return NbBundle.getMessage (UninstallUnitWizard.class, "UninstallUnitWizard_Title");
     }
     
-    public boolean hasNext () {
-        return index < panels.size () - 1;
-    }
-    
     public boolean hasPrevious () {
-        return index > 0 && ! (current () instanceof UninstallStep);
-    }
-    
-    public void nextPanel () {
-        if (!hasNext ()) {
-            throw new NoSuchElementException ();
+        // disable Back on 'confirmation' screen
+        if (current() instanceof UninstallStep) {
+            return false;
         }
-        index++;
-    }
-    
-    public void previousPanel () {
-        if (!hasPrevious ()) {
-            throw new NoSuchElementException ();
+        // disable Back during installation, no turning back to licenses
+        if (current() instanceof InstallStep) {
+            return false;
         }
-        index--;
+        return super.hasPrevious();
     }
     
     // If nothing unusual changes in the middle of the wizard, simply:
     public void addChangeListener (ChangeListener l) {}
     public void removeChangeListener (ChangeListener l) {}
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        if (e.getSource() != descStep) {
+            return;
+        }
+        // if the model has initialized and says we have components to install,
+        // add the intermediate install panels to the wizard
+        if (uninstallModel.hasComponentsToInstall() && !installAdded) {
+            installAdded = true;
+            insertPanels(1);
+        }
+    }
+    
+    protected void compactPanels() {
+        // block compacting on further panels since it may damage the 
+        // current() panel after installation is complete
+        if (index == 0) {
+            super.compactPanels();
+        }
+    }
     
 }

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1668,12 +1668,24 @@ public final class ModuleManager extends Modules {
         }
     }
     
+    /**
+     * Determines if enabling compat modules is disruptive. Compat modules are often 
+     * fragment modules augmenting regular ones. If the host module is already enabled / loaded,
+     * the compat module cannot back-patch already existing classes, and IDE restart is needed.
+     * 
+     * @param modules initial set of modules
+     * @return true, if the operation requires a restart
+     * @throws IllegalArgumentException 
+     */
     public boolean hasToEnableCompatModules(Set<Module> modules) throws IllegalArgumentException {
         List<Module> toEnable = simulateEnable(modules);
         for (Module m : toEnable) {            
             String fragmentHostCodeName = m.getFragmentHostCodeName();
             if (fragmentHostCodeName != null && !fragmentHostCodeName.isEmpty()) {
-                return true;
+                Module fragHost = get(fragmentHostCodeName);
+                if (fragHost != null && fragHost.isEnabled()) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
This is a backport of [PR-1044](https://github.com/apache/incubator-netbeans/pull/1044) for NetBeans rel. 10.

In addition to commits in [PR-1044](https://github.com/apache/incubator-netbeans/pull/1044) I **have also backported part of** [commit 4b8d8a788dc](https://github.com/apache/incubator-netbeans/commit/4b8d8a788dce05c60444c35c895c3be5bc373537), so the code in `ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod` is as close as possible to master without affecting other functionality: it seemed as less error-prone than converting `ExtraModuleInfo`s back to `Strings` for the release branch. 

I have **not cherry-picked** the `MavenRepoURLHandler` or `javafx` addition to extramodules in `java` feature in commit 4b8d8a788dc
