### PR TITLE
[NETBEANS-2121] Updated dependency version on our Java EE support modules.

### DIFF
--- a/groovy/gradle.persistence/nbproject/project.xml
+++ b/groovy/gradle.persistence/nbproject/project.xml
@@ -56,7 +56,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>1.32.1</specification-version>
+                        <specification-version>1.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -65,7 +65,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.5</specification-version>
+                        <specification-version>1.40.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/GradlePersistenceProvider.java
+++ b/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/GradlePersistenceProvider.java
@@ -72,7 +72,7 @@ public class GradlePersistenceProvider implements PersistenceLocationProvider,
     final Project project;
 
     /**
-     * Creates a new instance of MavenPersistenceProvider
+     * Creates a new instance of GradlePersistenceProvider
      */
     public GradlePersistenceProvider(Project proj, Lookup lkp) {
         this.project = proj;

--- a/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceLocationProviderImpl.java
+++ b/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceLocationProviderImpl.java
@@ -71,7 +71,7 @@ public class PersistenceLocationProviderImpl implements PersistenceLocationProvi
     }
 
     /**
-     * creates a new persistence location using the maven resource folder ->
+     * creates a new persistence location using the Gradle resource folder ->
      * /src/main/resources/META-INF
      *
      * @return the newly created FileObject the location (eg. parent folder) of
@@ -103,7 +103,7 @@ public class PersistenceLocationProviderImpl implements PersistenceLocationProvi
     }
 
     /**
-     * Protected method used by MavenPersistenceSupport to create a file
+     * Protected method used by GradlePersistenceSupport to create a file
      * listener
      *
      * @return property access to the current persistence.xml file

--- a/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceScopeImpl.java
+++ b/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceScopeImpl.java
@@ -31,7 +31,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
 /**
- * Maven2 Implementation of <CODE>org.netbeans.modules.j2ee.persistence.spi.PersistenceScopeImplementation</CODE>
+ * Gradle Implementation of <CODE>org.netbeans.modules.j2ee.persistence.spi.PersistenceScopeImplementation</CODE>
  *
  * @author Daniel Mohni
  */

--- a/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceScopeProviderImpl.java
+++ b/groovy/gradle.persistence/src/org/netbeans/modules/gradle/persistence/PersistenceScopeProviderImpl.java
@@ -30,7 +30,7 @@ import org.openide.filesystems.FileObject;
 
 
 /**
- * Maven2 Implementation of 
+ * Gradle Implementation of 
  * <CODE>org.netbeans.modules.j2ee.persistence.spi.PersistenceScopeProvider</CODE> 
  * @author Daniel Mohni
  */


### PR DESCRIPTION
The module we are depending on is org.netbeans.modules.j2ee.persistenceapi has a version 1.40.0 it has the include implementation version checkbox ticked in and its implementation version is 1.
Shall I mark the dependency as 1.40.0.1 instead?
Telling the truth I could not reproduce the CNFE locally, but I just have one project where I can test this an it works there.

The other part of the commit is just Maven -> Gradle renames.