### PR TITLE
Making CreateLicenseSummary logging less aggressive

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/CreateLicenseSummary.java
@@ -211,7 +211,7 @@ public class CreateLicenseSummary extends Task {
         } catch (IOException x) {
             throw new BuildException(x, getLocation());
         }
-        log(license + ": written");
+        log(license + ": written", Project.MSG_VERBOSE);
         JUnitReportWriter.writeReport(this, null, reportFile, pseudoTests);
     }
     


### PR DESCRIPTION
The current logging of `CreateLicenseSummary` task is too verbose. It steals focus during build with `F11` in the IDE. The output window output stops at 
```
init:
/incubator-netbeans/platform/libs.felix/build/classes/META-INF/LICENSE: written
All tests passed
```
message and doesn't scroll down. That is annoying as to see `BUILD SUCCESSFUL` or first real error one has to scroll down.

I guess we don't need to see the message at all, right @matthiasblaesing?