### PR TITLE
[NETBEANS-2022]:Updation for external nb-javac jar in libs.javacapi a…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -2162,8 +2162,8 @@ public class CasualDiff {
     }
 
     protected int diffBreak(JCBreak oldT, JCBreak newT, int[] bounds) {
-        final Name oldTLabel = oldT.label;
-        final Name newTlabel = newT.label;
+        final Name oldTLabel = oldT.getLabel();
+        final Name newTlabel = newT.getLabel();
         return printBreakContinueTree(bounds, oldTLabel, newTlabel, oldT);
     }
 

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
@@ -90,7 +90,7 @@ public class NBClassWriterTest extends NbTestCase {
 
         Context context = new Context();
         NBMessager.preRegister(context, null, DEV_NULL, DEV_NULL, DEV_NULL);
-        final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-bootclasspath",  bootPath, "-source", "1.6", "-target", "1.6"), null, Arrays.asList(new MyFileObject(code)), context);
+        final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-bootclasspath",  bootPath, "-source", "1.7", "-target", "1.7"), null, Arrays.asList(new MyFileObject(code)), context);
 
         NBClassReader.preRegister(ct.getContext());
         NBClassWriter.preRegister(ct.getContext());

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-5315CCC2626F13C8EB620D21EF25C2501BD2D6AF nb-javac-9-api.jar
+A318D725959B3F102B53BA249F3C35C0F68B1E3D nb-javac-12-api.jar

--- a/java/libs.javacapi/external/nb-javac-12-api-license.txt
+++ b/java/libs.javacapi/external/nb-javac-12-api-license.txt
@@ -1,9 +1,9 @@
 Name: Javac Compiler API
 Description: Javac Compiler API
-Version: 9
+Version: 12
 License: GPL-2-CP
 Origin: OpenJDK (http://hg.openjdk.java.net/)
-Source: http://hg.netbeans.org/main/nb-javac/
+Source: http://hg.netbeans.org/main/nb-java-x/
 Type: compile-time,optional
 Comment: Used at design time to compile against; optional at runtime.
 

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -41,7 +41,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-9-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-12-api.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.javacimpl/external/binaries-list
+++ b/java/libs.javacimpl/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F5ABB7CA56096B881173E987AC62F13C9DB7A64D nb-javac-9-impl.jar
+48EF66E1C3EABC275295D2E09CD442B4DE13A816 nb-javac-12-impl.jar

--- a/java/libs.javacimpl/external/nb-javac-12-impl-license.txt
+++ b/java/libs.javacimpl/external/nb-javac-12-impl-license.txt
@@ -1,9 +1,9 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 9
+Version: 12
 License: GPL-2-CP
 Origin: OpenJDK (http://hg.openjdk.java.net/)
-Source: http://hg.netbeans.org/main/nb-javac/
+Source: http://hg.netbeans.org/main/nb-java-x/
 Type: compile-time,optional
 Comment: Used at compile and design time to compile against; optional at runtime.
 

--- a/java/libs.javacimpl/nbproject/project.xml
+++ b/java/libs.javacimpl/nbproject/project.xml
@@ -37,7 +37,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-9-impl.jar</binary-origin>
+                <binary-origin>external/nb-javac-12-impl.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
@@ -69,7 +69,7 @@ public class JackpotTrees {
                 Method visitIdent = Visitor.class.getDeclaredMethod("visitIdent", JCIdent.class);
                 Method visitIdentifier = TreeVisitor.class.getDeclaredMethod("visitIdentifier", IdentifierTree.class, Object.class);
                 Method toString = Object.class.getDeclaredMethod("toString");
-                fake = new ByteBuddy()
+                fake = Utilities.load(new ByteBuddy()
                         .subclass(clazz)
                         .implement(IdentifierTree.class)
                         .defineField("ident", Name.class, Visibility.PUBLIC)
@@ -79,8 +79,7 @@ public class JackpotTrees {
                         .method(ElementMatchers.named("accept").and(ElementMatchers.takesArguments(Visitor.class))).intercept(MethodCall.invoke(visitIdent).onArgument(0).withField("jcIdent"))
                         .method(ElementMatchers.named("accept").and(ElementMatchers.takesArgument(0, TreeVisitor.class))).intercept(MethodCall.invoke(visitIdentifier).onArgument(0).withThis().withArgument(1))
                         .method(ElementMatchers.named("toString")).intercept(MethodCall.invoke(toString).onField("ident"))
-                        .make()
-                        .load(JackpotTrees.class.getClassLoader())
+                        .make())
                         .getLoaded();
                 baseClass2Impl.put(clazz, fake);
             }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -92,9 +92,14 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.CharBuffer;
 import java.util.Arrays;
@@ -130,6 +135,12 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType.Loaded;
+import net.bytebuddy.dynamic.DynamicType.Unloaded;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodCall;
+import net.bytebuddy.matcher.ElementMatchers;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -162,6 +173,7 @@ import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbCollections;
 import org.openide.util.WeakListeners;
@@ -365,7 +377,7 @@ public class Utilities {
             patternTree = ((SwitchTree) switchTree).getCases().get(0);
         }
 
-        if (patternTree == null || isErrorTree(patternTree)) {
+        if (patternTree == null || isErrorTree(patternTree) || "SWITCH_EXPRESSION".equals(patternTree.getKind().name())) {
             SourcePositions[] currentPatternTreePositions = new SourcePositions[1];
             List<Diagnostic<? extends JavaFileObject>> currentPatternTreeErrors = new LinkedList<Diagnostic<? extends JavaFileObject>>();
             Tree currentPatternTree = parseStatement(c, "{" + pattern + "}", currentPatternTreePositions, currentPatternTreeErrors);
@@ -581,7 +593,7 @@ public class Utilities {
             ParserFactory factory = ParserFactory.instance(context);
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
-            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
+            Parser parser = newParser(context, (NBParserFactory) factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
             if (parser instanceof JavacParser) {
                 if (pos != null)
                     pos[0] = new ParserSourcePositions((JavacParser)parser);
@@ -611,7 +623,7 @@ public class Utilities {
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
             Scanner scanner = scannerFactory.newScanner(buf, false);
-            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scanner, false, false, CancelService.instance(context), names);
+            Parser parser = newParser(context, (NBParserFactory) factory, scanner, false, false, CancelService.instance(context), names);
             if (parser instanceof JavacParser) {
                 if (pos != null)
                     pos[0] = new ParserSourcePositions((JavacParser)parser);
@@ -1272,9 +1284,49 @@ public class Utilities {
         }
     }
 
+    private static Class<?> parserClass;
+    private static synchronized Parser newParser(Context ctx, NBParserFactory fac,
+                                                 Lexer S, boolean keepDocComments,
+                                                 boolean keepLineMap, CancelService cancelService,
+                                                 Names names) {
+        try {
+            if (parserClass == null) {
+                Method switchBlockStatementGroup = JavacParser.class.getDeclaredMethod("switchBlockStatementGroup");
+                Method delegate;
+                if (switchBlockStatementGroup.getReturnType().equals(com.sun.tools.javac.util.List.class)) {
+                    delegate = JackpotJavacParser.class.getDeclaredMethod("switchBlockStatementGroupListImpl");
+                } else {
+                    delegate = JackpotJavacParser.class.getDeclaredMethod("switchBlockStatementGroupImpl");
+                }
+                parserClass = load(new ByteBuddy()
+                                    .subclass(JackpotJavacParser.class)
+                                    .method(ElementMatchers.named("switchBlockStatementGroup")).intercept(MethodCall.invoke(delegate))
+                                    .make())
+                            .getLoaded();
+            }
+            return (Parser) parserClass.getConstructor(Context.class, NBParserFactory.class, Lexer.class, boolean.class, boolean.class, CancelService.class, Names.class)
+                    .newInstance(ctx, fac, S, keepDocComments, keepLineMap, cancelService, names);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static <T> Loaded<T> load(Unloaded<T> unloaded) {
+        ClassLoadingStrategy<ClassLoader> strategy;
+
+        try {
+            strategy = ClassLoadingStrategy.UsingLookup.of(MethodHandles.lookup());
+        } catch (IllegalStateException ex) {
+            strategy = new ClassLoadingStrategy.ForUnsafeInjection();
+        }
+
+        return unloaded.load(JackpotTrees.class.getClassLoader(), strategy);
+    }
+
     private static class JackpotJavacParser extends NBJavacParser {
 
         private final Context ctx;
+        private final com.sun.tools.javac.tree.TreeMaker make;
         private final com.sun.tools.javac.util.Name dollar;
         public JackpotJavacParser(Context ctx, NBParserFactory fac,
                          Lexer S,
@@ -1284,6 +1336,7 @@ public class Utilities {
                          Names names) {
             super(fac, S, keepDocComments, keepLineMap, true, false, cancelService);
             this.ctx = ctx;
+            this.make = com.sun.tools.javac.tree.TreeMaker.instance(ctx);
             this.dollar = names.fromString("$");
         }
 
@@ -1394,8 +1447,7 @@ public class Utilities {
             return super.checkExprStat(t);
         }
 
-        @Override
-        protected JCCase switchBlockStatementGroup() {
+        protected JCCase switchBlockStatementGroupImpl() throws Throwable {
             if (token.kind == TokenKind.CASE) {
                 Token peeked = S.token(1);
 
@@ -1419,9 +1471,40 @@ public class Utilities {
                 }
             }
 
-            return super.switchBlockStatementGroup();
+            return (JCCase) MethodHandles.lookup()
+                                         .findSpecial(NBJavacParser.class, "switchBlockStatementGroup", MethodType.methodType(JCCase.class), JackpotJavacParser.class)
+                                         .invoke(this);
         }
 
+        protected com.sun.tools.javac.util.List<JCCase> switchBlockStatementGroupListImpl() throws Throwable {
+            if (token.kind == TokenKind.CASE) {
+                Token peeked = S.token(1);
+
+                if (peeked.kind == TokenKind.IDENTIFIER) {
+                    String ident = peeked.name().toString();
+
+                    if (ident.startsWith("$") && ident.endsWith("$")) {
+                        nextToken();
+
+                        int pos = token.pos;
+                        com.sun.tools.javac.util.Name name = token.name();
+
+                        nextToken();
+
+                        if (token.kind == TokenKind.SEMI) {
+                            nextToken();
+                        }
+
+                        Class caseKind = Class.forName("com.sun.source.tree.CaseTree$CaseKind", false, JCCase.class.getClassLoader());
+                        return com.sun.tools.javac.util.List.of(JackpotTrees.createInstance(ctx, JCCase.class, name, make.Ident(name), new Class[] {caseKind, com.sun.tools.javac.util.List.class, com.sun.tools.javac.util.List.class, JCTree.class}, new Object[] {Enum.valueOf(caseKind, "STATEMENT"), com.sun.tools.javac.util.List.nil(), com.sun.tools.javac.util.List.nil(), null}));
+                    }
+                }
+            }
+
+            return (com.sun.tools.javac.util.List) MethodHandles.lookup()
+                                                                .findSpecial(NBJavacParser.class, "switchBlockStatementGroup", MethodType.methodType(com.sun.tools.javac.util.List.class), JackpotJavacParser.class)
+                                                                .invoke(this);
+        }
 
         @Override
         protected JCTree resource() {

--- a/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
@@ -511,9 +511,12 @@ public class UtilitiesTest extends TestBase {
         assertTrue(result.getKind().name(), result.getKind() == Kind.VARIABLE);
 
         ModifiersTree mods = ((VariableTree) result).getModifiers();
-        String golden = "$mods$,@Deprecated(), [public]";
+        String golden1 = "$mods$,@Deprecated(), [public]";
+        String golden2 = "$mods$,@Deprecated, [public]";
+        String actual = mods.getAnnotations().toString() + ", " + mods.getFlags().toString();
         
-        assertEquals(golden.replaceAll("[ \n\r]+", " "), mods.getAnnotations().toString() + ", " + mods.getFlags().toString());
+        if (!golden1.equals(actual) && !golden2.equals(actual))
+            assertEquals(golden1, actual);
     }
     
     public void testBrokenPlatform226678() throws Exception {

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -174,7 +174,7 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
         <property name="locmakenbm.brands" value="${brandings}"/>
         <!-- When requires.nb.javac property is true, prepend javac-api and javac-impl on bootclasspath to allow override the default annotation
              processing API located in rt.jar. -->
-        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-9-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-9-impl.jar" />
+        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-12-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-12-impl.jar" />
         <property name="bootclasspath.prepend.vanilla" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar${path.separator}${nb_all}/nbbuild/external/vanilla-javac-impl.jar" />
         <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
             <istrue value="${requires.nb.javac.impl}"/>


### PR DESCRIPTION
…nd libs.javaimpl modules with nb-javac jar for jdk-12

Changes:
1. Added support for downloading new ext nb-javac jars for jdk-12 (nb-javac-12-api.jar and nb-javac-12-impl.jar)
2. changed the corresponding license files
To-Do :
Below Test-Cases failure issues were also fixed which will be caused due to nb-javac upgrade
a. https://issues.apache.org/jira/browse/NETBEANS-2019
b. https://issues.apache.org/jira/browse/NETBEANS-2020
c. https://issues.apache.org/jira/browse/NETBEANS-2021