### PR TITLE
[NETBEANS-731] Rename AutoHidingMenuBarManualTest to fix test failure

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBar.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBar.java
@@ -44,6 +44,8 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.openide.util.Utilities;
 
+/* Note to developers: To manually test the behavior of this class without running the entire IDE,
+run AutoHidingMenuBarManualTestApp.java in the test sources. */
 /**
  * Container for logic that allows a {@link JFrame}'s {@link JMenuBar} to be hidden by default in
  * full screen mode, but shown again if the user moves the mouse to the top of the screen or invokes

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBarManualTestApp.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/view/ui/AutoHidingMenuBarManualTestApp.java
@@ -37,7 +37,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * A standalone Swing app that can be used to manually test {@link AutoHidingMenuBar} without
  * launching the full IDE. Tested on Windows 10. Not applicable to MacOS.
  */
-public final class AutoHidingMenuBarManualTest {
+public final class AutoHidingMenuBarManualTestApp {
     private final JFrame frame = new JFrame();
     private final JMenuBar mainMenuBar = new JMenuBar();
 
@@ -52,12 +52,12 @@ public final class AutoHidingMenuBarManualTest {
                 {
                     e.printStackTrace();
                 }
-                new AutoHidingMenuBarManualTest().setVisible(true);
+                new AutoHidingMenuBarManualTestApp().setVisible(true);
             }
         });
     }
 
-    public AutoHidingMenuBarManualTest() {
+    public AutoHidingMenuBarManualTestApp() {
         initComponents();
     }
 


### PR DESCRIPTION
This avoids a "No runnable methods" error while running tests in the core.windows package, due to the AutoHidingMenuBarManualTest class having a name that ends with "Test" but no test methods in it. The class in question is kept around for manual testing purposes only, and is not intended to be run automatically. See https://github.com/apache/incubator-netbeans/pull/1060 .