### PR TITLE
Only load the custom CSS when the LaF is one of the recognized ones

### DIFF
--- a/platform/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
+++ b/platform/api.htmlui/src/org/netbeans/modules/htmlui/NbBrowsers.java
@@ -60,29 +60,30 @@ final class NbBrowsers {
 
     static void applyNbSkin() {
         LookAndFeel lookAndFeel = UIManager.getLookAndFeel();
-        String name = lookAndFeel.getName();
+        String name = findLafName(lookAndFeel.getName());
+        if (name == null) {
+            return;
+        }
+        String resource = "nbres:/org/netbeans/modules/htmlui/css/wizard-" + name + ".css";
+        loadCss(resource);
+    }
+
+    private static String findLafName(String name) {
         switch (name) {
             case "Mac OS X":
-                name = "mac";
-                break;
+                return "mac";
             case "Metal":
-                name = "metal";
-                break;
+                return "metal";
             case "GTK look and feel":
-                name = "gtk";
-                break;
+                return "gtk";
             case "Nimbus":
-                name = "nimbus";
-                break;
+                return "nimbus";
             case "Windows":
-                name = "win";
-                break;
+                return "win";
             case "Darcula":
-                name = "darcula";
-                break;
+                return "darcula";
         }
-        final String resource = "nbres:/org/netbeans/modules/htmlui/css/wizard-" + name + ".css";
-        loadCss(resource);
+        return null;
     }
 
     @JavaScriptBody(args = { "css" }, body =


### PR DESCRIPTION
@sdedic reported an exception when `--laf com.sun.java.swing.plaf.motif.MotifLookAndFeel` is used. Then:
```
java.io.IOException: Could not connect to URL nbres:/org/netbeans/modules/htmlui/css/wizard-CDE/Motif.css. No such resource was found. 
at org.netbeans.core.startup.NbResourceStreamHandler$Connection.connect(NbResourceStreamHandler.java:118) 
at com.sun.webkit.network.URLLoader.sendRequest(URLLoader.java:368) [catch] 
at com.sun.webkit.network.URLLoader.doRun(URLLoader.java:164) 
at com.sun.webkit.network.URLLoader.lambda$run$98(URLLoader.java:129) 
at java.security.AccessController.doPrivileged(Native Method) 
at com.sun.webkit.network.URLLoader.run(URLLoader.java:128) 
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) 
at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at java.lang.Thread.run(Thread.java:748)
```
This fix only loads the custom CSS for known L&Fs.