### PR TITLE
[NETBEANS-2125] Enable Oracle JS Parser to be installed with Java EE

### DIFF
--- a/ergonomics/ide.ergonomics/enterprise.properties
+++ b/ergonomics/ide.ergonomics/enterprise.properties
@@ -22,3 +22,6 @@ project.xpath.nbproject/project.xml=\
 project.xpath.src/main/webapp=
 
 mainModule=org.netbeans.modules.j2ee.kit
+
+extra.modules=org.netbeans.libs.oracle.jsparser
+LBL_Ergonomics_Extra_Required=Javascript Parser is required by HTML5 features.


### PR DESCRIPTION
Tried @JaroslavTulach instructions in https://issues.apache.org/jira/browse/NETBEANS-2125, and it works, so here it is.