### PR TITLE
[NETBEANS-1995] Exclude extra cluster when generating LICENSE file

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -79,6 +79,7 @@
             <include name="platform/javahelp/external/binaries-list"/>
         </manifest>
     </downloadbinaries>
+    <property name="nb-extra-files" value="test/**,extra/**"/>
 
     <echo message="Bootstrapping NetBeans-specific Ant extensions..."/>
     <path id="bootstrap-cp">
@@ -442,8 +443,6 @@ Hg ID:    ${hg.id}
     <delete file="NetBeans-${buildnum}-build-extra-data.zip"/>
     <delete file="NetBeans-${buildnum}-javadoc-web.zip"/> <!-- XXX why? -->
     <delete file="NetBeans-${buildnum}-javadoc.zip"/> <!-- XXX why? -->
-
-    <property name="nb-extra-files" value="test/**,extra/**"/>
 
     <antcall target="zip-cluster-config" inheritall="true"/>
   </target>
@@ -1568,7 +1567,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
         
         <delete dir="${netbeans.dest.dir}/licenses" />
         <mkdir dir="${netbeans.dest.dir}/licenses" />
-        
+
         <createlicensesummary licenseStub="${nb_all}/LICENSE" 
                               noticeStub="notice-stub.txt" 
                               report="${nb.build.dir}/createlicensesummary.xml" 
@@ -1578,6 +1577,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
                               licenseTargetDir="${netbeans.dest.dir}/licenses"
                               notice="${nb.build.dir}/notice-temp"
                               binary="true"
+                              excludes="${nb-extra-files}"
         />
         
         <concat destfile="${netbeans.dest.dir}/NOTICE">

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -79,6 +79,12 @@
             <include name="platform/javahelp/external/binaries-list"/>
         </manifest>
     </downloadbinaries>
+    <!--
+    nb-extra-files denotes directories/files, that are not packed for
+    distribution. The clusters are only used for local development/testing.
+    The files must not be included in distribution zip and also need to be
+    excluded from license analysis
+    -->
     <property name="nb-extra-files" value="test/**,extra/**"/>
 
     <echo message="Bootstrapping NetBeans-specific Ant extensions..."/>


### PR DESCRIPTION
According to [NETBEANS-1995](https://issues.apache.org/jira/browse/NETBEANS-1995) report the `LICENSE` file contains references to files from `extra` cluster. However that one isn't included in the final ZIP. As such there is no need to include those files in the NOTICE file.

Adjusting the build tasks and scripts to exclude `extra/**` files.