### PR TITLE
[NETBEANS-1936] Removing the SVN client version suffix before parsing the number

### DIFF
--- a/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -84,7 +84,7 @@ public class VersionCommand extends SvnCommand {
             if (pos > -1) {
                 String vString = string.substring(pos + 9);
                 Subversion.LOG.log(Level.INFO, "Commandline client version: {0}", vString);
-                Version version = Version.parse(vString);
+                Version version = Version.parse(vString.replace("-dev", ""));
                 if (version.lowerThan(VERSION_15)) {
                     unsupportedVersion = true;
                     return false;


### PR DESCRIPTION
If dev version of the SVN client is used together with Netbeans, many operations over SVN versioned projects fail because of NumberFormatException.