### PR TITLE
[NETBEANS-168] Simple least intrustive patch prevent IDE to burn CPU on broken symlinks.

### DIFF
--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -296,7 +297,7 @@ public final class FileObjectFactory {
                 } else {
                     //!!!!!!!!!!!!!!!!! inconsistence
                     exist = touchExists(file, realExists);
-                    if (!exist) {
+                    if (!exist  && !Files.isSymbolicLink(file.toPath())) {
                         refreshFromGetter(parent,asyncFire);
                     }
                 }

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjSymlinkTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjSymlinkTest.java
@@ -174,6 +174,45 @@ public class FileObjSymlinkTest extends NbTestCase {
         assertTrue(linkFO.readSymbolicLinkPath().endsWith("data.dat"));
     }
 
+    public void testBrokenSymbolicLink1() throws IOException {
+        if (!checkSymlinksSupported()) {
+            return;
+        }
+        File dir = getWorkDir();
+        File data = new File(dir, "data.dat");
+        File link = new File(dir, "link.lnk");
+        Files.createSymbolicLink(link.toPath(), data.toPath());
+        FileObject linkFO = FileUtil.toFileObject(link);
+        assertNull(linkFO);
+    }
+
+    public void testBrokenSymbolicLink2() throws IOException {
+        if (!checkSymlinksSupported()) {
+            return;
+        }
+        File dir = getWorkDir();
+        File data = new File(dir, "data.dat");
+        File link = new File(dir, "link.lnk");
+        Files.createSymbolicLink(link.toPath(), data.toPath());
+        FileObject dirFO = FileUtil.toFileObject(dir);
+        FileObject[] children = dirFO.getChildren();
+        assertEquals(children.length, 0);
+    }
+
+    public void testBrokenSymbolicLink3() throws IOException {
+        if (!checkSymlinksSupported()) {
+            return;
+        }
+        File dir = getWorkDir();
+        File data = new File(dir, "data.dat");
+        File link = new File(dir, "link.lnk");
+        Files.createSymbolicLink(link.toPath(), data.toPath());
+        FileObject dirFO = FileUtil.toFileObject(dir);
+        dirFO.getChildren(); //Cache children
+        FileObject linkFO = FileUtil.toFileObject(link);
+        assertNull(linkFO);
+    }
+
     /**
      * Test getCanonicalFileObject method.
      *


### PR DESCRIPTION
However, this may be not the right solution to solve the burning CPU on broken symlinks, I think there is no harm to include this one till the FS masters come up with the right solution.

I've opened https://issues.apache.org/jira/browse/NETBEANS-1845 for tracking that.