### PR TITLE
[NETBEANS-2126] Use correct grammar for javaee-endorsed-api-7.0.xml

### DIFF
--- a/enterprise/javaee7.api/src/org/netbeans/modules/javaee7/api/javaee-endorsed-api-7.0.xml
+++ b/enterprise/javaee7.api/src/org/netbeans/modules/javaee7/api/javaee-endorsed-api-7.0.xml
@@ -20,8 +20,7 @@
     under the License.
 
 -->
-<!DOCTYPE library PUBLIC "-//NetBeans//DTD Library Declaration 1.0//EN" "http://www.netbeans.org/dtds/library-declaration-1_0.dtd">
-<library version="1.0">
+<library version="3.0" xmlns="http://www.netbeans.org/ns/library-declaration/3">
     <name>javaee-endorsed-api-7.0</name>
     <type>j2se</type>
     <localizing-bundle>org/netbeans/modules/javaee7/api/Bundle</localizing-bundle>


### PR DESCRIPTION
Version 1 of the library grammar did not support properties. The addition
of the information about maven dependencies broke loading of the library
definition.