### PR TITLE
[NETBEANS-2182] Display correct licence (Oracle / Eclipse Foundation) depending on version of GlassFish to download

### DIFF
--- a/enterprise/glassfish.common/manifest.mf
+++ b/enterprise/glassfish.common/manifest.mf
@@ -4,6 +4,6 @@ OpenIDE-Module: org.netbeans.modules.glassfish.common/0
 OpenIDE-Module-Install: org/netbeans/modules/glassfish/common/Installer.class
 OpenIDE-Module-Layer: org/netbeans/modules/glassfish/common/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/glassfish/common/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.76
+OpenIDE-Module-Specification-Version: 1.77
 OpenIDE-Module-Provides: org.netbeans.modules.glassfish.common
 

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
@@ -156,6 +156,7 @@ STR_41_SERVER_NAME=GlassFish Server 4.1
 STR_411_SERVER_NAME=GlassFish Server 4.1.1
 STR_412_SERVER_NAME=GlassFish Server 4.1.2
 STR_50_SERVER_NAME=GlassFish Server 5.0
+STR_51_SERVER_NAME=GlassFish Server 5.1
 
 # CommonServerSupport.java
 MSG_FLAKEY_NETWORK=<html>Network communication problem<br/>Could not establish \

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -164,6 +164,16 @@ public enum ServerDetails {
         500,
         "https://download.oracle.com/glassfish/5.0/release/glassfish-5.0.zip", // NOI18N
         "https://download.oracle.com/glassfish/5.0/release/glassfish-5.0.zip" // NOI18N
+    ),
+    
+    /**
+     * details for an instance of GlassFish Server 5
+     */
+    GLASSFISH_SERVER_5_1(NbBundle.getMessage(ServerDetails.class, "STR_51_SERVER_NAME", new Object[]{}), // NOI18N
+        "deployer:gfv3ee6wc", // NOI18N
+        500,
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip" // NOI18N
     );
 
     /**
@@ -175,6 +185,7 @@ public enum ServerDetails {
     public static WizardDescriptor.InstantiatingIterator
             getInstantiatingIterator() {
         return new ServerWizardIterator(new ServerDetails[]{
+                    GLASSFISH_SERVER_5_1,
                     GLASSFISH_SERVER_5_0,
                     GLASSFISH_SERVER_4_1_2,
                     GLASSFISH_SERVER_4_1_1,
@@ -188,12 +199,12 @@ public enum ServerDetails {
                     GLASSFISH_SERVER_3_0_1,
                     GLASSFISH_SERVER_3,},
                 new ServerDetails[]{
+                    GLASSFISH_SERVER_5_1,
                     GLASSFISH_SERVER_5_0,
                     GLASSFISH_SERVER_4_1_2,
                     GLASSFISH_SERVER_4_1_1,
                     GLASSFISH_SERVER_4_1,
-                    GLASSFISH_SERVER_4_0,
-                    GLASSFISH_SERVER_3_1_2_2});
+                    GLASSFISH_SERVER_4_0});
     }
 
     /**
@@ -226,6 +237,7 @@ public enum ServerDetails {
                 case GF_4_1_1:   return GLASSFISH_SERVER_4_1_1.getVersion();
                 case GF_4_1_2:   return GLASSFISH_SERVER_4_1_2.getVersion();
                 case GF_5:       return GLASSFISH_SERVER_5_0.getVersion();
+                case GF_5_1:     return GLASSFISH_SERVER_5_1.getVersion();
                 default:         return -1;
             }
         }

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -57,7 +57,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6", // NOI18N
         300,
         "https://download.oracle.com/glassfish/v3/release/glassfish-v3.zip", // NOI18N
-        "https://download.oracle.com/glassfish/v3/release/glassfish-v3.zip" // NOI18N
+        "https://download.oracle.com/glassfish/v3/release/glassfish-v3.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     /**
      * details for an instance of GlassFish Server 3.0/3.0.x
@@ -66,7 +67,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6", // NOI18N
         301,
         "https://download.oracle.com/glassfish/3.0.1/release/glassfish-3.0.1-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/3.0.1/release/glassfish-3.0.1-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/3.0.1/release/glassfish-3.0.1-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     /**
      * details for an instance of GlassFish Server 3.1
@@ -75,7 +77,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         310,
         "https://download.oracle.com/glassfish/3.1/release/glassfish-3.1-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/3.1/release/glassfish-3.1-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/3.1/release/glassfish-3.1-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     /**
      * details for an instance of GlassFish Server 3.1.1
@@ -84,8 +87,9 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         311,
         "https://download.oracle.com/glassfish/3.1.1/release/glassfish-3.1.1-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/3.1.1/release/glassfish-3.1.1-ml.zip" // NOI18N
-            ),
+        "https://download.oracle.com/glassfish/3.1.1/release/glassfish-3.1.1-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
+    ),
     /**
      * details for an instance of GlassFish Server 3.1.2
      */
@@ -93,7 +97,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         312,
         "https://download.oracle.com/glassfish/3.1.2/release/glassfish-3.1.2-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/3.1.2/release/glassfish-3.1.2-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/3.1.2/release/glassfish-3.1.2-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
 
     /**
@@ -103,7 +108,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         312,
         "https://download.oracle.com/glassfish/3.1.2.2/release/glassfish-3.1.2.2-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/3.1.2.2/release/glassfish-3.1.2.2-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/3.1.2.2/release/glassfish-3.1.2.2-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
 
     /**
@@ -113,7 +119,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         400,
         "https://download.oracle.com/glassfish/4.0/release/glassfish-4.0-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/4.0/release/glassfish-4.0-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/4.0/release/glassfish-4.0-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
 
     /**
@@ -123,7 +130,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         401,
         "https://download.oracle.com/glassfish/4.0.1/release/glassfish-4.0.1-ml.zip", // NOI18N
-        "https://download.oracle.com/glassfish/4.0.1/release/glassfish-4.0.1-ml.zip" // NOI18N
+        "https://download.oracle.com/glassfish/4.0.1/release/glassfish-4.0.1-ml.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N"
     ),
     
     /**
@@ -133,7 +141,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         410,
         "https://download.oracle.com/glassfish/4.1/release/glassfish-4.1.zip", // NOI18N
-        "https://download.oracle.com/glassfish/4.1/release/glassfish-4.1.zip" // NOI18N
+        "https://download.oracle.com/glassfish/4.1/release/glassfish-4.1.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
 
     /**
@@ -143,7 +152,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         411,
         "https://download.oracle.com/glassfish/4.1.1/release/glassfish-4.1.1.zip", // NOI18N
-        "https://download.oracle.com/glassfish/4.1.1/release/glassfish-4.1.1.zip" // NOI18N
+        "https://download.oracle.com/glassfish/4.1.1/release/glassfish-4.1.1.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     
     /**
@@ -153,7 +163,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         412,
         "https://download.oracle.com/glassfish/4.1.2/release/glassfish-4.1.2.zip", // NOI18N
-        "https://download.oracle.com/glassfish/4.1.2/release/glassfish-4.1.2.zip" // NOI18N
+        "https://download.oracle.com/glassfish/4.1.2/release/glassfish-4.1.2.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     
     /**
@@ -163,7 +174,8 @@ public enum ServerDetails {
         "deployer:gfv3ee6wc", // NOI18N
         500,
         "https://download.oracle.com/glassfish/5.0/release/glassfish-5.0.zip", // NOI18N
-        "https://download.oracle.com/glassfish/5.0/release/glassfish-5.0.zip" // NOI18N
+        "https://download.oracle.com/glassfish/5.0/release/glassfish-5.0.zip", // NOI18N
+        "https://javaee.github.io/glassfish/LICENSE" //NOI18N
     ),
     
     /**
@@ -171,9 +183,10 @@ public enum ServerDetails {
      */
     GLASSFISH_SERVER_5_1(NbBundle.getMessage(ServerDetails.class, "STR_51_SERVER_NAME", new Object[]{}), // NOI18N
         "deployer:gfv3ee6wc", // NOI18N
-        500,
+        510,
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip" // NOI18N
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
 
     /**
@@ -271,16 +284,18 @@ public enum ServerDetails {
     private String uriFragment;
     private String indirectUrl;
     private String directUrl;
+    private String licenseUrl;
     private int versionInt;
     
 
     ServerDetails(String displayName, String uriFragment, int versionInt,
-            String directUrl, String indirectUrl) {
+            String directUrl, String indirectUrl, String licenseUrl) {
             this.displayName = displayName;
             this.uriFragment = uriFragment;
             this.indirectUrl = indirectUrl;
             this.directUrl = directUrl;
             this.versionInt = versionInt;
+            this.licenseUrl = licenseUrl;
     }
     
     @Override 
@@ -331,4 +346,7 @@ public enum ServerDetails {
         return indirectUrl;
     }
 
+    public String getLicenseUrl() {
+        return licenseUrl;
+    }
 }

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddServerLocationVisualPanel.form
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddServerLocationVisualPanel.form
@@ -46,28 +46,29 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="downloadStatusLabel" alignment="0" max="32767" attributes="0"/>
                   <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                          <Component id="localDomainRadioButton" max="32767" attributes="0"/>
-                          <Component id="downloadButton" max="32767" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" attributes="0">
-                              <Component id="agreeCheckBox" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="readlicenseButton" pref="0" max="32767" attributes="0"/>
-                          </Group>
-                          <Component id="remoteDomainRadioButton" pref="266" max="32767" attributes="0"/>
-                      </Group>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <Component id="hk2HomeLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                      <Component id="localDomainRadioButton" min="-2" pref="121" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="17" max="-2" attributes="0"/>
+                      <Component id="remoteDomainRadioButton" pref="253" max="32767" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="0" attributes="0">
                       <Component id="hk2HomeTextField" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="browseButton" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="hk2HomeLabel" min="-2" max="-2" attributes="0"/>
+                          <Component id="chooseServerLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="chooseServerComboBox" alignment="0" min="-2" pref="159" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="downloadButton" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace type="separate" max="-2" attributes="0"/>
+                      <Component id="agreeCheckBox" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="readlicenseButton" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -88,15 +89,26 @@
                   <Component id="localDomainRadioButton" alignment="2" min="-2" max="-2" attributes="0"/>
                   <Component id="remoteDomainRadioButton" alignment="2" min="-2" max="-2" attributes="0"/>
               </Group>
+              <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
+              <Component id="chooseServerLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="2" attributes="0">
-                  <Component id="downloadButton" alignment="2" min="-2" max="-2" attributes="0"/>
-                  <Component id="readlicenseButton" alignment="2" min="-2" max="-2" attributes="0"/>
-                  <Component id="agreeCheckBox" alignment="2" min="-2" max="-2" attributes="0"/>
+              <Component id="chooseServerComboBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="agreeCheckBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="downloadButton" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace pref="6" max="32767" attributes="0"/>
+                      <Component id="downloadStatusLabel" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Component id="readlicenseButton" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="downloadStatusLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -222,6 +234,30 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="remoteDomainRadioButtonActionPerformed"/>
       </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="chooseServerLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="hk2HomeTextField"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/glassfish/common/wizards/Bundle.properties" key="LBL_ChooseOne" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="chooseServerComboBox">
+      <Properties>
+        <Property name="selectedItem" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="wizardIterator.downloadableValues[0]" type="code"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new javax.swing.JComboBox&lt;ServerDetails&gt;(wizardIterator.downloadableValues)"/>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;ServerDetails&gt;"/>
+      </AuxValues>
     </Component>
   </SubComponents>
 </Form>

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddServerLocationVisualPanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddServerLocationVisualPanel.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.glassfish.common.wizards;
 
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
@@ -81,6 +83,14 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
             public void removeUpdate(DocumentEvent e) {
                 homeFolderChanged();
             }                    
+        });
+        chooseServerComboBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if(e.getStateChange() == ItemEvent.SELECTED) {
+                    serverVersionChanged();
+                }
+            }
         });
         setDownloadState(DownloadState.AVAILABLE);
         updateMessageText("");
@@ -272,6 +282,11 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
             updateButton();
         }
     }
+    
+    private void serverVersionChanged() {
+        agreeCheckBox.setSelected(false);
+        agreeCheckBoxActionPerformed(null);
+    }
        
     private static class DirFilter extends javax.swing.filechooser.FileFilter {
         DirFilter() {
@@ -311,6 +326,8 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
         downloadStatusLabel = new javax.swing.JLabel();
         localDomainRadioButton = new javax.swing.JRadioButton();
         remoteDomainRadioButton = new javax.swing.JRadioButton();
+        chooseServerLabel = new javax.swing.JLabel();
+        chooseServerComboBox = new javax.swing.JComboBox<ServerDetails>(wizardIterator.downloadableValues);
 
         hk2HomeLabel.setLabelFor(hk2HomeTextField);
         org.openide.awt.Mnemonics.setLocalizedText(hk2HomeLabel, org.openide.util.NbBundle.getMessage(AddServerLocationVisualPanel.class, "LBL_InstallLocation")); // NOI18N
@@ -368,6 +385,11 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
             }
         });
 
+        chooseServerLabel.setLabelFor(hk2HomeTextField);
+        org.openide.awt.Mnemonics.setLocalizedText(chooseServerLabel, org.openide.util.NbBundle.getMessage(AddServerLocationVisualPanel.class, "LBL_ChooseOne")); // NOI18N
+
+        chooseServerComboBox.setSelectedItem(wizardIterator.downloadableValues[0]);
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -377,23 +399,25 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(downloadStatusLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                            .addComponent(localDomainRadioButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(downloadButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(agreeCheckBox)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(readlicenseButton, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE))
-                            .addComponent(remoteDomainRadioButton, javax.swing.GroupLayout.DEFAULT_SIZE, 266, Short.MAX_VALUE)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(hk2HomeLabel)
-                        .addGap(0, 0, Short.MAX_VALUE))
+                        .addComponent(localDomainRadioButton, javax.swing.GroupLayout.PREFERRED_SIZE, 121, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(17, 17, 17)
+                        .addComponent(remoteDomainRadioButton, javax.swing.GroupLayout.DEFAULT_SIZE, 253, Short.MAX_VALUE))
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(hk2HomeTextField)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(browseButton)))
+                        .addComponent(browseButton))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(hk2HomeLabel)
+                            .addComponent(chooseServerLabel)
+                            .addComponent(chooseServerComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, 159, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(0, 0, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(downloadButton)
+                        .addGap(18, 18, 18)
+                        .addComponent(agreeCheckBox)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(readlicenseButton, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -408,14 +432,22 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.CENTER)
                     .addComponent(localDomainRadioButton)
                     .addComponent(remoteDomainRadioButton))
+                .addGap(10, 10, 10)
+                .addComponent(chooseServerLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.CENTER)
-                    .addComponent(downloadButton)
-                    .addComponent(readlicenseButton, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(agreeCheckBox))
+                .addComponent(chooseServerComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(downloadStatusLabel)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(agreeCheckBox)
+                            .addComponent(downloadButton))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 6, Short.MAX_VALUE)
+                        .addComponent(downloadStatusLabel))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(readlicenseButton, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(0, 0, Short.MAX_VALUE)))
+                .addContainerGap())
         );
 
         hk2HomeTextField.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(AddServerLocationVisualPanel.class, "AddServerLocationVisualPanel.hk2HomeTextField.AccessibleContext.accessibleDescription")); // NOI18N
@@ -426,8 +458,9 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel implements 
 
 private void readlicenseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_readlicenseButtonActionPerformed
         try {
+            ServerDetails chosenServerVersion = (ServerDetails) chooseServerComboBox.getSelectedItem();
             URLDisplayer.getDefault().showURL(
-                    new URL("https://javaee.github.io/glassfish/LICENSE")); //NOI18N
+                    new URL(chosenServerVersion.getLicenseUrl())); //NOI18N
         } catch (Exception ex){
             Logger.getLogger("glassfish").log(Level.INFO, ex.getLocalizedMessage(), ex);
         }
@@ -437,11 +470,7 @@ private void downloadButtonActionPerformed(java.awt.event.ActionEvent evt) {//GE
         if(retriever == null) {
             ServerDetails selectedValue = wizardIterator.downloadableValues[0];
             if (wizardIterator.downloadableValues.length > 1) {
-                selectedValue = (ServerDetails) JOptionPane.showInputDialog(null,
-                    NbBundle.getMessage(AddServerLocationVisualPanel.class, "LBL_ChooseOne"), // NOI18N
-                    NbBundle.getMessage(AddServerLocationVisualPanel.class, "LBL_SELECT_BITS"), // NOI18N
-                    JOptionPane.INFORMATION_MESSAGE, null,
-                    wizardIterator.downloadableValues, wizardIterator.downloadableValues[0]);
+                selectedValue = (ServerDetails) chooseServerComboBox.getSelectedItem();
             }
             if (null != selectedValue) {
             updateStatusText("");  // NOI18N
@@ -488,6 +517,8 @@ private void agreeCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox agreeCheckBox;
     private javax.swing.JButton browseButton;
+    private javax.swing.JComboBox<ServerDetails> chooseServerComboBox;
+    private javax.swing.JLabel chooseServerLabel;
     private javax.swing.ButtonGroup domainType;
     private javax.swing.JButton downloadButton;
     private javax.swing.JLabel downloadStatusLabel;

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -75,8 +75,10 @@ public enum GlassFishVersion {
     /** GlassFish 4.1.2. */
     GF_4_1_2    ((short) 4, (short) 1, (short) 1, (short) 2, GlassFishVersion.GF_4_1_2_STR),
     /** GlassFish 5. */
-    GF_5        ((short) 5, (short) 0, (short) 0, (short) 0, GlassFishVersion.GF_5_STR);
-
+    GF_5        ((short) 5, (short) 0, (short) 0, (short) 0, GlassFishVersion.GF_5_STR),
+    /** GlassFish 5.1 */
+    GF_5_1      ((short) 5, (short) 1, (short) 0, (short) 0, GlassFishVersion.GF_5_1_STR);
+    
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //
     ////////////////////////////////////////////////////////////////////////////
@@ -176,7 +178,11 @@ public enum GlassFishVersion {
     static final String GF_5_STR = "5";
     /** Additional <code>String</code> representations of GF_5 value. */
     static final String GF_5_STR_NEXT[] = {"5.0", "5.0.0", "5.0.0.0"};
-
+    
+    /**  A <code>String</code> representation of GF_5 value. */
+    static final String GF_5_1_STR = "5.1";
+    /** Additional <code>String</code> representations of GF_5 value. */
+    static final String GF_5_1_STR_NEXT[] = {"5.1.0", "5.1.0.0"};
     /** 
      * Stored <code>String</code> values for backward <code>String</code>
      * conversion.
@@ -204,6 +210,7 @@ public enum GlassFishVersion {
         initStringValuesMapFromArray(GF_4_1_1, GF_4_1_1_STR_NEXT);
         initStringValuesMapFromArray(GF_4_1_2, GF_4_1_2_STR_NEXT);
         initStringValuesMapFromArray(GF_5, GF_5_STR_NEXT);
+        initStringValuesMapFromArray(GF_5_1, GF_5_1_STR_NEXT);
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
What this pull request does in a nutshell
---------------------------------------------
Expands on #1141 by:

- Removing the JOptionDialog to select a version of GlassFish to download, and moving that functionality to the JPanel in the Wizard
- Amending the ServerDetails enums to include a URL to the appropriate license (Oracle / EF) for each GlassFish version supported
- Button to open license now checks selected version of GlassFish and opens browser pointing to correct license from ServerDetails
- Fixes a tiny typo in #1141 (typo was probably actually copied from my instructions in Jira!)


API Changes
--------------
org.netbeans.modules.glassfish.common.ServerDetails now has a new public method, getLicenseUrl() that returns the URL for a given version of GlassFish

I have incremented the API version number in the manifest file from 1.76 to 1.77.  Is there anything else I need to do?


Alternative to API change
----------------------------
If the API change is a bad thing, an alternative would be to add a couple of constants to the Glassfish Wizard, and if ServerDetails.getVersion() <= 500 then Oracle license, else Eclipse license.  That would feel hacky though, and one more random thing to miss when added support for a new version of GF.


Testing
--------
- Launch NB, Services tab -> Servers -> Right click -> Add Server
- Select GlassFish server -> Next
- After PR: JComboBox is now on this panel.  Select a version of GF and click on the license link - correct license for the version of GlassFish selected should be displayed
- Changing version of GlassFish selected, will uncheck the license checkbox


Dependencies
----------------
This is built on top of b141842 from #1141