### PR TITLE
Fix ExplorerManager#setSelectedNodes()

### DIFF
--- a/platform/openide.explorer/src/org/openide/explorer/ExplorerManager.java
+++ b/platform/openide.explorer/src/org/openide/explorer/ExplorerManager.java
@@ -227,7 +227,7 @@ public final class ExplorerManager extends Object implements Serializable, Clone
                         if (validNodes == null) {
                             validNodes = new ArrayList<Node>(value.length);
                             for (int j = 0; j < i; j++) {
-                                validNodes.add(value[i]);
+                                validNodes.add(value[j]);
                             }
                         }
                     } else if (validNodes != null) {


### PR DESCRIPTION
Use correct index variable when copying validated nodes; this was originally
reported by me in 2015, original issue is at

https://netbeans.org/bugzilla/show_bug.cgi?id=257181