### PR TITLE
Updating Graal.js and co. to RC12

### DIFF
--- a/ide/libs.graalsdk/external/binaries-list
+++ b/ide/libs.graalsdk/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-12900D233D14F6382DD15C6481763777C56BF183 org.graalvm.sdk:graal-sdk:1.0.0-rc10
+0E1CCE754C9EF8847B473FAB3F848D1FE324F09E org.graalvm.sdk:graal-sdk:1.0.0-rc12

--- a/ide/libs.graalsdk/external/graal-sdk-1.0.0-license.txt
+++ b/ide/libs.graalsdk/external/graal-sdk-1.0.0-license.txt
@@ -3,7 +3,7 @@ Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
 Version: 1.0
-Files: graal-sdk-1.0.0-rc10.jar
+Files: graal-sdk-1.0.0-rc12.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/ide/libs.graalsdk/nbproject/project.properties
+++ b/ide/libs.graalsdk/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/graal-sdk-1.0.0-rc10.jar=modules/ext/graal-sdk-1.0.0-rc10.jar
+release.external/graal-sdk-1.0.0-rc12.jar=modules/ext/graal-sdk-1.0.0-rc12.jar
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/libs.graalsdk/nbproject/project.xml
+++ b/ide/libs.graalsdk/nbproject/project.xml
@@ -78,8 +78,8 @@
                 <package>org.netbeans.libs.graalsdk</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/graal-sdk-1.0.0-rc10.jar</runtime-relative-path>
-                <binary-origin>external/graal-sdk-1.0.0-rc10.jar</binary-origin>
+                <runtime-relative-path>ext/graal-sdk-1.0.0-rc12.jar</runtime-relative-path>
+                <binary-origin>external/graal-sdk-1.0.0-rc12.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/GraalEnginesTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/GraalEnginesTest.java
@@ -70,7 +70,7 @@ public final class GraalEnginesTest {
                 .append("\nnames: ").append(engineNames)
                 .append("\ntypes: ").append(types);
 
-            if (engineNames.contains("llvm")) {
+            if (engineNames.contains("LLVM")) {
                 llvmFactory = factory;
             }
             if (types.contains("text/javascript")) {

--- a/nbbuild/travis/scripting.sh
+++ b/nbbuild/travis/scripting.sh
@@ -20,8 +20,8 @@
 set -e
 
 if [ -z "$GRAALVM" ]; then
-  BASE=graalvm-ce-1.0.0-rc10
-  URL=https://github.com/oracle/graal/releases/download/vm-1.0.0-rc10/$BASE-linux-amd64.tar.gz
+  BASE=graalvm-ce-1.0.0-rc12
+  URL=https://github.com/oracle/graal/releases/download/vm-1.0.0-rc12/$BASE-linux-amd64.tar.gz
   curl -L $URL --output graalvm.tgz
   tar fxz graalvm.tgz
   GRAALVM=`pwd`/$BASE

--- a/nbbuild/travis/scripting.sh
+++ b/nbbuild/travis/scripting.sh
@@ -41,8 +41,5 @@ $GRAALVM/bin/gu install R
 JAVA_HOME=$GRAALVM ant -f platform/api.scripting/build.xml test
 JAVA_HOME=$GRAALVM ant -f ide/libs.graalsdk/build.xml test
 
-# currently broken. fixed by
-# https://github.com/oracle/graal/commit/4c217f2b2fba77c55d05c7aa3654e13c215b5ddb
-# which is likely to appear in GraalVM RC12
-JAVA_HOME=$GRAALVM ant -f webcommon/libs.graaljs/build.xml test || echo "==== Expected failure ===="
+JAVA_HOME=$GRAALVM ant -f webcommon/libs.graaljs/build.xml test
 

--- a/webcommon/libs.graaljs/external/binaries-list
+++ b/webcommon/libs.graaljs/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-36E95FC415035174626479AFA64D145088ED512F org.graalvm.js:js:1.0.0-rc10
-E9D20C2841577D83B6DE44ADD90BD201E2A9134D org.graalvm.regex:regex:1.0.0-rc10
+F1AAEE616CB62866C0C22CA26C8FDD93A7D3E0F8 org.graalvm.js:js:1.0.0-rc12
+FA1A582E348CEED1B0C5F3C0171E2156DAAB5486 org.graalvm.regex:regex:1.0.0-rc12

--- a/webcommon/libs.graaljs/external/js-1.0.0-license.txt
+++ b/webcommon/libs.graaljs/external/js-1.0.0-license.txt
@@ -3,7 +3,7 @@ Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
 Version: 1.0
-Files: js-1.0.0-rc10.jar regex-1.0.0-rc10.jar
+Files: js-1.0.0-rc12.jar regex-1.0.0-rc12.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.graaljs/nbproject/project.properties
+++ b/webcommon/libs.graaljs/nbproject/project.properties
@@ -19,5 +19,5 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/js-1.0.0-rc10.jar=modules/ext/js-1.0.0-rc10.jar
-release.external/regex-1.0.0-rc10.jar=modules/ext/regex-1.0.0-rc10.jar
+release.external/js-1.0.0-rc12.jar=modules/ext/js-1.0.0-rc12.jar
+release.external/regex-1.0.0-rc12.jar=modules/ext/regex-1.0.0-rc12.jar

--- a/webcommon/libs.graaljs/nbproject/project.xml
+++ b/webcommon/libs.graaljs/nbproject/project.xml
@@ -60,12 +60,12 @@
                 <package>com.oracle.js.parser.ir</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/js-1.0.0-rc10.jar</runtime-relative-path>
-                <binary-origin>external/js-1.0.0-rc10.jar</binary-origin>
+                <runtime-relative-path>ext/js-1.0.0-rc12.jar</runtime-relative-path>
+                <binary-origin>external/js-1.0.0-rc12.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/regex-1.0.0-rc10.jar</runtime-relative-path>
-                <binary-origin>external/regex-1.0.0-rc10.jar</binary-origin>
+                <runtime-relative-path>ext/regex-1.0.0-rc12.jar</runtime-relative-path>
+                <binary-origin>external/regex-1.0.0-rc12.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/webcommon/libs.truffleapi/external/binaries-list
+++ b/webcommon/libs.truffleapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8F158287A04DC01E8137FEFC8AB949421C8E21A2 org.graalvm.truffle:truffle-api:1.0.0-rc10
+3B67206816378D4BABE37009C78A5BD429C560E1 org.graalvm.truffle:truffle-api:1.0.0-rc12

--- a/webcommon/libs.truffleapi/external/truffle-api-1.0.0-license.txt
+++ b/webcommon/libs.truffleapi/external/truffle-api-1.0.0-license.txt
@@ -3,7 +3,7 @@ Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
 Version: 1.0
-Files: truffle-api-1.0.0-rc10.jar
+Files: truffle-api-1.0.0-rc12.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.truffleapi/nbproject/project.properties
+++ b/webcommon/libs.truffleapi/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/truffle-api-1.0.0-rc10.jar=modules/ext/truffle-api-1.0.0-rc10.jar
+release.external/truffle-api-1.0.0-rc12.jar=modules/ext/truffle-api-1.0.0-rc12.jar

--- a/webcommon/libs.truffleapi/nbproject/project.xml
+++ b/webcommon/libs.truffleapi/nbproject/project.xml
@@ -40,8 +40,8 @@
                 <package>com.oracle.truffle.api.utilities</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/truffle-api-1.0.0-rc10.jar</runtime-relative-path>
-                <binary-origin>external/truffle-api-1.0.0-rc10.jar</binary-origin>
+                <runtime-relative-path>ext/truffle-api-1.0.0-rc12.jar</runtime-relative-path>
+                <binary-origin>external/truffle-api-1.0.0-rc12.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Essential fixes to make NetBeans work with Graal.js got into RC12 - hence we can update the dependencies and uncomment the test on GraalVM RC12. Once these updates are in the work on #1092 can continue, as the RC12 version of Graal.js fixes the flaw discovered by @jlahoda.