### PR TITLE
[NETBEANS-1728] fix for Exception encountered when break returns value

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
@@ -546,16 +546,7 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
             }
         // No need to check for version of JDK, as targetExpressionTree can only be non-null in case of JDK-12 or higher
         } else if (targetExpressionTree != null) {
-            try {
-                Class switchExpressionTree = Class.forName("com.sun.source.tree.SwitchExpressionTree");
-                java.lang.reflect.Method mt = switchExpressionTree.getDeclaredMethod("getExpression");
-                ExpressionTree et = (ExpressionTree) mt.invoke(targetExpressionTree);
-                if (et.getKind() == Kind.BLOCK) {
-                    block = et;
-                }
-            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | ClassNotFoundException | java.lang.reflect.InvocationTargetException ex) {
-                //
-            }
+            block = targetExpressionTree;
         }
 
         if (block != null) {

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
@@ -24,6 +24,7 @@ import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ContinueTree;
 import com.sun.source.tree.DoWhileLoopTree;
 import com.sun.source.tree.EnhancedForLoopTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ForLoopTree;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.LabeledStatementTree;
@@ -47,6 +48,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -499,11 +501,11 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
 
     private List<int[]> detectBreakOrContinueTarget(CompilationInfo info, Document document, TreePath breakOrContinue, int caretPosition) {
         List<int[]> result = new ArrayList<int[]>();
-        StatementTree target = info.getTreeUtilities().getBreakContinueTarget(breakOrContinue);
+        Tree target = info.getTreeUtilities().getBreakContinueTargetTree(breakOrContinue);
 
         if (target == null)
             return null;
-
+        
         TokenSequence<JavaTokenId> ts = info.getTokenHierarchy().tokenSequence(JavaTokenId.language());
         
         ts.move((int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), target));
@@ -511,30 +513,49 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
         if (ts.moveNext()) {
             result.add(new int[] {ts.offset(), ts.offset() + ts.token().length()});
         }
-
-        StatementTree statement = target.getKind() == Kind.LABELED_STATEMENT ? ((LabeledStatementTree) target).getStatement() : target;
+        StatementTree targetStatementTree = null;
+        ExpressionTree targetExpressionTree = null;
+        if (target instanceof StatementTree) {
+            targetStatementTree = target.getKind() == Kind.LABELED_STATEMENT ?  ((LabeledStatementTree) target).getStatement() : (StatementTree) target;
+        } else if (target instanceof ExpressionTree) {
+            targetExpressionTree = (ExpressionTree) target;
+        }
         Tree block = null;
-
-        switch (statement.getKind()) {
-            case SWITCH:
-                block = statement;
-                break;
-            case WHILE_LOOP:
-                if (((WhileLoopTree) statement).getStatement().getKind() == Kind.BLOCK)
-                    block = ((WhileLoopTree) statement).getStatement();
-                break;
-            case FOR_LOOP:
-                if (((ForLoopTree) statement).getStatement().getKind() == Kind.BLOCK)
-                    block = ((ForLoopTree) statement).getStatement();
-                break;
-            case ENHANCED_FOR_LOOP:
-                if (((EnhancedForLoopTree) statement).getStatement().getKind() == Kind.BLOCK)
-                    block = ((EnhancedForLoopTree) statement).getStatement();
-                break;
-            case DO_WHILE_LOOP:
-                if (((DoWhileLoopTree) statement).getStatement().getKind() == Kind.BLOCK)
-                    block = ((DoWhileLoopTree) statement).getStatement();
-                break;
+        
+        if (targetStatementTree != null) {
+            switch (targetStatementTree.getKind()) {
+                case SWITCH:
+                    block = targetStatementTree;
+                    break;
+                case WHILE_LOOP:
+                    if (((WhileLoopTree) targetStatementTree).getStatement().getKind() == Kind.BLOCK)
+                        block = ((WhileLoopTree) targetStatementTree).getStatement();
+                    break;
+                case FOR_LOOP:
+                    if (((ForLoopTree) targetStatementTree).getStatement().getKind() == Kind.BLOCK)
+                        block = ((ForLoopTree) targetStatementTree).getStatement();
+                    break;
+                case ENHANCED_FOR_LOOP:
+                    if (((EnhancedForLoopTree) targetStatementTree).getStatement().getKind() == Kind.BLOCK)
+                        block = ((EnhancedForLoopTree) targetStatementTree).getStatement();
+                    break;
+                case DO_WHILE_LOOP:
+                    if (((DoWhileLoopTree) targetStatementTree).getStatement().getKind() == Kind.BLOCK)
+                        block = ((DoWhileLoopTree) targetStatementTree).getStatement();
+                    break;
+            }
+        // No need to check for version of JDK, as targetExpressionTree can only be non-null in case of JDK-12 or higher
+        } else if (targetExpressionTree != null) {
+            try {
+                Class switchExpressionTree = Class.forName("com.sun.source.tree.SwitchExpressionTree");
+                java.lang.reflect.Method mt = switchExpressionTree.getDeclaredMethod("getExpression");
+                ExpressionTree et = (ExpressionTree) mt.invoke(targetExpressionTree);
+                if (et.getKind() == Kind.BLOCK) {
+                    block = et;
+                }
+            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | ClassNotFoundException | java.lang.reflect.InvocationTargetException ex) {
+                //
+            }
         }
 
         if (block != null) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
@@ -22,6 +22,7 @@ import com.sun.source.tree.BreakTree;
 import com.sun.source.tree.ContinueTree;
 import com.sun.source.tree.LabeledStatementTree;
 import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
 import org.netbeans.api.java.source.support.ErrorAwareTreePathScanner;
@@ -328,7 +329,7 @@ public class InstantRenamePerformer implements DocumentListener, KeyListener {
                 Token<JavaTokenId> span = org.netbeans.modules.java.editor.base.semantic.Utilities.findIdentifierSpan(info, doc, path);
                 if (span != null && span.offset(null) <= adjustedCaret[0] && adjustedCaret[0] <= span.offset(null) + span.length()) {
                     if (path.getLeaf().getKind() != Kind.LABELED_STATEMENT) {
-                        StatementTree tgt = info.getTreeUtilities().getBreakContinueTarget(path);
+                        Tree tgt = info.getTreeUtilities().getBreakContinueTargetTree(path);
                         path = tgt != null ? info.getTrees().getPath(info.getCompilationUnit(), tgt) : null;
                     }
                     if (path != null) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursion.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/InfiniteRecursion.java
@@ -422,7 +422,7 @@ public class InfiniteRecursion {
 
         @Override
         public State visitBreak(BreakTree node, Void p) {
-            StatementTree target = ci.getTreeUtilities().getBreakContinueTarget(getCurrentPath());
+            Tree target = ci.getTreeUtilities().getBreakContinueTargetTree(getCurrentPath());
             breakContinueJumps.add(target);
             return State.NO;
         }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -1250,7 +1250,7 @@ public class NPECheck {
         public State visitBreak(BreakTree node, Void p) {
             super.visitBreak(node, p);
 
-            StatementTree target = info.getTreeUtilities().getBreakContinueTarget(getCurrentPath());
+            Tree target = info.getTreeUtilities().getBreakContinueTargetTree(getCurrentPath());
             
             resumeAfter(target, variable2State);
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
@@ -102,10 +102,10 @@ public class RemoveUnnecessary {
     @Hint(displayName="#DN_RemoveUnnecessaryContinue", description="#DESC_RemoveUnnecessaryContinue", category="general", suppressWarnings="UnnecessaryContinue")
     @TriggerPattern("continue $val$;")
     public static ErrorDescription unnecessaryContinue(HintContext ctx) {
-        return unnecessaryReturnContinue(ctx, ctx.getInfo().getTreeUtilities().getBreakContinueTarget(ctx.getPath()), "UnnecessaryContinueStatement", false);
+        return unnecessaryReturnContinue(ctx, ctx.getInfo().getTreeUtilities().getBreakContinueTargetTree(ctx.getPath()), "UnnecessaryContinueStatement", false);
     }
     
-    private static ErrorDescription unnecessaryReturnContinue(HintContext ctx, StatementTree targetLoop, String key, boolean isReturn) {
+    private static ErrorDescription unnecessaryReturnContinue(HintContext ctx, Tree targetLoop, String key, boolean isReturn) {
         TreePath tp = ctx.getPath();
 
         OUTER: while (tp != null && !TreeUtilities.CLASS_TREE_KINDS.contains(tp.getLeaf().getKind())) {
@@ -193,7 +193,7 @@ public class RemoveUnnecessary {
                 }
 
                 if (next.getKind() == Kind.BREAK) {
-                    StatementTree target = ctx.getInfo().getTreeUtilities().getBreakContinueTarget(new TreePath(tp, next));
+                    Tree target = ctx.getInfo().getTreeUtilities().getBreakContinueTargetTree(new TreePath(tp, next));
                     
                     if (target == null) return null;
                     
@@ -467,7 +467,7 @@ public class RemoveUnnecessary {
         
         if (loop == null) return null;
         
-        if (ctx.getInfo().getTreeUtilities().getBreakContinueTarget(ctx.getPath()) != loop.getParentPath().getLeaf()) return null;
+        if (ctx.getInfo().getTreeUtilities().getBreakContinueTargetTree(ctx.getPath()) != loop.getParentPath().getLeaf()) return null;
         
         Fix fix = JavaFixUtilities.rewriteFix(ctx, brk ? Bundle.FIX_UnnecessaryBreakStatementLabel() : Bundle.FIX_UnnecessaryContinueStatementLabel(), ctx.getPath(), brk ? "break;" : "continue;");
         

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
@@ -1170,7 +1170,7 @@ public class Flow {
         public Boolean visitBreak(BreakTree node, ConstructorData p) {
             super.visitBreak(node, p);
 
-            StatementTree target = info.getTreeUtilities().getBreakContinueTarget(getCurrentPath());
+            Tree target = info.getTreeUtilities().getBreakContinueTargetTree(getCurrentPath());
             
             resumeAfter(target, variable2State);
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/ScanStatement.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/ScanStatement.java
@@ -238,7 +238,7 @@ final class ScanStatement extends ErrorAwareTreePathScanner<Void, Void> {
 
     @Override
     public Void visitBreak(BreakTree node, Void p) {
-        if (isMethodCode() && phase == PHASE_INSIDE_SELECTION && !treesSeensInSelection.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()))) {
+        if (isMethodCode() && phase == PHASE_INSIDE_SELECTION && !treesSeensInSelection.contains(info.getTreeUtilities().getBreakContinueTargetTree(getCurrentPath()))) {
             selectionExits.add(getCurrentPath());
             hasBreaks = true;
         }
@@ -319,7 +319,7 @@ final class ScanStatement extends ErrorAwareTreePathScanner<Void, Void> {
         if ((exitsFromAllBranches ? 0 : i) + usedAfterSelection.size() > 1) {
             return "ERR_Too_Many_Return_Values"; // NOI18N
         }
-        StatementTree breakOrContinueTarget = null;
+        Tree breakOrContinueTarget = null;
         boolean returnValueComputed = false;
         TreePath returnValue = null;
         for (TreePath tp : selectionExits) {
@@ -344,7 +344,7 @@ final class ScanStatement extends ErrorAwareTreePathScanner<Void, Void> {
                     }
                 }
             } else {
-                StatementTree target = info.getTreeUtilities().getBreakContinueTarget(tp);
+                Tree target = info.getTreeUtilities().getBreakContinueTargetTree(tp);
                 if (breakOrContinueTarget == null) {
                     breakOrContinueTarget = target;
                 }

--- a/java/java.source.base/apichanges.xml
+++ b/java/java.source.base/apichanges.xml
@@ -294,7 +294,7 @@
         <description>
             <p>
                 Find the target of <code>break</code> or <code>continue</code> 
-                statement especially when one of them returns a value.
+                statement. Target is of type Tree here.
             </p>
         </description>
         <class name="TreeUtilities" package="org.netbeans.api.java.source"/>

--- a/java/java.source.base/apichanges.xml
+++ b/java/java.source.base/apichanges.xml
@@ -290,7 +290,7 @@
         <version major="1" minor="2.40.0"/>
         <date day="22" month="1" year="2019"/>
         <author login="sarveshkesharwani"/>
-        <compatibility addition="yes" binary="compatible" source="compatibility"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"/>
         <description>
             <p>
                 Find the target of <code>break</code> or <code>continue</code> 

--- a/java/java.source.base/apichanges.xml
+++ b/java/java.source.base/apichanges.xml
@@ -284,6 +284,21 @@
             </p>
         </description>
     </change>
+    <change id="TreeUtilities.getBreakContinueTargetTree">
+        <api name="javasource_base" />
+        <summary>Find the target of Break or Continue statement</summary>
+        <version major="1" minor="2.40.0"/>
+        <date day="22" month="1" year="2019"/>
+        <author login="sarveshkesharwani"/>
+        <compatibility addition="yes" binary="compatible" source="compatibility"/>
+        <description>
+            <p>
+                Find the target of <code>break</code> or <code>continue</code> 
+                statement especially when one of them returns a value.
+            </p>
+        </description>
+        <class name="TreeUtilities" package="org.netbeans.api.java.source"/>
+    </change>
 </changes>
 <htmlcontents>
 <head>

--- a/java/java.source.base/nbproject/org-netbeans-modules-java-source-base.sig
+++ b/java/java.source.base/nbproject/org-netbeans-modules-java-source-base.sig
@@ -1575,6 +1575,7 @@ meth public com.sun.source.tree.Scope reattributeTreeTo(com.sun.source.tree.Tree
 meth public com.sun.source.tree.Scope scopeFor(int)
 meth public com.sun.source.tree.Scope toScopeWithDisabledAccessibilityChecks(com.sun.source.tree.Scope)
 meth public com.sun.source.tree.StatementTree getBreakContinueTarget(com.sun.source.util.TreePath)
+meth public com.sun.source.tree.Tree getBreakContinueTargetTree(com.sun.source.util.TreePath)
 meth public com.sun.source.tree.StatementTree parseStatement(java.lang.String,com.sun.source.util.SourcePositions[])
 meth public com.sun.source.tree.Tree translate(com.sun.source.tree.Tree,java.util.Map<? extends com.sun.source.tree.Tree,? extends com.sun.source.tree.Tree>)
  anno 0 org.netbeans.api.annotations.common.NonNull()

--- a/java/java.source.base/nbproject/project.properties
+++ b/java/java.source.base/nbproject/project.properties
@@ -23,7 +23,7 @@ javadoc.name=Java Source Base
 javadoc.title=Java Source Base
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=2.39.0
+spec.version.base=2.40.0
 test.qa-functional.cp.extra=${refactoring.java.dir}/modules/ext/nb-javac-api.jar
 test.unit.run.cp.extra=${o.n.core.dir}/core/core.jar:\
     ${o.n.core.dir}/lib/boot.jar:\

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1345,7 +1345,7 @@ public final class TreeUtilities {
      * @return the tree that is the "target" for the given break or continue statement, or null if there is none. Tree can be of type StatementTree or ExpressionTree
      * @throws IllegalArgumentException if the given tree is not a break or continue tree or if the given {@link CompilationInfo}
      *         is not in the {@link Phase#RESOLVED} phase.
-     * @since 0.16
+     * @since 2.40
      */
     public Tree getBreakContinueTargetTree(TreePath breakOrContinue) throws IllegalArgumentException {
         if (info.getPhase().compareTo(Phase.RESOLVED) < 0)

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1355,7 +1355,11 @@ public final class TreeUtilities {
         
         switch (leaf.getKind()) {
             case BREAK:
-                return (StatementTree) ((JCTree.JCBreak) leaf).target;
+                Tree breakTarget = (Tree) ((JCTree.JCBreak) leaf).target;
+                if (breakTarget == null || !(breakTarget instanceof StatementTree)) {
+                    return null;
+                }
+                return (StatementTree) breakTarget;
             case CONTINUE:
                 StatementTree target = (StatementTree) ((JCTree.JCContinue) leaf).target;
                 

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1342,6 +1342,54 @@ public final class TreeUtilities {
      *                        The <code>breakOrContinue.getLeaf().getKind()</code>
      *                        has to be either {@link Kind#BREAK} or {@link Kind#CONTINUE}, or
      *                        an IllegalArgumentException is thrown
+     * @return the tree that is the "target" for the given break or continue statement, or null if there is none. Tree can be of type StatementTree or ExpressionTree
+     * @throws IllegalArgumentException if the given tree is not a break or continue tree or if the given {@link CompilationInfo}
+     *         is not in the {@link Phase#RESOLVED} phase.
+     * @since 0.16
+     */
+    public Tree getBreakContinueTargetTree(TreePath breakOrContinue) throws IllegalArgumentException {
+        if (info.getPhase().compareTo(Phase.RESOLVED) < 0)
+            throw new IllegalArgumentException("Not in correct Phase. Required: Phase.RESOLVED, got: Phase." + info.getPhase().toString());
+        
+        Tree leaf = breakOrContinue.getLeaf();
+        
+        switch (leaf.getKind()) {
+            case BREAK:
+                return (Tree) ((JCTree.JCBreak) leaf).target;
+            case CONTINUE:
+                Tree target = (Tree) ((JCTree.JCContinue) leaf).target;
+                
+                if (target == null)
+                    return null;
+                
+                if (((JCTree.JCContinue) leaf).label == null)
+                    return target;
+                
+                TreePath tp = breakOrContinue;
+                
+                while (tp.getLeaf() != target) {
+                    tp = tp.getParentPath();
+                }
+                
+                Tree parent = tp.getParentPath().getLeaf();
+                
+                if (parent.getKind() == Kind.LABELED_STATEMENT) {
+                    return (StatementTree) parent;
+                } else {
+                    return target;
+                }
+            default:
+                throw new IllegalArgumentException("Unsupported kind: " + leaf.getKind());
+        }
+    }
+    
+    /**Find the target of <code>break</code> or <code>continue</code>. The given
+     * {@link CompilationInfo} has to be at least in the {@link Phase#RESOLVED} phase.
+     * 
+     * @param breakOrContinue {@link TreePath} to the tree that should be inspected.
+     *                        The <code>breakOrContinue.getLeaf().getKind()</code>
+     *                        has to be either {@link Kind#BREAK} or {@link Kind#CONTINUE}, or
+     *                        an IllegalArgumentException is thrown
      * @return the tree that is the "target" for the given break or continue statement, or null if there is none.
      * @throws IllegalArgumentException if the given tree is not a break or continue tree or if the given {@link CompilationInfo}
      *         is not in the {@link Phase#RESOLVED} phase.

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameTransformer.java
@@ -170,7 +170,7 @@ public class RenameTransformer extends RefactoringVisitor {
     @Override
     public Tree visitBreak(BreakTree tree, Element p) {
         if(handle != null && handle.getKind() == Tree.Kind.LABELED_STATEMENT) {
-            StatementTree target = workingCopy.getTreeUtilities().getBreakContinueTarget(getCurrentPath());
+            Tree target = workingCopy.getTreeUtilities().getBreakContinueTargetTree(getCurrentPath());
             if(target == handle.resolve(workingCopy).getLeaf()) {
                 BreakTree newTree = make.Break(newName);
                 rewrite(tree, newTree);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUIImpl.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/InstantRefactoringUIImpl.java
@@ -414,7 +414,7 @@ public final class InstantRefactoringUIImpl implements InstantRefactoringUI {
         }
         if (nameSpan != null && nameSpan[0] <= adjustedCaret[0] && adjustedCaret[0] <= nameSpan[1]) {
             if (path[0].getLeaf().getKind() != Tree.Kind.LABELED_STATEMENT) {
-                StatementTree tgt = info.getTreeUtilities().getBreakContinueTarget(path[0]);
+                Tree tgt = info.getTreeUtilities().getBreakContinueTargetTree(path[0]);
                 path[0] = tgt != null ? info.getTrees().getPath(info.getCompilationUnit(), tgt) : null;
             }
             if (path[0] != null) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenameRefactoringUI.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RenameRefactoringUI.java
@@ -409,7 +409,7 @@ public class RenameRefactoringUI implements RefactoringUI, RefactoringUIBypass, 
                 if(resolve != null && EnumSet.of(Kind.LABELED_STATEMENT, Kind.BREAK, Kind.CONTINUE).contains(resolve.getLeaf().getKind())) {
                     TreePath path = resolve;
                     if (path.getLeaf().getKind() != Kind.LABELED_STATEMENT) {
-                        StatementTree tgt = info.getTreeUtilities().getBreakContinueTarget(path);
+                        Tree tgt = info.getTreeUtilities().getBreakContinueTargetTree(path);
                         path = tgt != null ? info.getTrees().getPath(info.getCompilationUnit(), tgt) : null;
                     }
                     if (path == null) {


### PR DESCRIPTION
In JDK 12, when we try to return a value with a break statement, (for example in a switch statement), for eg. 

`
String str = switch(i) {
        case 1 :
                System.out.println("one");
                break "one";
        default :
                System.out.println("def");
                break "def";
};
`

Currently, BreakTree extends from StatementTree, which means that the break statement cannot be used to assign a variable, but with the advent of JDK 12, break statement can be used to assign values to variables as mentioned above.
Now, BreakTree cannot be cast as an Expression Tree, and because of this Statement Tree is expected wherever getBreakContinueTarget is being called from.