### PR TITLE
[NETBEANS-2303] Update version number on Windows Launchers

### DIFF
--- a/harness/apisupport.harness/windows-launcher-src/app.exe.manifest
+++ b/harness/apisupport.harness/windows-launcher-src/app.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="9.0.0.0"
+<assemblyIdentity version="11.0.0.0"
    processorArchitecture="x86"
    name="app.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/netbeans.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="9.0.0.0"
+<assemblyIdentity version="11.0.0.0"
    processorArchitecture="x86"
    name="netbeans.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/netbeans64.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans64.exe.manifest
@@ -22,7 +22,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <!-- Use processorArchitecture="x86", which is the value used by the 64-bit
      javaw.exe on Java 10.0.2 and Java 11ea. -->
-<assemblyIdentity version="9.0.0.0"
+<assemblyIdentity version="11.0.0.0"
    processorArchitecture="x86"
    name="netbeans64.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/version.h
+++ b/nb/ide.launcher/windows/version.h
@@ -19,10 +19,10 @@
 
 #define COMPANY ""
 #define COMPONENT "NetBeans IDE"
-#define VER "9.0.0.0"
-#define FVER 9,0,0,0
+#define VER "11.0.0.0"
+#define FVER 11,0,0,0
 #define BUILD_ID "03062018"
 #define INTERNAL_NAME "netbeans"
 #define COPYRIGHT "Based on Apache NetBeans from the Apache Software Foundation and is licensed under Apache License Version 2.0"
-#define NAME "NetBeans IDE 9.0"
+#define NAME "NetBeans IDE 11.0"
 

--- a/platform/o.n.bootstrap/launcher/windows/nbexec.exe.manifest
+++ b/platform/o.n.bootstrap/launcher/windows/nbexec.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="9.0.0.0"
+<assemblyIdentity version="11.0.0.0"
    processorArchitecture="X86"
    name="nbexec.exe"
    type="win32"/>

--- a/platform/o.n.bootstrap/launcher/windows/version.h
+++ b/platform/o.n.bootstrap/launcher/windows/version.h
@@ -19,8 +19,8 @@
 
 #define COMPANY ""
 #define COMPONENT "NetBeans Platform Launcher"
-#define VER "9.0.0.0"
-#define FVER 9,0,0,0
+#define VER "11.0.0.0"
+#define FVER 11,0,0,0
 #define BUILD_ID "03062018"
 #define INTERNAL_NAME "nbexec"
 #define COPYRIGHT "Based on Apache NetBeans from the Apache Software Foundation and is licensed under Apache License Version 2.0"


### PR DESCRIPTION
Well in the unlikely event of releasing a 11.0-vc5 it could be useful to have a Windows Launcher version update as well.