### PR TITLE
[NETBEANS-1970] Gradle projects are not loading on java 11

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleDaemon.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleDaemon.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.gradle;
 
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
-import org.netbeans.modules.gradle.options.GradleDistributionManager;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import java.io.File;
 import org.gradle.tooling.BuildAction;
@@ -60,14 +59,11 @@ public final class GradleDaemon {
 
         @Override
         public void run() {
-            if ( GradleSettings.getDefault().isStartDaemonOnStart()
-                    && GradleDistributionManager.defaultToolingVersion().isAvailable(GradleSettings.getDefault().getGradleUserHome())) {
-                GRADLE_LOADER_RP.submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        doLoadDaemon();
-                    }
-                });
+            GradleSettings settings = GradleSettings.getDefault();
+            GradleDistributionManager dmgr = GradleDistributionManager.get(settings.getGradleUserHome());
+            if ( settings.isStartDaemonOnStart()
+                    && dmgr.defaultToolingVersion().isAvailable()) {
+                GRADLE_LOADER_RP.submit(GradleDaemon::doLoadDaemon);
             }
         }
     }

--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleDaemon.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleDaemon.java
@@ -43,7 +43,7 @@ public final class GradleDaemon {
     static final RequestProcessor GRADLE_LOADER_RP = new RequestProcessor("gradle-project-loader", 1); //NOI18N
     static final String INIT_SCRIPT_NAME = "modules/gradle/nb-tooling.gradle"; //NOI18N
     static final String TOOLING_JAR_NAME = "modules/gradle/netbeans-gradle-tooling.jar"; //NOI18N
-    
+
     public static final String PROP_TOOLING_JAR = "NETBEANS_TOOLING_JAR";
     public static final String INIT_SCRIPT = InstalledFileLocator.getDefault().locate(INIT_SCRIPT_NAME, NbGradleProject.CODENAME_BASE, false).getAbsolutePath();
     public static final String TOOLING_JAR = InstalledFileLocator.getDefault().locate(TOOLING_JAR_NAME, NbGradleProject.CODENAME_BASE, false).getAbsolutePath();
@@ -61,7 +61,7 @@ public final class GradleDaemon {
         @Override
         public void run() {
             if ( GradleSettings.getDefault().isStartDaemonOnStart()
-                    && GradleDistributionManager.isDefaultVersionAvailable()) {
+                    && GradleDistributionManager.defaultToolingVersion().isAvailable(GradleSettings.getDefault().getGradleUserHome())) {
                 GRADLE_LOADER_RP.submit(new Runnable() {
                     @Override
                     public void run() {

--- a/groovy/gradle/src/org/netbeans/modules/gradle/Installer.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/Installer.java
@@ -27,7 +27,7 @@ import org.openide.util.NbBundle.Messages;
 public final class Installer extends ModuleInstall {
 
     private static final String CONFLICTING_PROJECT = "org.netbeans.gradle.project";
-    
+
     @Override
     @Messages(
             "MSG_MODULE_CONFLICT=Gradle Projects module conflicts with the Gradle Support module.\n"
@@ -41,4 +41,5 @@ public final class Installer extends ModuleInstall {
             throw new IllegalStateException(Bundle.MSG_MODULE_CONFLICT());
         }
     }
+
 }

--- a/groovy/gradle/src/org/netbeans/modules/gradle/classpath/AbstractGradleScriptClassPath.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/classpath/AbstractGradleScriptClassPath.java
@@ -19,8 +19,8 @@
 
 package org.netbeans.modules.gradle.classpath;
 
-import org.netbeans.modules.gradle.options.GradleDistributionManager;
-import org.netbeans.modules.gradle.options.GradleDistributionManager.NbGradleVersion;
+import org.netbeans.modules.gradle.GradleDistributionManager;
+import org.netbeans.modules.gradle.GradleDistributionManager.NbGradleVersion;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
+import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.spi.java.classpath.ClassPathImplementation;
 import org.netbeans.spi.java.classpath.PathResourceImplementation;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
@@ -52,7 +53,7 @@ abstract class AbstractGradleScriptClassPath implements ClassPathImplementation 
     File distDir;
 
     public AbstractGradleScriptClassPath() {
-        distDir = GradleDistributionManager.evaluateGradleDistribution();
+        distDir = RunUtils.evaluateGradleDistribution(null, false);
 
         prefListener = new PreferenceChangeListener() {
 
@@ -67,8 +68,9 @@ abstract class AbstractGradleScriptClassPath implements ClassPathImplementation 
                                 watchedVersion.removePropertyChangeListener(propListener);
                                 watchedVersion = null;
                             }
-                            NbGradleVersion version = settings.getGradleVersion();
-                            if (!version.isAvailable(settings.getGradleUserHome())) {
+                            GradleDistributionManager gdm = GradleDistributionManager.get(settings.getGradleUserHome());
+                            NbGradleVersion version = gdm.createVersion(settings.getGradleVersion());
+                            if (!version.isAvailable()) {
                                 watchedVersion = version;
                                 watchedVersion.addPropertyChangeListener(propListener);
                             }
@@ -128,7 +130,7 @@ abstract class AbstractGradleScriptClassPath implements ClassPathImplementation 
     }
 
     private void changeDistDir() {
-        File newDistDir = GradleDistributionManager.evaluateGradleDistribution();
+        File newDistDir = RunUtils.evaluateGradleDistribution(null, false);
         if (!distDir.equals(newDistDir)) {
             distDir = newDistDir;
             resources = null;

--- a/groovy/gradle/src/org/netbeans/modules/gradle/options/GradleOptionsController.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/options/GradleOptionsController.java
@@ -19,9 +19,9 @@
 
 package org.netbeans.modules.gradle.options;
 
+import org.netbeans.modules.gradle.GradleDistributionManager;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import java.beans.PropertyChangeListener;
-import java.io.File;
 import javax.swing.JComponent;
 import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.util.HelpCtx;
@@ -50,8 +50,8 @@ public class GradleOptionsController extends OptionsPanelController {
     @Override
     public void applyChanges() {
         getPanel().applyValues();
-        File gradleUserHome = GradleSettings.getDefault().getGradleUserHome();
-        GradleSettings.getDefault().getGradleVersion().install(gradleUserHome);
+        GradleDistributionManager gdm = GradleDistributionManager.get(GradleSettings.getDefault().getGradleUserHome());
+        gdm.createVersion(GradleSettings.getDefault().getGradleVersion()).install();
     }
 
     @Override

--- a/groovy/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
@@ -19,12 +19,13 @@
 
 package org.netbeans.modules.gradle.options;
 
+import org.netbeans.modules.gradle.GradleDistributionManager;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import java.awt.CardLayout;
 import java.io.File;
 import javax.swing.JFileChooser;
 import org.netbeans.spi.options.OptionsPanelController;
-import org.netbeans.modules.gradle.options.GradleDistributionManager.NbGradleVersion;
+import org.netbeans.modules.gradle.GradleDistributionManager.NbGradleVersion;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
@@ -58,6 +59,8 @@ public class SettingsPanel extends javax.swing.JPanel {
     private static final String RESTART_ICON = "org/netbeans/modules/gradle/resources/restart.png"; //NOI18
 
     private final static String[] CARDS = {"Execution", "Appearance", "Dependencies", "Experimental"}; //NOI18N
+
+    private final GradleDistributionManager gdm = GradleDistributionManager.get(GradleSettings.getDefault().getGradleUserHome());
 
     /**
      * Creates new form SettingsPanel
@@ -582,7 +585,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_lstCategoriesValueChanged
 
     private void cbGradleVersionItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_cbGradleVersionItemStateChanged
-        NbGradleVersion v = (NbGradleVersion) evt.getItem();
+        NbGradleVersion v = gdm.createVersion(evt.getItem().toString());
         if ((v != null) && (evt.getStateChange() == ItemEvent.SELECTED)) {
             if (v.isBlackListed()) {
                 lbVersionInfo.setText("This version does not work with NetBeans!");
@@ -640,7 +643,7 @@ public class SettingsPanel extends javax.swing.JPanel {
 
             @Override
             protected List<NbGradleVersion> doInBackground() throws Exception {
-                return GradleDistributionManager.availableVersions(true);
+                return gdm.availableVersions(true);
             }
 
             @Override
@@ -664,7 +667,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     })
     public void applyValues() {
         GradleSettings settings = GradleSettings.getDefault();
-        settings.setGradleVersion((NbGradleVersion) cbGradleVersion.getSelectedItem());
+        settings.setGradleVersion(cbGradleVersion.getSelectedItem().toString());
         settings.setDistributionHome(tfUseCustomGradle.getText());
         settings.setWrapperPreferred(cbPreferWrapper.isSelected());
         boolean useCustomGradle = bgUsedDistribution.getSelection() == rbUseCustomGradle.getModel();
@@ -705,7 +708,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         GradleSettings settings = GradleSettings.getDefault();
         boolean isChanged = !settings.getDistributionHome().equals(tfUseCustomGradle.getText());
         isChanged |= settings.isWrapperPreferred() != cbPreferWrapper.isSelected();
-        isChanged |= !settings.getGradleVersion().equals(cbGradleVersion.getSelectedItem());
+        isChanged |= !settings.getGradleVersion().equals(String.valueOf(cbGradleVersion.getSelectedItem()));
 
         boolean useCustomGradle = bgUsedDistribution.getSelection() == rbUseCustomGradle.getModel();
         isChanged |= settings.useCustomGradle() != useCustomGradle;
@@ -743,7 +746,6 @@ public class SettingsPanel extends javax.swing.JPanel {
 
     private class VersionCellRenderer extends DefaultListCellRenderer {
         final ListCellRenderer delegate;
-
         public VersionCellRenderer(ListCellRenderer delegate) {
             this.delegate = delegate;
         }
@@ -759,8 +761,8 @@ public class SettingsPanel extends javax.swing.JPanel {
                 JLabel label = (JLabel) cmp;
                 label.setHorizontalAlignment(RIGHT);
                 if (value != null) {
-                    NbGradleVersion version = (NbGradleVersion) value;
-                    if (!version.isAvailable(currentGradleUserHome())) {
+                    NbGradleVersion version = gdm.createVersion(value.toString());
+                    if (!version.isAvailable()) {
                         label.setToolTipText(Bundle.NbGradleVersion_autoInstall_TXT());
                         label.setForeground(Color.gray);
                     }

--- a/groovy/gradle/src/org/netbeans/modules/gradle/queries/GradleSourceForBinary.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/queries/GradleSourceForBinary.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.queries;
 
-import org.netbeans.modules.gradle.options.GradleDistributionManager;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -27,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation;
 import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
 import org.openide.filesystems.FileObject;
@@ -56,7 +56,7 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
     public Result findSourceRoots2(URL binaryRoot) {
         Res ret = cache.get(binaryRoot);
         if (ret == null) {
-            FileObject distDir = FileUtil.toFileObject(GradleDistributionManager.evaluateGradleDistribution());
+            FileObject distDir = FileUtil.toFileObject(RunUtils.evaluateGradleDistribution(null, false));
             FileObject srcDir = distDir == null ? null : distDir.getFileObject("src"); //NOI18N
             if ((srcDir != null) && ("jar".equals(binaryRoot.getProtocol()))) {  //NOI18N
 

--- a/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
@@ -19,10 +19,9 @@
 
 package org.netbeans.modules.gradle.spi;
 
-import org.netbeans.modules.gradle.options.GradleDistributionManager;
-import org.netbeans.modules.gradle.options.GradleDistributionManager.NbGradleVersion;
 import java.io.File;
 import java.util.prefs.Preferences;
+import org.gradle.util.GradleVersion;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine.LogLevel;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine.StackTrace;
 import org.openide.util.NbBundle.Messages;
@@ -197,13 +196,12 @@ public final class GradleSettings {
         return getPreferences().getBoolean(PROP_SKIP_CHECK, true);
     }
 
-    public void setGradleVersion(NbGradleVersion version) {
-        getPreferences().put(PROP_GRADLE_VERSION, version.getVersion().getVersion());
+    public void setGradleVersion(String version) {
+        getPreferences().put(PROP_GRADLE_VERSION, version);
     }
 
-    public NbGradleVersion getGradleVersion() {
-        String ver = getPreferences().get(PROP_GRADLE_VERSION, null);
-        return ver != null ? GradleDistributionManager.createVersion(ver) : GradleDistributionManager.defaultToolingVersion();
+    public String getGradleVersion() {
+        return getPreferences().get(PROP_GRADLE_VERSION, GradleVersion.current().getVersion());
     }
 
     public void setNoRebuild(boolean b) {

--- a/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
@@ -202,7 +202,8 @@ public final class GradleSettings {
     }
 
     public NbGradleVersion getGradleVersion() {
-        return GradleDistributionManager.createVersion(getPreferences().get(PROP_GRADLE_VERSION, GradleDistributionManager.defaultToolingVersion()));
+        String ver = getPreferences().get(PROP_GRADLE_VERSION, null);
+        return ver != null ? GradleDistributionManager.createVersion(ver) : GradleDistributionManager.defaultToolingVersion();
     }
 
     public void setNoRebuild(boolean b) {


### PR DESCRIPTION
Well this set of patches makes Gradle project evaluation work on Java 11 even when the Gradle wrapper is below this version, by silently ignore the wrapper specified distribution for loading the project.

Also it contains the refactor of the GradleDistributionManager making it a real class instead of a bunch of utility functions. Now it takes the gradle user home to create one. Though, right now the plugin does not support switching between gradle user home directories, this refactor is one step further to that support.

Removed the automatic install of Gradle from the startup.

Filed leaking private internals through GradleSettings as getVersion() returned a module private NbGradleVersion type.