### PR TITLE
[NETBEANS-731] Making the test class a @Test

### DIFF
--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBarManualTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBarManualTest.java
@@ -32,6 +32,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+import org.junit.Test;
 
 /**
  * A standalone Swing app that can be used to manually test {@link AutoHidingMenuBar} without
@@ -41,7 +42,7 @@ public final class AutoHidingMenuBarManualTest {
     private final JFrame frame = new JFrame();
     private final JMenuBar mainMenuBar = new JMenuBar();
 
-    public static void main(String args[]) {
+    public static void main(String... args) {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -59,6 +60,11 @@ public final class AutoHidingMenuBarManualTest {
 
     public AutoHidingMenuBarManualTest() {
         initComponents();
+    }
+
+    @Test
+    public void runMain() {
+        main();
     }
 
     public void setVisible(boolean visible) {


### PR DESCRIPTION
The [AutoHidingMenuBarManualTest](https://builds.apache.org/job/incubator-netbeans-linux/946/testReport/org.netbeans.core.windows.view.ui/AutoHidingMenuBarManualTest/initializationError/) test is failing for the past 334 builds (since build 613) with following error:
```
Error Message

No runnable methods

Stacktrace

java.lang.Exception: No runnable methods
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
```
probably related to @eirikbakke's [NETBEANS-731](https://issues.apache.org/jira/browse/NETBEANS-731).
