### PR TITLE
Some more fixes for the Language Server Protocol client:

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
@@ -34,7 +34,10 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.TextDocumentSyncOptions;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.netbeans.api.editor.EditorRegistry;
 import org.netbeans.editor.BaseDocumentEvent;
 import org.netbeans.modules.editor.*;
@@ -133,20 +136,50 @@ public class TextDocumentSyncServerCapabilityHandler {
                         }
                         Position endPos = new Position(startPos.getLine() + additionalLines,
                                                        startPos.getCharacter() + additionalChars);
-                        TextDocumentContentChangeEvent event;
-                        event = new TextDocumentContentChangeEvent(new Range(startPos,
+                        TextDocumentContentChangeEvent[] event = new TextDocumentContentChangeEvent[1];
+                        event[0] = new TextDocumentContentChangeEvent(new Range(startPos,
                                                                              endPos),
                                                                    oldText.length(),
                                                                    newText);
-                        VersionedTextDocumentIdentifier di = new VersionedTextDocumentIdentifier(++version);
-                        di.setUri(org.netbeans.modules.lsp.client.Utils.toURI(file));
-                        DidChangeTextDocumentParams params = new DidChangeTextDocumentParams(di, Arrays.asList(event));
 
                         WORKER.post(() -> {
                             LSPBindings server = LSPBindings.getBindings(file);
 
                             if (server == null)
                                 return ; //ignore
+
+                            TextDocumentSyncKind syncKind = TextDocumentSyncKind.None;
+                            Either<TextDocumentSyncKind, TextDocumentSyncOptions> sync = server.getInitResult().getCapabilities().getTextDocumentSync();
+                            if (sync != null) {
+                                if (sync.isLeft()) {
+                                    syncKind = sync.getLeft();
+                                } else {
+                                    TextDocumentSyncKind change = sync.getRight().getChange();
+                                    if (change != null)
+                                        syncKind = change;
+                                }
+                            }
+                            switch (syncKind) {
+                                case None:
+                                    return ;
+                                case Full:
+                                    doc.render(() -> {
+                                        try {
+                                            event[0] = new TextDocumentContentChangeEvent(doc.getText(0, doc.getLength()));
+                                        } catch (BadLocationException ex) {
+                                            Exceptions.printStackTrace(ex);
+                                            event[0] = new TextDocumentContentChangeEvent("");
+                                        }
+                                    });
+                                    break;
+                                case Incremental:
+                                    //event already filled
+                                    break;
+                            }
+
+                            VersionedTextDocumentIdentifier di = new VersionedTextDocumentIdentifier(++version);
+                            di.setUri(org.netbeans.modules.lsp.client.Utils.toURI(file));
+                            DidChangeTextDocumentParams params = new DidChangeTextDocumentParams(di, Arrays.asList(event));
 
                             server.getTextDocumentService().didChange(params);
                             server.scheduleBackgroundTasks(file);


### PR DESCRIPTION
-following TextDocumentSyncKind requestes
-sending client configuration also when connecting to a server manually
-prevent NPE when closing IDE when a server is configured manually