### PR TITLE
Made Gradle to be downloaded from hg.netbeans.org

### DIFF
--- a/groovy/gradle/netbeans-gradle-tooling/gradle/wrapper/gradle-wrapper.properties
+++ b/groovy/gradle/netbeans-gradle-tooling/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://netbeans.osuosl.org/binaries/2564503471E1FC18A4E7D2A120BC567EA3B26AA4-gradle-4.10.2-bin.zip


### PR DESCRIPTION
Just uploaded the gradle runtime to hg.netbeans.org. If somebody has problem to download it from it's original location.
It is possible that I could make it work with the standard NetBeans binary download mechanism, so do not merge this yet.