### PR TITLE
[NETBEANS-2378] Tighten the Groovy more to the Gralde plugin

### DIFF
--- a/groovy/gradle/manifest.mf
+++ b/groovy/gradle/manifest.mf
@@ -4,3 +4,4 @@ OpenIDE-Module: org.netbeans.modules.gradle
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.1
+OpenIDE-Module-Requires: cnb.org.netbeans.modules.groovy.kit


### PR DESCRIPTION
I used this OpenIDE-Module-Requires: cnb.org.netbeans.modules.groovy.kit before integrating the plugin into the main. Though I had to remove it during the Groovy <-> Gradle dependency change when the Groovy feature was depending on Gradle. Now this has been changed, so adding this glue shall help in some cases when the Gradle kit is enabled without the Groovy kit.