### PR TITLE
[NETBEANS-1251] nb-javac 11 testcase failure : Compound var declaration

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarCompDeclaration.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarCompDeclaration.java
@@ -123,6 +123,10 @@ public class VarCompDeclaration implements ErrorRule<Void> {
             int pos = statements.indexOf(statementPath.getLeaf());
             List<StatementTree> newStatements = new ArrayList<>();
             if (pos > 0) {
+                if(info.getTreeUtilities().isPartOfCompoundVariableDeclaration(statements.get(pos - 1))
+                        && !info.getTreeUtilities().isEndOfCompoundVariableDeclaration(statements.get(pos - 1))){
+                    pos--;
+                }
                 newStatements.addAll(statements.subList(0, pos));
             }
 

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarCompDeclarationTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarCompDeclarationTest.java
@@ -68,7 +68,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "package test; \n" +
                        "public class Test {\n" +
                        "    private void test() { \n" +
-                       "        var v = 1, /*comment*/ v1 = 10;\n" +
+                       "        var v = 1, v1 = 10, v2 = 100;\n" +
                        "    } \n" +
                        "}",
                        -1,
@@ -76,8 +76,9 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        ("package test; \n" +
                        "public class Test {\n" +
                        "    private void test() { \n" +
-                       "        var v = 1; /*comment*/ \n" +
+                       "        var v = 1;\n" +
                        "        var v1 = 10;\n" +
+                       "        var v2 = 100;\n" +
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
@@ -259,6 +260,25 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "}").replaceAll("[\\s]+", " "));
     }
     
+    public void testCase11() throws Exception {
+        performFixTest("test/Test.java",
+                       "package test; \n" +
+                       "public class Test {\n" +
+                       "    private void test() { \n" +
+                       "        var v = {1, 2}, w = 2;\n" +
+                       "    } \n" +
+                       "}",
+                       -1,
+                       NbBundle.getMessage(VarCompDeclarationTest.class, "FIX_VarCompDeclaration"),
+                       ("package test; \n" +
+                       "public class Test {\n" +
+                       "    private void test() { \n" +
+                       "        var v = {1, 2};\n" +
+                       "        var w = 2;\n" +
+                       "    } \n" +
+                       "}").replaceAll("[\\s]+", " "));
+    }
+
     @Override
     protected List<Fix> computeFixes(CompilationInfo info, int pos, TreePath path) throws Exception {
         return new VarCompDeclaration().run(info, null, pos, path, null);

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsTestBase.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsTestBase.java
@@ -337,6 +337,7 @@ public abstract class ErrorHintsTestBase extends NbTestCase {
             if (d.getKind() == Diagnostic.Kind.ERROR && (supportedErrorKeys == null || supportedErrorKeys.contains(d.getCode()))) {
                 if (found == null) {
                     found = d;
+                } else if (found.getCode().equals(d.getCode())) {
                 } else {
                     throw new IllegalStateException("More than one error: " + diagnosticsToString(info.getDiagnostics()));
                 }
@@ -345,7 +346,7 @@ public abstract class ErrorHintsTestBase extends NbTestCase {
         if (found == null) {
             throw new IllegalStateException("No error found: " + diagnosticsToString(info.getDiagnostics()));
         }
-        
+
         return found;
     }
     


### PR DESCRIPTION
The PR fixed the following test cases failures after changes in position of trees in compound var declaration:
[junit] Testcase: testVarCompoundDeclaration1(org.netbeans.api.java.source.gen.VarCompoundDeclarationTest): FAILED
[junit] Testcase: testVarCompoundDeclaration2(org.netbeans.api.java.source.gen.VarCompoundDeclarationTest): FAILED
[junit] Testcase: testVarCompoundDeclaration3(org.netbeans.api.java.source.gen.VarCompoundDeclarationTest): FAILED
[junit] Testcase: testVarCompoundDeclaration4(org.netbeans.api.java.source.gen.VarCompoundDeclarationTest): FAILED

[junit] Testcase: testCase1(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase2(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase3(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase5(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase6(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase7(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase8(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase9(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
[junit] Testcase: testCase10(org.netbeans.modules.java.hints.errors.VarCompDeclarationTest): FAILED
 
