### PR TITLE
Improving ability of o.n.core tests to pass on JDK 11.

### DIFF
--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -321,7 +321,7 @@ public abstract class SetupHid extends NbTestCase {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         StandardJavaFileManager mgr = compiler.getStandardFileManager(null, null, null);
         List<String> fullOptions = new ArrayList<String>(options);
-        fullOptions.addAll(Arrays.asList("-source", "6", "-target", "6"));
+        fullOptions.addAll(Arrays.asList("-source", "8", "-target", "8"));
         if (!compiler.getTask(null, mgr, null, fullOptions, null, mgr.getJavaFileObjectsFromFiles(files)).call()) {
             throw new IOException("compilation failed");
         }

--- a/platform/o.n.core/nbproject/project.properties
+++ b/platform/o.n.core/nbproject/project.properties
@@ -19,8 +19,6 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.7
 javac.target=1.7
 
-requires.nb.javac=true
-
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 


### PR DESCRIPTION
Removing require.nb.javac=true, using -source/-target 8 instead of 6.