### PR TITLE
Update projectized.xml to find the ide.css

### DIFF
--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -504,7 +504,7 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
         <!-- (XXX maybe the viewer task can automagically do this...) -->
         <mkdir dir="${build.javahelp.dir}/org/netbeans/modules/usersguide"/>
         <copy tofile="${build.javahelp.dir}/org/netbeans/modules/usersguide/ide.css"
-              file="${nb_all}/usersguide/javahelp/org/netbeans/modules/usersguide/ide.css"
+              file="${nb_all}/ide/usersguide/javahelp/org/netbeans/modules/usersguide/ide.css"
               failonerror="false"/>
         <mkdir dir="${cluster}/${javahelp.jar.dir}"/>
         <jar jarfile="${cluster}/${javahelp.jar}" compress="true">


### PR DESCRIPTION
I got a warning message saying:

[copy] Warning: Could not find file /root/NetBeansProjects/incubator-netbeans/usersguide/javahelp/org/netbeans/modules/usersguide/ide.css to copy.

Solution: changing the path of ide.css file in the template file nbbuild/templates/projectized.xml
from <copy tofile="${build.javahelp.dir}/org/netbeans/modules/usersguide/ide.css"
              file="${nb_all}/usersguide/javahelp/org/netbeans/modules/usersguide/ide.css"
              failonerror="false"/>

to 

<copy tofile="${build.javahelp.dir}/org/netbeans/modules/usersguide/ide.css"
              file="${nb_all}/ide/usersguide/javahelp/org/netbeans/modules/usersguide/ide.css"
              failonerror="false"/>