### PR TITLE
[NETBEANS-2315] Switch expression multi cases should have Enum values…

### DIFF
--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.7/ruleSwitchEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.7/ruleSwitchEnumCaseValues.pass
@@ -1,0 +1,1 @@
+public static final colors BLUE

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.7/switchExprEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.7/switchExprEnumCaseValues.pass
@@ -1,0 +1,2 @@
+public static final colors BLUE
+public static final colors GREEN

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/ruleSwitchEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/ruleSwitchEnumCaseValues.pass
@@ -1,0 +1,1 @@
+public static final colors BLUE

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/switchExprEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/switchExprEnumCaseValues.pass
@@ -1,0 +1,2 @@
+public static final colors BLUE
+public static final colors GREEN

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/10/ruleSwitchEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/10/ruleSwitchEnumCaseValues.pass
@@ -1,0 +1,1 @@
+public static final colors BLUE

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/10/switchExprEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/10/switchExprEnumCaseValues.pass
@@ -1,0 +1,2 @@
+public static final colors BLUE
+public static final colors GREEN

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/11/ruleSwitchEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/11/ruleSwitchEnumCaseValues.pass
@@ -1,0 +1,1 @@
+public static final colors BLUE

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/11/switchExprEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/11/switchExprEnumCaseValues.pass
@@ -1,0 +1,2 @@
+public static final colors BLUE
+public static final colors GREEN

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/12/ruleSwitchEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/12/ruleSwitchEnumCaseValues.pass
@@ -1,0 +1,1 @@
+public static final colors BLUE

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/12/switchExprEnumCaseValues.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/12/switchExprEnumCaseValues.pass
@@ -1,0 +1,2 @@
+public static final colors BLUE
+public static final colors GREEN

--- a/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/RuleSwitchWithMultiEnumValues.java
+++ b/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/RuleSwitchWithMultiEnumValues.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class Test {
+
+    enum colors {RED, GREEN, BLUE}
+
+    public void op(int a) {
+        colors color = colors.RED;
+        switch (color) {
+            case RED -> a = 10;
+            case GREEN,
+                
+	}
+    }
+}

--- a/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SwitchExprWithMultiEnumValues.java
+++ b/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SwitchExprWithMultiEnumValues.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class Test {
+
+    enum colors {RED, GREEN, BLUE}
+
+    public void op(int a) {
+        colors color = colors.RED;
+        a = switch (color) {
+            case RED, 
+                
+	}
+    }
+}

--- a/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SwitchStatementWithMultiEnumValues.java
+++ b/java/java.completion/test/unit/data/org/netbeans/modules/java/completion/data/SwitchStatementWithMultiEnumValues.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class Test {
+
+    enum colors {RED, GREEN, BLUE}
+
+    public void op(int a) {
+        colors color = colors.RED;
+        switch (color) {
+            case RED, 
+                
+	}
+    }
+}

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask112FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask112FeaturesTest.java
@@ -61,6 +61,18 @@ public class JavaCompletionTask112FeaturesTest extends CompletionTestBase {
         performTest("SwitchExprWithEnumValues2", 1020, null, "switchEnumCaseValues2.pass");
     }
 
+    public void testSwitchExprMultiEnumCaseValue() throws Exception {
+        performTest("SwitchExprWithMultiEnumValues", 994, null, "switchExprEnumCaseValues.pass");
+    }
+
+    public void testSwitchStatementMultiEnumCaseValue() throws Exception {
+        performTest("SwitchStatementWithMultiEnumValues", 990, null, "switchExprEnumCaseValues.pass");
+    }
+
+    public void testRuleSwitchMultiEnumCaseValue() throws Exception {
+        performTest("RuleSwitchWithMultiEnumValues", 1024, null, "ruleSwitchEnumCaseValues.pass");
+    }
+
     public void noop() {
     }
 


### PR DESCRIPTION
… in auto complete options
The multi cases in switch expression should show the enum value in auto complete options:

Example:

enum state {CANCELLED, INTERRUPTING, INTERRUPTED, NORMAL , EXCEPTIONAL}

String status = switch (state) {
case NORMAL -> "[Completed normally]";
case EXCEPTIONAL, <caret pos> -> "[Completed exceptionally: " + outcome + "]";

The auto complete option at <caret pos> should contain the enum value of {CANCELLED, INTERRUPTING, INTERRUPTED}