### PR TITLE
[NETBEANS-2009] Improve Gradle sub-project Detection

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -36,6 +36,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -67,6 +68,7 @@ import static org.netbeans.modules.gradle.GradleDaemon.*;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.JLabel;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.openide.awt.Notification;
@@ -91,6 +93,8 @@ public final class GradleProjectCache {
 
     private static AtomicLong timeInLoad = new AtomicLong();
     private static AtomicInteger loadedProjects = new AtomicInteger();
+
+    private static final Map<File, Set<File>> SUB_PROJECT_DIR_CACHE = new ConcurrentHashMap<>();
 
     // Increase this number if new info is gathered from the projects.
     private static final int COMPATIBLE_CACHE_VERSION = 10;
@@ -119,7 +123,8 @@ public final class GradleProjectCache {
             if (cacheEntry != null) {
                 if (cacheEntry.isCompatible()) {
                     prev = createGradleProject(cacheEntry.quality, cacheEntry.data);
-                    if (cacheEntry.isValid(aim)) {
+                    if (cacheEntry.isValid()) {
+                        updateSubDirectoryCache(prev);
                         return prev;
                     }
                 }
@@ -136,6 +141,7 @@ public final class GradleProjectCache {
         GradleProject ret;
         try {
             ret = GRADLE_LOADER_RP.submit(new ProjectLoaderTask(ctx)).get();
+            updateSubDirectoryCache(ret);
         } catch (InterruptedException | ExecutionException ex) {
             ret = fallbackProject(files);
         }
@@ -434,6 +440,20 @@ public final class GradleProjectCache {
 
     }
 
+    private static void updateSubDirectoryCache(GradleProject gp) {
+        if (gp.getQuality().atLeast(EVALUATED)) {
+            GradleBaseProject baseProject = gp.getBaseProject();
+            if (baseProject.isRoot()) {
+                SUB_PROJECT_DIR_CACHE.put(baseProject.getProjectDir(), new HashSet<File>(baseProject.getSubProjects().values()));
+            }
+        }
+    }
+
+    static Boolean isKnownSubProject(File rootDir, File subProjectDir) {
+        Set<File> cache = SUB_PROJECT_DIR_CACHE.get(rootDir);
+        return (cache != null) ? cache.contains(subProjectDir) : null;
+    }
+
     private static void saveCachedProjectInfo(NbProjectInfo data, GradleProject gp) {
         assert gp.getQuality().betterThan(FALLBACK) : "Never attempt to cache FALLBACK projects."; //NOi18N
         //TODO: Make it possible to handle external file set as cache.
@@ -536,7 +556,7 @@ public final class GradleProjectCache {
             return version == COMPATIBLE_CACHE_VERSION;
         }
 
-        public boolean isValid(Quality aim) {
+        public boolean isValid() {
             boolean ret = isCompatible();
             if (ret && (sourceFiles != null)) {
                 for (File f : sourceFiles) {

--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -457,7 +457,7 @@ public final class GradleProjectCache {
     private static void saveCachedProjectInfo(NbProjectInfo data, GradleProject gp) {
         assert gp.getQuality().betterThan(FALLBACK) : "Never attempt to cache FALLBACK projects."; //NOi18N
         //TODO: Make it possible to handle external file set as cache.
-        GradleFiles gf = new GradleFiles(gp.getBaseProject().getProjectDir());
+        GradleFiles gf = new GradleFiles(gp.getBaseProject().getProjectDir(), true);
 
         ProjectCacheEntry entry = new ProjectCacheEntry(new StoredProjectInfo(data), gp, gf.getProjectFiles());
         File cacheFile = new File(getCacheDir(gp), INFO_CACHE_FILE_NAME);

--- a/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.gradle;
 
+import java.io.File;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.spi.GradleSettings;
@@ -52,9 +53,10 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
             if ((pom != null) && pom.isData() && GradleSettings.getDefault().isPreferMaven()) {
                 ret = false;
             } else {
-                GradleFiles files = new GradleFiles(FileUtil.toFile(dir));
+                File suspect = FileUtil.toFile(dir);
+                GradleFiles files = new GradleFiles(suspect);
                 if (!files.isRootProject()) {
-                    Boolean inSubDirCache = GradleProjectCache.isKnownSubProject(files.getRootDir(), files.getProjectDir());
+                    Boolean inSubDirCache = GradleProjectCache.isKnownSubProject(files.getRootDir(), suspect);
                     ret = inSubDirCache != null ? inSubDirCache : files.isProject();
                 } else {
                     ret = true;

--- a/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -53,7 +53,12 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
                 ret = false;
             } else {
                 GradleFiles files = new GradleFiles(FileUtil.toFile(dir));
-                ret = files.isProject();
+                if (!files.isRootProject()) {
+                    Boolean inSubDirCache = GradleProjectCache.isKnownSubProject(files.getRootDir(), files.getProjectDir());
+                    ret = inSubDirCache != null ? inSubDirCache : files.isProject();
+                } else {
+                    ret = true;
+                }
             }
         }
 

--- a/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -123,7 +123,7 @@ public final class NbGradleProjectImpl implements Project {
     public NbGradleProjectImpl(final FileObject projectDir, ProjectState projectState) {
         this.projectDir = projectDir;
         this.projectState = projectState;
-        this.gradleFiles = new GradleFiles(FileUtil.normalizeFile(FileUtil.toFile(projectDir)));
+        this.gradleFiles = new GradleFiles(FileUtil.normalizeFile(FileUtil.toFile(projectDir)), true);
         lookup = Lookups.proxy(new Lookup.Provider() {
             @Override
             public Lookup getLookup() {

--- a/groovy/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
@@ -30,7 +30,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 
 /**
  * Utility methods working with Gradle projects and Artifacts.
- * 
+ *
  * @since 1.0
  * @author Laszlo Kishalmi
  */
@@ -115,26 +115,26 @@ public final class GradleProjects {
      * Try to determine if the given directory belongs to a Gradle project.
      * This method use heuristics and usual project layout of project files.
      * The returned value is not necessary correct.
-     * 
+     *
      * @param dir the directory to test
-     * @return true if the given directory is suspected as a Gradle project. 
+     * @return true if the given directory is suspected as a Gradle project.
      */
     public static boolean testForProject(File dir) {
         return new GradleFiles(dir).isProject();
     }
-    
+
     /**
      * Try to determine if the given directory belongs to a Gradle root project.
      * This method use heuristics and usual project layout of project files.
      * The returned value is not necessary correct.
-     * 
+     *
      * @param dir the directory to test
-     * @return true if the given directory is suspected as a Gradle root project. 
+     * @return true if the given directory is suspected as a Gradle root project.
      */
     public static boolean testForRootProject(File dir) {
         return new GradleFiles(dir).isRootProject();
     }
-    
+
     private static void collectProjectDependencies(final Map<String, Project> ret, Map<String, Project> siblings, final Project prj) {
         GradleBaseProject gbp = GradleBaseProject.get(prj);
         for (GradleDependency.ProjectDependency dep : gbp.getProjectDependencies()) {

--- a/groovy/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -212,7 +212,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
 
         GradleBaseProject gbp = GradleBaseProject.get(config.getProject());
         if (gbp != null
-                && new GradleFiles(gbp.getProjectDir()).hasWrapper()
+                && new GradleFiles(gbp.getProjectDir(), true).hasWrapper()
                 && GradleSettings.getDefault().isWrapperPreferred()) {
 
                 Path rootPath = gbp.getRootDir().toPath();

--- a/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -43,7 +43,7 @@ import org.openide.util.Utilities;
 
 /**
  * Collection of notable files used in a Gradle project.
- * 
+ *
  * @author Laszlo Kishalmi
  */
 public final class GradleFiles implements Serializable {
@@ -68,6 +68,7 @@ public final class GradleFiles implements Serializable {
     public static final String WRAPPER_PROPERTIES     = "gradle/wrapper/gradle-wrapper.properties"; //NOI18N
 
     final File projectDir;
+    final boolean knownProject;
     File rootDir;
     File buildScript;
     File parentScript;
@@ -77,6 +78,11 @@ public final class GradleFiles implements Serializable {
     File wrapperProperties;
 
     public GradleFiles(File dir) {
+        this(dir, false);
+    }
+    
+    public GradleFiles(File dir, boolean knownProject) {
+        this.knownProject = knownProject;
         try {
             dir = dir.getCanonicalFile();
         } catch (IOException ex) {
@@ -179,7 +185,7 @@ public final class GradleFiles implements Serializable {
     }
 
     public boolean isProject() {
-        boolean ret = buildScript != null;
+        boolean ret = knownProject || (buildScript != null);
         if (!ret && (settingsScript != null)) {
             ret = SettingsFile.getSubProjects(settingsScript).contains(projectDir);
         }
@@ -344,7 +350,7 @@ public final class GradleFiles implements Serializable {
             }
             return firstGuess;
         }
-        
+
         public static Set<File> getSubProjects(File f) {
             SettingsFile sf = CACHE.get(f);
             if ((sf == null) || (sf.time < f.lastModified())) {


### PR DESCRIPTION
Not a complete solution on NETBEANS-2009 Gradle sub-project detection, but allows to load sub-projects when the root project is loaded in the IDE. The complete solution would require some architectural changes which could go into NetBeans 12.0. 