### PR TITLE
[NETBEANS-1458] Fix for CSS3 perspective property doesn't support pixels value

### DIFF
--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/properties/transforms_3d.properties
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/properties/transforms_3d.properties
@@ -19,7 +19,7 @@ $category=transformations_3D
 
 backface-visibility=visible | hidden 
 
-perspective=none | !number
+perspective=none | <length>
 
 perspective-origin=[ \
                     [ <percentage> | <length> | left | center | right ] \
@@ -53,6 +53,6 @@ perspective-origin=[ \
 
 @rotateZ=rotateZ ( <angle> )
 
-@perspective=perspective ( !number )
+@perspective=perspective ( <length> )
 
 transform-style=flat | preserve-3d 

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/Transforms3DTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/module/main/Transforms3DTest.java
@@ -30,14 +30,14 @@ public class Transforms3DTest extends CssModuleTestBase {
   
     public void testProperties() {
         assertPropertyValues("backface-visibility", "visible", "hidden");
-        assertPropertyValues("perspective", "none", "5");
+        assertPropertyValues("perspective", "none", "5px");
         
         assertPropertyValues("perspective-origin", "10%", "5px", "left", "center", "right");
         assertPropertyValues("perspective-origin", "10% 20px", "5px 5%", "left top", "center 10%", "left bottom");
         
         assertPropertyValues("transform", "none", "rotate(10deg)");
         
-        assertPropertyValues("transform", "rotateX(10deg)", "rotateY(2rad)");
+        assertPropertyValues("transform", "rotateX(10deg)", "rotateY(2rad)", "perspective(100px)");
     }
     
 }


### PR DESCRIPTION
Quick and easy.

Netbeans CSS parser rule for the perspective property is configured as:

none | \<number>

and for the perspective() function is configured as:

perspective(\<number>)

This appears based on [2009-03-20  W3C 3D-Transformations module CSS spec.](https://www.w3.org/TR/2009/WD-css3-3d-transforms-20090320/#perspective-property) 

In the [2013-11-26 W3C 3D-Transformations module CSS spec](https://www.w3.org/TR/2013/WD-css-transforms-1-20131126/#perspective-property) the perspective property rule was changed to:

none | \<length>

and the perspective function changed to:

perspective(\<length>)

Although Perspective didn't appear to make it past the draft stage of the 3D transform module spec, it is implemented in browsers as none | \<length> and the [W3C CSS validator](https://jigsaw.w3.org/css-validator/) accepts perspective: \<length> as valid CSS, so there is a strong argument NB should be updated to match.

To test
---------

1. Create a new PHP / HTML project with a CSS file
2. Copy and paste the following CSS:

.classA {
    perspective: 100;
    transform: perspective(100);
}

.classB {
    perspective: 100px;
    transform: perspective(100px);
}

* Before PR: NB will parse classA as valid CSS
* After PR: NB will parse classB as valid CSS

Check which one is actually valid (classB !) with W3C validator.

HTH :)
