### PR TITLE
[NETBEANS-1145] Make Windows Launchers part of the build process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Apache NetBeans is an open source development environment, tooling platform, and
   * Ant 1.9.9 or above
   * Oracle JDK 8 or OpenJDK 8 (to build NetBeans)
   * Oracle JDK 9 or OpenJDK 9 (to run NetBeans)
+  * MinGW (optional), to build Windows Launchers
 
 **Note:** NetBeans also runs with JDK 8, although then it will not include tools for the JDK 9 Shell.
 
@@ -61,6 +62,19 @@ $ ant -Dcluster.config=platform
 ```
 
 **Note:** You can also use `php`, `enterprise`, etc. See the [cluster.properties](https://github.com/apache/incubator-netbeans/blob/master/nbbuild/cluster.properties) file.
+
+#### Building Windows Launchers
+Windows launchers can be build using [MinGW](http://www.mingw.org/) both on Windows and Linux.
+
+As of [NETBEANS-1145](https://issues.apache.org/jira/browse/NETBEANS-1145), the Windows Launchers can be built adding ```do.build.windows.launchers=true``` property to the build process.
+```
+$ ant -Ddo.build.windows.launchers=true
+```
+
+##### Software Requirement to Build Windows Launchers on Ubuntu (16.04+):
+```
+sudo apt install make mingw-w64
+```
 
 ### Running NetBeans
 

--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -63,8 +63,9 @@
             <arg value="-f"/>
             <arg value="Makefile.mingw"/>
         </exec>
-        <copy file="windows-launcher-src/app.exe" tofile="${cluster}/launchers/app.exe" overwrite="true" />
-        <copy file="windows-launcher-src/app64.exe" tofile="${cluster}/launchers/app64.exe" overwrite="true" />
+        <copy todir="${cluster}/launchers" overwrite="true">
+            <fileset dir="windows-launcher-src" includes="app*.exe"/>
+        </copy>
     </target>
 
 </project>

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -334,17 +334,40 @@
       <include name="${nb.cluster.platform.dir}/lib/nbexec" />
     </fixcrlf>
   </target>
-  <target name="finish-build-nb" depends="init,-check-nb-cluster" if="has.nb.cluster">
-    <loadproperties srcFile="${clusters.list.file}" />
-
+  <target name="-shall-build-nb-windows-launchers" depends="init,-check-nb-cluster">
+      <condition property="shall.build.windows.launchers">
+          <and>
+              <istrue value="${do.build.windows.launchers}"/>
+              <istrue value="${has.nb.cluster}"/>
+          </and>
+      </condition>
+  </target>
+  
+  <target name="-build-nb-windows-launchers" depends="-shall-build-nb-windows-launchers" if="shall.build.windows.launchers">
+    <exec executable="make" dir="../nb/ide.launcher/windows">
+        <arg value="-f"/>
+        <arg value="Makefile.mingw"/>
+    </exec>
+    <copy todir="${netbeans.dest.dir}/bin" overwrite="true">
+        <fileset dir="../nb/ide.launcher/windows" includes="netbeans*.exe"/>
+    </copy>
+  </target>
+  
+  <target name="-download-nb-windows-launchers" depends="init,-check-nb-cluster" if="has.nb.cluster" unless="do.build.windows.launchers">
     <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
         <manifest dir="${nb_all}" includes="nb/ide.launcher/external/binaries-list"/>
     </downloadbinaries>
 
     <mkdir dir="${netbeans.dest.dir}/bin" />
+    <unzip src="../nb/ide.launcher/external/launchers-10.0.zip" dest="${netbeans.dest.dir}/bin" />
+  </target>
+
+  <target name="finish-build-nb" depends="init,-check-nb-cluster, -download-nb-windows-launchers, -build-nb-windows-launchers" if="has.nb.cluster">
+    <loadproperties srcFile="${clusters.list.file}" />
+
+    <mkdir dir="${netbeans.dest.dir}/bin" />
     <copy file="../nb/ide.launcher/unix/netbeans" todir="${netbeans.dest.dir}/bin" />
     <chmod file="${netbeans.dest.dir}/bin/netbeans" perm="ugo+rx"/>
-    <unzip src="../nb/ide.launcher/external/launchers-10.0.zip" dest="${netbeans.dest.dir}/bin" />
     <!-- if anybody knows better place for icons, let me know: jtulach@netbeans.org -->
 
     <mkdir dir="${netbeans.dest.dir}/etc" />

--- a/platform/o.n.bootstrap/build.xml
+++ b/platform/o.n.bootstrap/build.xml
@@ -32,11 +32,24 @@
     <target name="rebuild-main" unless="main.up.to.date">
         <mkdir dir="${build.classes.dir}"/>
         <delete file="${build.classes.dir}/org/netbeans/Main.class"/>
-        <javac srcdir="${src.dir}" destdir="${build.classes.dir}" debug="${build.compiler.debug}" debuglevel="${build.compiler.debuglevel}" deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="1.6" target="1.6" includeantruntime="false">
+        <javac srcdir="${src.dir}" destdir="${build.classes.dir}" debug="${build.compiler.debug}" debuglevel="${build.compiler.debuglevel}" deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="1.8" target="1.8" includeantruntime="false">
             <classpath refid="cp"/>
             <include name="org/netbeans/Main.java"/>
             <compilerarg line="${javac.compilerargs}"/>
         </javac>
     </target>
-
+    
+    <target name="-build-windows-launchers" depends="build-init" if="do.build.windows.launchers">
+        <exec executable="make" dir="launcher/windows">
+            <arg value="-f"/>
+            <arg value="Makefile.mingw"/>
+        </exec>
+        <copy todir="${cluster}/bin" overwrite="true">
+            <fileset dir="launcher/windows">
+                <include name="nbexec*.dll"/>
+                <include name="nbexec*.exe"/>
+            </fileset>
+        </copy>
+    </target>
+    <target name="release" depends="projectized.release,-build-windows-launchers" />
 </project>


### PR DESCRIPTION
Added the possibility to build the Launchers instead of relaying on "third party" uploads. It can be enabled by adding -Ddo.build.windows.launchers=true to the ant command line.

I did my tests on Ubuntu, though I could not test the resulted binaries, so please test.
If someone'd know the software requirements on Windows, please share.
If you find this Ok and working, I'd reconfigure our buildjob to produce the Windows binaries this way.
