### PR TITLE
[NETBEANS-1775] Fix for NPE

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -521,7 +521,7 @@ public class LocalAddressUtils {
             // (above from VirtualBox source code)
             //
             byte[] macAddress = nif.getHardwareAddress();
-            if (macAddress != null & macAddress.length >= 3) {
+            if (macAddress != null && macAddress.length >= 3) {
                 if ((macAddress[0] == 0x0A || macAddress[0] == 0x08) &&
                         (macAddress[1] == 0x00) &&
                         (macAddress[2] == 0x27)) {                


### PR DESCRIPTION
Simple typo but with devastating effect: `&` should have been `&&`. This caused an NPE when NetBeans was used with a VPN connection. 

This fixes [NETBEANS-1775](https://issues.apache.org/jira/browse/NETBEANS-1775).