### PR TITLE
[NETBEANS-1675]Java Hint to fix error :different case kinds used in the switch in switch expressions

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
@@ -197,4 +197,4 @@ FIX_AccessError_PROTECTED=Make {0} protected
 FIX_AccessError_PACKAGE_PRIVATE=Make {0} package private
 ImportClassCustomizer.organizeImports.text=Format and sort imports
 FIX_VarCompDeclaration=Split compound declaration
-FIX_SWITCH_MIX_CASE=Fix mixed case kinds used in switch
+FIX_DifferentCaseKinds=Fix mixed case kinds used in switch

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
@@ -197,3 +197,4 @@ FIX_AccessError_PROTECTED=Make {0} protected
 FIX_AccessError_PACKAGE_PRIVATE=Make {0} package private
 ImportClassCustomizer.organizeImports.text=Format and sort imports
 FIX_VarCompDeclaration=Split compound declaration
+FIX_SWITCH_MIX_CASE=Fix mix switch case

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
@@ -197,4 +197,4 @@ FIX_AccessError_PROTECTED=Make {0} protected
 FIX_AccessError_PACKAGE_PRIVATE=Make {0} package private
 ImportClassCustomizer.organizeImports.text=Format and sort imports
 FIX_VarCompDeclaration=Split compound declaration
-FIX_SWITCH_MIX_CASE=Fix mix switch case
+FIX_SWITCH_MIX_CASE=Fix mixed case kinds used in switch

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ConvertToRuleSwitch.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ConvertToRuleSwitch.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.errors;
+
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.BreakTree;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ContinueTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.IfTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.ThrowTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.tree.JCTree.JCCase;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
+import javax.tools.Diagnostic;
+import org.netbeans.api.java.queries.CompilerOptionsQuery;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.hints.TreeShims;
+import org.netbeans.modules.java.hints.spi.ErrorRule;
+import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.java.hints.JavaFix;
+import org.netbeans.spi.java.hints.JavaFix.TransformationContext;
+import org.openide.util.NbBundle;
+
+/**
+ * Handle error rule "compiler.err.switch.mixing.case.types" and provide the
+ * fix.
+ *
+ * @author vkprabha
+ */
+public class ConvertToRuleSwitch implements ErrorRule<Void> {
+
+    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+            "compiler.err.switch.mixing.case.types")); // NOI18N
+
+    @Override
+    public Set<String> getCodes() {
+        return Collections.unmodifiableSet(ERROR_CODES);
+    }
+
+    @Override
+    public List<Fix> run(CompilationInfo info, String diagnosticKey, int offset, TreePath treePath, Data<Void> data) {
+        if (!CompilerOptionsQuery.getOptions(info.getFileObject()).getArguments().contains("--enable-preview")) {
+            return null;
+        }
+        SwitchTree st = (SwitchTree) treePath.getParentPath().getLeaf();
+        boolean completesNormally = false;
+        boolean wasDefault = false;
+        boolean wasEmpty = false;
+        for (CaseTree ct : st.getCases()) {
+            if (ct.getStatements() == null && !(ct instanceof JCCase && ((JCCase) ct).stats != null)) { //TODO: test 
+                return null;
+            } else if (ct.getStatements() != null) {
+                if (completesNormally) {
+                    if (!wasEmpty) {//fall-through from a non-empty case
+                        return null;
+                    }
+                    if (wasDefault) {//fall-through from default to a case
+                        return null;
+                    }
+                    if (!wasDefault && ct.getExpression() == null) {//fall-through from a case to default
+                        return null;
+                    }
+                }
+                completesNormally = completesNormally(info, new TreePath(treePath.getParentPath(), ct));
+                wasDefault = ct.getExpression() == null;
+                wasEmpty = ct.getStatements().isEmpty();
+            }
+        }
+
+        return Collections.<Fix>singletonList(new ConvertToRuleSwitch.FixImpl(info, treePath).toEditorFix());
+    }
+
+    private static boolean completesNormally(CompilationInfo info, TreePath tp) {
+        class Scanner extends TreePathScanner<Void, Void> {
+
+            private boolean completesNormally = true;
+            private Set<Tree> seenTrees = new HashSet<>();
+
+            @Override
+            public Void visitReturn(ReturnTree node, Void p) {
+                completesNormally = false;
+                return null;
+            }
+
+            @Override
+            public Void visitBreak(BreakTree node, Void p) {
+                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
+                return null;
+            }
+
+            @Override
+            public Void visitContinue(ContinueTree node, Void p) {
+                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
+                return null;
+            }
+
+            @Override
+            public Void visitThrow(ThrowTree node, Void p) {
+                completesNormally = false;
+                return null;
+            }
+
+            @Override
+            public Void visitIf(IfTree node, Void p) {
+                boolean origCompletesNormally = completesNormally;
+                scan(node.getThenStatement(), p);
+                boolean afterThen = completesNormally;
+                completesNormally = origCompletesNormally;
+                scan(node.getElseStatement(), p);
+                completesNormally |= afterThen;
+                return null;
+            }
+
+            @Override
+            public Void visitSwitch(SwitchTree node, Void p) {
+                //exhaustiveness: (TODO)
+                boolean hasDefault = node.getCases().stream().anyMatch(c -> c.getExpression() == null);
+                if (node.getCases().size() > 0) {
+                    scan(node.getCases().get(node.getCases().size() - 1), p);
+                }
+                completesNormally |= !hasDefault;
+                return null;
+            }
+
+            //TODO: loops
+            @Override
+            public Void scan(Tree tree, Void p) {
+                seenTrees.add(tree);
+                return super.scan(tree, p);
+            }
+
+            @Override
+            public Void visitLambdaExpression(LambdaExpressionTree node, Void p) {
+                return null;
+            }
+
+            @Override
+            public Void visitClass(ClassTree node, Void p) {
+                return null;
+            }
+        }
+
+        Scanner scanner = new Scanner();
+
+        scanner.scan(tp, null);
+        return scanner.completesNormally;
+    }
+
+    @Override
+    public String getId() {
+        return ConvertToRuleSwitch.class.getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return NbBundle.getMessage(ConvertToRuleSwitch.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+    }
+
+    public String getDescription() {
+        return NbBundle.getMessage(ConvertToRuleSwitch.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    private static final class FixImpl extends JavaFix {
+
+        CompilationInfo info;
+        TreePath path;
+
+        public FixImpl(CompilationInfo info, TreePath path) {
+            super(info, path);
+            this.info = info;
+            this.path = path;
+        }
+
+        @Override
+        protected String getText() {
+            return NbBundle.getMessage(ConvertToRuleSwitch.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+        }
+
+        public String toDebugString() {
+            return NbBundle.getMessage(ConvertToRuleSwitch.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) {
+            TreePath tp = ctx.getPath();
+            Tree switchBlock = tp.getParentPath().getLeaf();
+            if (switchBlock instanceof SwitchTree) {
+                SwitchTree st = (SwitchTree) switchBlock;
+                handleSwitchTree(ctx, tp, st);
+            }//else if Handle SwitchExpressionTree using reflexon
+
+        }
+
+    }
+
+    private static void handleSwitchTree(TransformationContext ctx, TreePath tp, SwitchTree st) {
+        WorkingCopy wc = ctx.getWorkingCopy();
+        TreeMaker make = wc.getTreeMaker();
+        List<CaseTree> newCases = new ArrayList<>();
+        List<ExpressionTree> patterns = new ArrayList<>();
+        Set<VariableElement> variablesDeclaredInOtherCases = new HashSet<>();
+
+        for (Iterator<? extends CaseTree> it = st.getCases().iterator(); it.hasNext();) {
+            CaseTree ct = it.next();
+            TreePath casePath = new TreePath(tp, ct);
+            patterns.addAll(TreeShims.getExpressions(ct));
+            List<? extends StatementTree> statements = null;
+            if (ct.getStatements() == null) {
+                statements = ((JCCase) ct).stats;
+            } else {
+                statements = new ArrayList<>(ct.getStatements());
+            }
+            if (statements.isEmpty()) {
+                if (it.hasNext()) {
+                    continue;
+                }
+                //last case, no break
+            } else if (statements.get(statements.size() - 1).getKind() == Tree.Kind.BREAK
+                    && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1))) == st) {
+                statements.remove(statements.size() - 1);
+            } else {
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitBlock(BlockTree node, Void p) {
+                        if (!node.getStatements().isEmpty()
+                                && node.getStatements().get(node.getStatements().size() - 1).getKind() == Tree.Kind.BREAK
+                                && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(getCurrentPath(), node.getStatements().get(node.getStatements().size() - 1))) == st) {
+                            wc.rewrite(node, make.removeBlockStatement(node, node.getStatements().get(node.getStatements().size() - 1)));
+                            //TODO: optimize ifs?
+                        }
+                        return super.visitBlock(node, p);
+                    }
+                }.scan(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1)), null);
+            }
+            Set<Element> seenVariables = new HashSet<>();
+            int idx = 0;
+            for (StatementTree statement : new ArrayList<>(statements)) {
+                TreePath statementPath = new TreePath(casePath, statement);
+                if (statement.getKind() == Tree.Kind.EXPRESSION_STATEMENT) {
+                    ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
+                    if (expr.getKind() == Tree.Kind.ASSIGNMENT) {
+                        AssignmentTree at = (AssignmentTree) expr;
+                        Element var = wc.getTrees().getElement(new TreePath(new TreePath(statementPath, at), at.getVariable()));
+                        if (variablesDeclaredInOtherCases.contains(var)) {
+                            seenVariables.add(var);
+                            //XXX: take type from the original variable
+                            wc.rewrite(statement,
+                                    make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), at.getExpression()));
+                        }
+                    }
+                }
+                Set<Element> thisStatementSeenVariables = new HashSet<>();
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitIdentifier(IdentifierTree node, Void p) {
+                        Element el = wc.getTrees().getElement(getCurrentPath());
+                        if (variablesDeclaredInOtherCases.contains(el) && seenVariables.add(el)) {
+                            thisStatementSeenVariables.add(el);
+                        }
+                        return super.visitIdentifier(node, p);
+                    }
+                }.scan(statementPath, null);
+                
+// Todo : Need to check the use case
+//                if (!thisStatementSeenVariables.isEmpty()) {
+//                    for (Element el : thisStatementSeenVariables) {
+//                        VariableElement var = (VariableElement) el;
+//                        statements.add(idx++, make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), null));
+//                    }
+//                }
+                idx++;
+            }
+            Tree body = make.Block(statements, false);
+            if (statements.size() == 1) {
+                if (statements.get(0).getKind() == Tree.Kind.EXPRESSION_STATEMENT
+                        || statements.get(0).getKind() == Tree.Kind.THROW
+                        || statements.get(0).getKind() == Tree.Kind.BLOCK) {
+                    body = statements.get(0);
+                }
+            }
+            newCases.add(make.Case(patterns, body));
+            patterns = new ArrayList<>();
+                for (StatementTree statement : ct.getStatements()) {
+                    if (statement.getKind() == Tree.Kind.VARIABLE) {
+                        variablesDeclaredInOtherCases.add((VariableElement) wc.getTrees().getElement(new TreePath(casePath, statement)));
+                    }
+                }
+        }
+
+        wc.rewrite(st, make.Switch(st.getExpression(), newCases));
+
+    }
+}

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
@@ -18,41 +18,19 @@
  */
 package org.netbeans.modules.java.hints.errors;
 
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.BlockTree;
-import com.sun.source.tree.BreakTree;
 import com.sun.source.tree.CaseTree;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.ContinueTree;
-import com.sun.source.tree.ExpressionStatementTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.IfTree;
-import com.sun.source.tree.LambdaExpressionTree;
-import com.sun.source.tree.ReturnTree;
-import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.SwitchTree;
-import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.tree.JCTree.JCCase;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.VariableElement;
 import org.netbeans.api.java.queries.CompilerOptionsQuery;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.TreeMaker;
-import org.netbeans.api.java.source.WorkingCopy;
-import org.netbeans.modules.java.hints.TreeShims;
+import org.netbeans.modules.java.hints.jdk.mapreduce.TreeUtilities;
 import org.netbeans.modules.java.hints.spi.ErrorRule;
 import org.netbeans.spi.editor.hints.Fix;
 import org.netbeans.spi.java.hints.JavaFix;
@@ -99,90 +77,14 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
                         return null;
                     }
                 }
-                completesNormally = completesNormally(info, new TreePath(treePath.getParentPath(), ct));
+                completesNormally = TreeUtilities.completesNormally(info, new TreePath(treePath.getParentPath(), ct));
                 wasDefault = ct.getExpression() == null;
                 wasEmpty = ct.getStatements().isEmpty();
             }
         }
 
         return Collections.<Fix>singletonList(new DifferentCaseKindsFix.FixImpl(info, treePath).toEditorFix());
-    }
-
-    private static boolean completesNormally(CompilationInfo info, TreePath tp) {
-        class Scanner extends TreePathScanner<Void, Void> {
-
-            private boolean completesNormally = true;
-            private Set<Tree> seenTrees = new HashSet<>();
-
-            @Override
-            public Void visitReturn(ReturnTree node, Void p) {
-                completesNormally = false;
-                return null;
-            }
-
-            @Override
-            public Void visitBreak(BreakTree node, Void p) {
-                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
-                return null;
-            }
-
-            @Override
-            public Void visitContinue(ContinueTree node, Void p) {
-                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
-                return null;
-            }
-
-            @Override
-            public Void visitThrow(ThrowTree node, Void p) {
-                completesNormally = false;
-                return null;
-            }
-
-            @Override
-            public Void visitIf(IfTree node, Void p) {
-                boolean origCompletesNormally = completesNormally;
-                scan(node.getThenStatement(), p);
-                boolean afterThen = completesNormally;
-                completesNormally = origCompletesNormally;
-                scan(node.getElseStatement(), p);
-                completesNormally |= afterThen;
-                return null;
-            }
-
-            @Override
-            public Void visitSwitch(SwitchTree node, Void p) {
-                //exhaustiveness: (TODO)
-                boolean hasDefault = node.getCases().stream().anyMatch(c -> c.getExpression() == null);
-                if (node.getCases().size() > 0) {
-                    scan(node.getCases().get(node.getCases().size() - 1), p);
-                }
-                completesNormally |= !hasDefault;
-                return null;
-            }
-
-            //TODO: loops
-            @Override
-            public Void scan(Tree tree, Void p) {
-                seenTrees.add(tree);
-                return super.scan(tree, p);
-            }
-
-            @Override
-            public Void visitLambdaExpression(LambdaExpressionTree node, Void p) {
-                return null;
-            }
-
-            @Override
-            public Void visitClass(ClassTree node, Void p) {
-                return null;
-            }
-        }
-
-        Scanner scanner = new Scanner();
-
-        scanner.scan(tp, null);
-        return scanner.completesNormally;
-    }
+    }    
 
     @Override
     public String getId() {
@@ -191,11 +93,11 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
 
     @Override
     public String getDisplayName() {
-        return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+        return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"); // NOI18N
     }
 
     public String getDescription() {
-        return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+        return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"); // NOI18N
     }
 
     @Override
@@ -215,11 +117,11 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
 
         @Override
         protected String getText() {
-            return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+            return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"); // NOI18N
         }
 
         public String toDebugString() {
-            return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_SWITCH_MIX_CASE"); // NOI18N
+            return NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"); // NOI18N
         }
 
         @Override
@@ -228,107 +130,11 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
             Tree switchBlock = tp.getParentPath().getLeaf();
             if (switchBlock instanceof SwitchTree) {
                 SwitchTree st = (SwitchTree) switchBlock;
-                handleSwitchTree(ctx, tp, st);
+                TreeUtilities.performRewriteRuleSwitch(ctx, tp, st);
             }
 
         }
 
     }
-
-    private static void handleSwitchTree(TransformationContext ctx, TreePath tp, SwitchTree st) {
-        WorkingCopy wc = ctx.getWorkingCopy();
-        TreeMaker make = wc.getTreeMaker();
-        List<CaseTree> newCases = new ArrayList<>();
-        List<ExpressionTree> patterns = new ArrayList<>();
-        Set<VariableElement> variablesDeclaredInOtherCases = new HashSet<>();
-
-        for (Iterator<? extends CaseTree> it = st.getCases().iterator(); it.hasNext();) {
-            CaseTree ct = it.next();
-            TreePath casePath = new TreePath(tp, ct);
-            patterns.addAll(TreeShims.getExpressions(ct));
-            List<StatementTree> statements;
-            if (ct.getStatements() == null) {
-                statements = new ArrayList<>(((JCCase) ct).stats);
-            } else {
-                statements = new ArrayList<>(ct.getStatements());
-            }
-            if (statements.isEmpty()) {
-                if (it.hasNext()) {
-                    continue;
-                }
-                //last case, no break
-            } else if (statements.get(statements.size() - 1).getKind() == Tree.Kind.BREAK
-                    && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1))) == st) {
-                statements.remove(statements.size() - 1);
-            } else {
-                new TreePathScanner<Void, Void>() {
-                    @Override
-                    public Void visitBlock(BlockTree node, Void p) {
-                        if (!node.getStatements().isEmpty()
-                                && node.getStatements().get(node.getStatements().size() - 1).getKind() == Tree.Kind.BREAK
-                                && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(getCurrentPath(), node.getStatements().get(node.getStatements().size() - 1))) == st) {
-                            wc.rewrite(node, make.removeBlockStatement(node, node.getStatements().get(node.getStatements().size() - 1)));
-                            //TODO: optimize ifs?
-                        }
-                        return super.visitBlock(node, p);
-                    }
-                }.scan(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1)), null);
-            }
-            Set<Element> seenVariables = new HashSet<>();
-            int idx = 0;
-            for (StatementTree statement : statements) {
-                TreePath statementPath = new TreePath(casePath, statement);
-                if (statement.getKind() == Tree.Kind.EXPRESSION_STATEMENT) {
-                    ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
-                    if (expr.getKind() == Tree.Kind.ASSIGNMENT) {
-                        AssignmentTree at = (AssignmentTree) expr;
-                        Element var = wc.getTrees().getElement(new TreePath(new TreePath(statementPath, at), at.getVariable()));
-                        if (variablesDeclaredInOtherCases.contains(var)) {
-                            seenVariables.add(var);
-                            //XXX: take type from the original variable
-                            wc.rewrite(statement,
-                                    make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), at.getExpression()));
-                        }
-                    }
-                }
-                Set<Element> thisStatementSeenVariables = new HashSet<>();
-                new TreePathScanner<Void, Void>() {
-                    @Override
-                    public Void visitIdentifier(IdentifierTree node, Void p) {
-                        Element el = wc.getTrees().getElement(getCurrentPath());
-                        if (variablesDeclaredInOtherCases.contains(el) && seenVariables.add(el)) {
-                            thisStatementSeenVariables.add(el);
-                        }
-                        return super.visitIdentifier(node, p);
-                    }
-                }.scan(statementPath, null);             
-
-                if (!thisStatementSeenVariables.isEmpty()) {
-                    for (Element el : thisStatementSeenVariables) {
-                        VariableElement var = (VariableElement) el;
-                        statements.add(idx++, make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), null));
-                    }
-                }
-                idx++;
-            }
-            Tree body = make.Block(statements, false);
-            if (statements.size() == 1) {
-                if (statements.get(0).getKind() == Tree.Kind.EXPRESSION_STATEMENT
-                        || statements.get(0).getKind() == Tree.Kind.THROW
-                        || statements.get(0).getKind() == Tree.Kind.BLOCK) {
-                    body = statements.get(0);
-                }
-            }
-            newCases.add(make.Case(patterns, body));
-            patterns = new ArrayList<>();
-                for (StatementTree statement : ct.getStatements()) {
-                    if (statement.getKind() == Tree.Kind.VARIABLE) {
-                        variablesDeclaredInOtherCases.add((VariableElement) wc.getTrees().getElement(new TreePath(casePath, statement)));
-                    }
-                }
-        }
-
-        wc.rewrite(st, make.Switch(st.getExpression(), newCases));
-
-    }
+    
 }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
@@ -58,6 +58,9 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
         if (!CompilerOptionsQuery.getOptions(info.getFileObject()).getArguments().contains("--enable-preview")) {
             return null;
         }
+        if(treePath.getParentPath().getLeaf().getKind().toString().equals("SWITCH_EXPRESSION")){
+            return null;
+        }
         SwitchTree st = (SwitchTree) treePath.getParentPath().getLeaf();
         boolean completesNormally = false;
         boolean wasDefault = false;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToRuleSwitch.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToRuleSwitch.java
@@ -18,40 +18,13 @@
  */
 package org.netbeans.modules.java.hints.jdk;
 
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.BlockTree;
-import com.sun.source.tree.BreakTree;
 import com.sun.source.tree.CaseTree;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.ContinueTree;
-import com.sun.source.tree.ExpressionStatementTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.IfTree;
-import com.sun.source.tree.LambdaExpressionTree;
-import com.sun.source.tree.ReturnTree;
-import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.SwitchTree;
-import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
-import com.sun.source.util.TreeScanner;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.VariableElement;
 import org.netbeans.api.java.queries.CompilerOptionsQuery;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.TreeMaker;
-import org.netbeans.api.java.source.WorkingCopy;
-import org.netbeans.modules.java.hints.TreeShims;
+import org.netbeans.modules.java.hints.jdk.mapreduce.TreeUtilities;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
@@ -89,77 +62,12 @@ public class ConvertSwitchToRuleSwitch {
                 if (!wasDefault && ct.getExpression() == null) //fall-through from a case to default
                     return null;
             }
-            completesNormally = completesNormally(ctx.getInfo(), new TreePath(ctx.getPath(), ct));
+            completesNormally = TreeUtilities.completesNormally(ctx.getInfo(), new TreePath(ctx.getPath(), ct));
             wasDefault = ct.getExpression() == null;
             wasEmpty = ct.getStatements().isEmpty();
         }
         return ErrorDescriptionFactory.forName(ctx, ctx.getPath(), Bundle.ERR_ConverSwitchToRuleSwitch(), new FixImpl(ctx.getInfo(), ctx.getPath()).toEditorFix());
-    }
-    private static boolean completesNormally(CompilationInfo info, TreePath tp) {
-        class Scanner extends TreePathScanner<Void, Void> {
-            private boolean completesNormally = true;
-            private Set<Tree> seenTrees = new HashSet<>();
-            @Override
-            public Void visitReturn(ReturnTree node, Void p) {
-                completesNormally = false;
-                return null;
-            }
-            @Override
-            public Void visitBreak(BreakTree node, Void p) {
-                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
-                return null;
-            }
-            @Override
-            public Void visitContinue(ContinueTree node, Void p) {
-                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
-                return null;
-            }
-            @Override
-            public Void visitThrow(ThrowTree node, Void p) {
-                completesNormally = false;
-                return null;
-            }
-            @Override
-            public Void visitIf(IfTree node, Void p) {
-                boolean origCompletesNormally = completesNormally;
-                scan(node.getThenStatement(), p);
-                boolean afterThen = completesNormally;
-                completesNormally = origCompletesNormally;
-                scan(node.getElseStatement(), p);
-                completesNormally |= afterThen;
-                return null;
-            }
-            @Override
-            public Void visitSwitch(SwitchTree node, Void p) {
-                //exhaustiveness: (TODO)
-                boolean hasDefault = node.getCases().stream().anyMatch(c -> c.getExpression() == null);
-                if (node.getCases().size() > 0) {
-                    scan(node.getCases().get(node.getCases().size() - 1), p);
-                }
-                completesNormally |= !hasDefault;
-                return null;
-            }
-            //TODO: loops
-            @Override
-            public Void scan(Tree tree, Void p) {
-                seenTrees.add(tree);
-                return super.scan(tree, p);
-            }
-            @Override
-            public Void visitLambdaExpression(LambdaExpressionTree node, Void p) {
-                return null;
-            }
-            @Override
-            public Void visitClass(ClassTree node, Void p) {
-                return null;
-            }
-        }
-
-        Scanner scanner = new Scanner();
-
-        scanner.scan(tp, null);
-        return scanner.completesNormally;
-    }
+    }    
 
     private static final class FixImpl extends JavaFix {
 
@@ -175,96 +83,9 @@ public class ConvertSwitchToRuleSwitch {
 
         @Override
         protected void performRewrite(TransformationContext ctx) {
-            WorkingCopy wc = ctx.getWorkingCopy();
             TreePath tp = ctx.getPath();
-            TreeMaker make = wc.getTreeMaker();
             SwitchTree st = (SwitchTree) tp.getLeaf();
-            List<CaseTree> newCases = new ArrayList<>();
-            List<ExpressionTree> patterns = new ArrayList<>();
-            Set<VariableElement> variablesDeclaredInOtherCases = new HashSet<>();
-
-            for (Iterator<? extends CaseTree> it = st.getCases().iterator(); it.hasNext();) {
-                CaseTree ct = it.next();
-                TreePath casePath = new TreePath(tp, ct);
-                patterns.addAll(TreeShims.getExpressions(ct));
-                List<StatementTree> statements = new ArrayList<>(ct.getStatements());
-                if (statements.isEmpty()) {
-                    if (it.hasNext()) {
-                        continue;
-                    }
-                    //last case, no break
-                } else if (statements.get(statements.size() - 1).getKind() == Kind.BREAK &&
-                    ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1))) == st) {
-                    statements.remove(statements.size() - 1);
-                } else {
-                    new TreePathScanner<Void, Void>() {
-                        @Override
-                        public Void visitBlock(BlockTree node, Void p) {
-                            if (!node.getStatements().isEmpty() &&
-                                    node.getStatements().get(node.getStatements().size() - 1).getKind() == Kind.BREAK &&
-                                    ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(getCurrentPath(), node.getStatements().get(node.getStatements().size() - 1))) == st) {
-                                wc.rewrite(node, make.removeBlockStatement(node, node.getStatements().get(node.getStatements().size() - 1)));
-                                //TODO: optimize ifs?
-                            }
-                            return super.visitBlock(node, p);
-                        }
-                    }.scan(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1)), null);
-                }
-                Set<Element> seenVariables = new HashSet<>();
-                int idx = 0;
-                for (StatementTree statement : new ArrayList<>(statements)) {
-                    TreePath statementPath = new TreePath(casePath, statement);
-                    if (statement.getKind() == Kind.EXPRESSION_STATEMENT) {
-                        ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
-                        if (expr.getKind() == Kind.ASSIGNMENT) {
-                            AssignmentTree at = (AssignmentTree) expr;
-                            Element var = wc.getTrees().getElement(new TreePath(new TreePath(statementPath, at), at.getVariable()));
-                            if (variablesDeclaredInOtherCases.contains(var)) {
-                                seenVariables.add(var);
-                                //XXX: take type from the original variable
-                                wc.rewrite(statement,
-                                           make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), at.getExpression()));
-                            }
-                        }
-                    }
-                    Set<Element> thisStatementSeenVariables = new HashSet<>();
-                    new TreePathScanner<Void, Void>() {
-                        @Override
-                        public Void visitIdentifier(IdentifierTree node, Void p) {
-                            Element el = wc.getTrees().getElement(getCurrentPath());
-                            if (variablesDeclaredInOtherCases.contains(el) && seenVariables.add(el)) {
-                                thisStatementSeenVariables.add(el);
-                            }
-                            return super.visitIdentifier(node, p);
-                        }
-                    }.scan(statementPath, null);
-
-                    if (!thisStatementSeenVariables.isEmpty()) {
-                        for (Element el : thisStatementSeenVariables) {
-                            VariableElement var = (VariableElement) el;
-                            statements.add(idx++, make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), null));
-                        }
-                    }
-                    idx++;
-                }
-                Tree body = make.Block(statements, false);
-                if (statements.size() == 1) {
-                    if (statements.get(0).getKind() == Kind.EXPRESSION_STATEMENT ||
-                            statements.get(0).getKind() == Kind.THROW ||
-                            statements.get(0).getKind() == Kind.BLOCK) {
-                        body = statements.get(0);
-                    }
-                }
-                newCases.add(make.Case(patterns, body));
-                patterns = new ArrayList<>();
-                for (StatementTree statement : ct.getStatements()) {
-                    if (statement.getKind() == Kind.VARIABLE) {
-                        variablesDeclaredInOtherCases.add((VariableElement) wc.getTrees().getElement(new TreePath(casePath, statement)));
-                    }
-                }
-            }
-
-            wc.rewrite(st, make.Switch(st.getExpression(), newCases));
+            TreeUtilities.performRewriteRuleSwitch(ctx, tp, st);
         }
         
     }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/TreeUtilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/TreeUtilities.java
@@ -21,7 +21,39 @@
  */
 package org.netbeans.modules.java.hints.jdk.mapreduce;
 
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.BreakTree;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ContinueTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.IfTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.hints.TreeShims;
+import org.netbeans.spi.java.hints.JavaFix;
 
 /**
  *
@@ -48,4 +80,187 @@ public class TreeUtilities {
                 || opKind == Tree.Kind.POSTFIX_DECREMENT
                 || opKind == Tree.Kind.PREFIX_DECREMENT;
     }
+    
+    public static boolean completesNormally(CompilationInfo info, TreePath tp) {
+        class Scanner extends TreePathScanner<Void, Void> {
+
+            private boolean completesNormally = true;
+            private Set<Tree> seenTrees = new HashSet<>();
+
+            @Override
+            public Void visitReturn(ReturnTree node, Void p) {
+                completesNormally = false;
+                return null;
+            }
+
+            @Override
+            public Void visitBreak(BreakTree node, Void p) {
+                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
+                return null;
+            }
+
+            @Override
+            public Void visitContinue(ContinueTree node, Void p) {
+                completesNormally &= seenTrees.contains(info.getTreeUtilities().getBreakContinueTarget(getCurrentPath()));
+                return null;
+            }
+
+            @Override
+            public Void visitThrow(ThrowTree node, Void p) {
+                completesNormally = false;
+                return null;
+            }
+
+            @Override
+            public Void visitIf(IfTree node, Void p) {
+                boolean origCompletesNormally = completesNormally;
+                scan(node.getThenStatement(), p);
+                boolean afterThen = completesNormally;
+                completesNormally = origCompletesNormally;
+                scan(node.getElseStatement(), p);
+                completesNormally |= afterThen;
+                return null;
+            }
+
+            @Override
+            public Void visitSwitch(SwitchTree node, Void p) {
+                //exhaustiveness: (TODO)
+                boolean hasDefault = node.getCases().stream().anyMatch(c -> c.getExpression() == null);
+                if (node.getCases().size() > 0) {
+                    scan(node.getCases().get(node.getCases().size() - 1), p);
+                }
+                completesNormally |= !hasDefault;
+                return null;
+            }
+
+            //TODO: loops
+            @Override
+            public Void scan(Tree tree, Void p) {
+                seenTrees.add(tree);
+                return super.scan(tree, p);
+            }
+
+            @Override
+            public Void visitLambdaExpression(LambdaExpressionTree node, Void p) {
+                return null;
+            }
+
+            @Override
+            public Void visitClass(ClassTree node, Void p) {
+                return null;
+            }
+        }
+
+        Scanner scanner = new Scanner();
+
+        scanner.scan(tp, null);
+        return scanner.completesNormally;
+    }
+
+    public static void performRewriteRuleSwitch(JavaFix.TransformationContext ctx, TreePath tp, SwitchTree st) {
+        WorkingCopy wc = ctx.getWorkingCopy();
+        TreeMaker make = wc.getTreeMaker();
+        List<CaseTree> newCases = new ArrayList<>();
+        Set<VariableElement> variablesDeclaredInOtherCases = new HashSet<>();
+        List<ExpressionTree> patterns = new ArrayList<>();
+
+        for (Iterator<? extends CaseTree> it = st.getCases().iterator(); it.hasNext();) {
+            CaseTree ct = it.next();
+            TreePath casePath = new TreePath(tp, ct);
+            patterns.addAll(TreeShims.getExpressions(ct));
+            List<StatementTree> statements;
+            if (ct.getStatements() == null) {
+                statements = new ArrayList<>(((JCTree.JCCase) ct).stats);
+            } else {
+                statements = new ArrayList<>(ct.getStatements());
+            }
+            if (statements.isEmpty()) {
+                if (it.hasNext()) {
+                    continue;
+                }
+                //last case, no break
+            } else if (statements.get(statements.size() - 1).getKind() == Tree.Kind.BREAK
+                    && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1))) == st) {
+                statements.remove(statements.size() - 1);
+            } else {
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitBlock(BlockTree node, Void p) {
+                        if (!node.getStatements().isEmpty()
+                                && node.getStatements().get(node.getStatements().size() - 1).getKind() == Tree.Kind.BREAK
+                                && ctx.getWorkingCopy().getTreeUtilities().getBreakContinueTarget(new TreePath(getCurrentPath(), node.getStatements().get(node.getStatements().size() - 1))) == st) {
+                            wc.rewrite(node, make.removeBlockStatement(node, node.getStatements().get(node.getStatements().size() - 1)));
+                            //TODO: optimize ifs?
+                        }
+                        return super.visitBlock(node, p);
+                    }
+                }.scan(new TreePath(new TreePath(tp, ct), statements.get(statements.size() - 1)), null);
+            }
+            Set<Element> seenVariables = new HashSet<>();
+            int idx = 0;
+            for (StatementTree statement : new ArrayList<>(statements)) {
+                TreePath statementPath = new TreePath(casePath, statement);
+                if (statement.getKind() == Tree.Kind.EXPRESSION_STATEMENT) {
+                    ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
+                    if (expr.getKind() == Tree.Kind.ASSIGNMENT) {
+                        AssignmentTree at = (AssignmentTree) expr;
+                        Element var = wc.getTrees().getElement(new TreePath(new TreePath(statementPath, at), at.getVariable()));
+                        if (variablesDeclaredInOtherCases.contains(var)) {
+                            seenVariables.add(var);
+                            //XXX: take type from the original variable
+                            wc.rewrite(statement,
+                                    make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), at.getExpression()));
+                        }
+                    }
+                }
+                Set<Element> thisStatementSeenVariables = new HashSet<>();
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitIdentifier(IdentifierTree node, Void p) {
+                        Element el = wc.getTrees().getElement(getCurrentPath());
+                        if (variablesDeclaredInOtherCases.contains(el) && seenVariables.add(el)) {
+                            thisStatementSeenVariables.add(el);
+                        }
+                        return super.visitIdentifier(node, p);
+                    }
+                }.scan(statementPath, null);
+
+                if (!thisStatementSeenVariables.isEmpty()) {
+                    for (Element el : thisStatementSeenVariables) {
+                        VariableElement var = (VariableElement) el;
+                        statements.add(idx++, make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), var.getSimpleName(), make.Type(var.asType()), null));
+                    }
+                }
+                idx++;
+            }
+            Tree body = make.Block(statements, false);
+            if (statements.size() == 1) {
+                if (statements.get(0).getKind() == Tree.Kind.EXPRESSION_STATEMENT
+                        || statements.get(0).getKind() == Tree.Kind.THROW
+                        || statements.get(0).getKind() == Tree.Kind.BLOCK) {
+                    body = statements.get(0);
+                }
+            }
+            newCases.add(make.Case(patterns, body));
+            patterns = new ArrayList<>();
+            for (StatementTree statement : getSwitchStatement(ct)) {
+                if (statement.getKind() == Tree.Kind.VARIABLE) {
+                    variablesDeclaredInOtherCases.add((VariableElement) wc.getTrees().getElement(new TreePath(casePath, statement)));
+                }
+            }
+        }
+
+        wc.rewrite(st, make.Switch(st.getExpression(), newCases));
+    }
+
+    private static List<? extends StatementTree> getSwitchStatement(CaseTree ct) {
+        if (ct.getStatements() != null) {
+            return ct.getStatements();
+        } else if (ct instanceof JCTree.JCCase) {
+            return ((JCTree.JCCase) ct).stats;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
@@ -148,7 +148,7 @@
                 <file name="org-netbeans-modules-java-hints-errors-ImportClass.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-AddCast.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-VarCompDeclaration.instance"/>
-                <file name="org-netbeans-modules-java-hints-errors-ConvertToRuleSwitch.instance"/>
+                <file name="org-netbeans-modules-java-hints-errors-DifferentCaseKindsFix.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-CreateElement.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-ChangeMethodParameters.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-RenameConstructor.instance"/>
@@ -326,7 +326,7 @@
 
                 <folder name="bugs">
                     <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.java.hints.resources.Bundle"/>
-                    <file name="org-netbeans-modules-java-hints-SuspiciousNamesCombination.instance" />
+                    <file name="org-netbeans-modules-java-hints-SuspiciousNamesCombination.instance"/>
                 </folder>
 
                 <folder name="thread">

--- a/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
@@ -148,6 +148,7 @@
                 <file name="org-netbeans-modules-java-hints-errors-ImportClass.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-AddCast.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-VarCompDeclaration.instance"/>
+                <file name="org-netbeans-modules-java-hints-errors-ConvertToRuleSwitch.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-CreateElement.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-ChangeMethodParameters.instance"/>
                 <file name="org-netbeans-modules-java-hints-errors-RenameConstructor.instance"/>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
@@ -326,7 +326,7 @@
 
                 <folder name="bugs">
                     <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.java.hints.resources.Bundle"/>
-                    <file name="org-netbeans-modules-java-hints-SuspiciousNamesCombination.instance"/>
+                    <file name="org-netbeans-modules-java-hints-SuspiciousNamesCombination.instance" />
                 </folder>
 
                 <folder name="thread">

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/Bundle_test.properties
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/Bundle_test.properties
@@ -52,6 +52,7 @@ FIX_AccessError_PUBLIC=FIX_AccessError_PUBLIC:{0}
 FIX_AccessError_PROTECTED=FIX_AccessError_PROTECTED:{0}
 FIX_AccessError_PACKAGE_PRIVATE=FIX_AccessError_PACKAGE_PRIVATE:{0}
 FIX_VarCompDeclaration=FIX_VarCompDeclaration
+FIX_DifferentCaseKinds=FIX_DifferentCaseKinds
 
 LBL_Impl_Abstract_Methods=LBL_Impl_Abstract_Methods
 ERR_CannotOverrideAbstractMethods=ERR_CannotOverrideAbstractMethods

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFixTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFixTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.errors;
+
+import com.sun.source.util.TreePath;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.modules.java.hints.infrastructure.ErrorHintsTestBase;
+import org.netbeans.modules.java.source.parsing.JavacParser;
+import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Test cases for the Different Case Kinds errors fix.
+ * 
+ */
+public class DifferentCaseKindsFixTest extends ErrorHintsTestBase {
+
+    private static final List<String> EXTRA_OPTIONS = new ArrayList<>();
+
+    public DifferentCaseKindsFixTest(String name) {
+        super(name, DifferentCaseKindsFix.class);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        sourceLevel = "12";
+        JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
+        EXTRA_OPTIONS.add("--enable-preview");
+    }
+
+    @ServiceProvider(service = CompilerOptionsQueryImplementation.class, position = 100)
+    public static class TestCompilerOptionsQueryImplementation implements CompilerOptionsQueryImplementation {
+
+        @Override
+        public CompilerOptionsQueryImplementation.Result getOptions(FileObject file) {
+            return new CompilerOptionsQueryImplementation.Result() {
+                @Override
+                public List<? extends String> getArguments() {
+                    return EXTRA_OPTIONS;
+                }
+
+                @Override
+                public void addChangeListener(ChangeListener listener) {
+                }
+
+                @Override
+                public void removeChangeListener(ChangeListener listener) {
+                }
+            };
+        }
+
+    }
+
+    public void testCase1() throws Exception {
+        performFixTest("test/Test.java",
+                "package test; \n"
+                + "public class Test {\n"
+                + "     private void test(int p) {\n"
+                + "         String result;\n"
+                + "         switch (p) {\n"
+                + "             case 1: result = \"1\"; break;\n"
+                + "             case 2: result = \"2\"; break;\n"
+                + "             default -> result = \"3\";\n"
+                + "         }\n"
+                + "     }\n"
+                + "}\n",
+                -1,
+                NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"),
+                ("package test; \n"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> result = \"1\";\n"
+                        + "             case 2 -> result = \"2\";\n"
+                        + "             default -> result = \"3\";\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n").replaceAll("[\\s]+", " "));
+    }
+
+    public void testCase2() throws Exception {
+        performFixTest("test/Test.java",
+                "package test; \n"
+                + "public class Test {\n"
+                + "     private void test(int p) {\n"
+                + "         String result;\n"
+                + "         switch (p) {\n"
+                + "             case 1: result = \"1\"; break;\n"
+                + "             case 2 -> result = \"2\";\n"
+                + "             default -> result = \"3\";\n"
+                + "         }\n"
+                + "     }\n"
+                + "}\n",
+                -1,
+                NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"),
+                ("package test; \n"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> result = \"1\";\n"
+                        + "             case 2 -> result = \"2\";\n"
+                        + "             default -> result = \"3\";\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n").replaceAll("[\\s]+", " "));
+    }
+
+    public void testCase3() throws Exception {
+        performFixTest("test/Test.java",
+                "package test; \n"
+                + "public class Test {\n"
+                + "     private void test(int p) {\n"
+                + "         String result;\n"
+                + "         switch (p) {\n"
+                + "             case 1 -> result = \"1\";\n"
+                + "             case 2 -> result = \"2\";\n"
+                + "             default : result = \"3\"; break;\n"
+                + "         }\n"
+                + "     }\n"
+                + "}\n",
+                -1,
+                NbBundle.getMessage(DifferentCaseKindsFix.class, "FIX_DifferentCaseKinds"),
+                ("package test; \n"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> result = \"1\";\n"
+                        + "             case 2 -> result = \"2\";\n"
+                        + "             default -> result = \"3\";\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n").replaceAll("[\\s]+", " "));
+    }    
+
+    @Override
+    protected List<Fix> computeFixes(CompilationInfo info, int pos, TreePath path) throws Exception {
+        return new DifferentCaseKindsFix().run(info, null, pos, path, null);
+    }
+
+    @Override
+    protected Set<String> getSupportedErrorKeys() {
+        return new DifferentCaseKindsFix().getCodes();
+    }
+
+    @Override
+    protected String toDebugString(CompilationInfo info, Fix f) {
+        return f.getText();
+    }
+}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
@@ -71,6 +71,7 @@ import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.tree.WildcardTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.tree.JCTree;
 import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1786,7 +1787,14 @@ public class CopyFinder extends ErrorAwareTreeScanner<Boolean, TreePath> {
             case BLOCK:
                 return ((BlockTree) firstLeaf.getParentPath().getLeaf()).getStatements();
             case CASE:
-                return ((CaseTree) firstLeaf.getParentPath().getLeaf()).getStatements();
+                CaseTree caseTree = (CaseTree) firstLeaf.getParentPath().getLeaf();
+                if(caseTree.getStatements() != null){
+                    return caseTree.getStatements();
+                }else if(caseTree instanceof JCTree.JCCase){
+                    return ((JCTree.JCCase)caseTree).stats;
+                }else {
+		    return null;
+                }
             default:
                 return Collections.singletonList((StatementTree) firstLeaf.getLeaf());
         }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
@@ -1788,12 +1788,12 @@ public class CopyFinder extends ErrorAwareTreeScanner<Boolean, TreePath> {
                 return ((BlockTree) firstLeaf.getParentPath().getLeaf()).getStatements();
             case CASE:
                 CaseTree caseTree = (CaseTree) firstLeaf.getParentPath().getLeaf();
-                if(caseTree.getStatements() != null){
+                if (caseTree.getStatements() != null) {
                     return caseTree.getStatements();
-                }else if(caseTree instanceof JCTree.JCCase){
-                    return ((JCTree.JCCase)caseTree).stats;
-                }else {
-		    return null;
+                } else if (caseTree instanceof JCTree.JCCase) {
+                    return ((JCTree.JCCase) caseTree).stats;
+                } else {
+                    return null;
                 }
             default:
                 return Collections.singletonList((StatementTree) firstLeaf.getLeaf());


### PR DESCRIPTION
The changes works for different case kinds in switch expression.
Ex: Scenario 1: Switch Statements
int k = 1;
switch(k){
   case 1 :          
         System.out.println( "one");         
         break;   
   case 2 -> System.out.println( "two");
 }
After Fix:
ink k = 1;
switch (k){  
   case 1 -> System.out.println( "one");   
  case 2 -> System.out.println( "two");
 }

To do Task:
1. Handle the Switch expression Scenario
2. Write the test cases 
3. Handle comment issues