### PR TITLE
Ensuring important DTDs are used locally when running java.completion…

### DIFF
--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
@@ -45,6 +45,10 @@ import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.xml.EntityCatalog;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  *
@@ -709,5 +713,22 @@ public class CompletionTestBase extends CompletionTestBaseBase {
             }
             return text1.length() - text2.length();
         }
+    }
+
+    @ServiceProvider(service=EntityCatalog.class)
+    public static final class TestEntityCatalogImpl extends EntityCatalog {
+
+        @Override
+        public InputSource resolveEntity(String publicID, String systemID) throws SAXException, IOException {
+            switch (publicID) {
+                case "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN":
+                    return new InputSource(TestEntityCatalogImpl.class.getResourceAsStream("/org/netbeans/modules/editor/settings/storage/keybindings/EditorKeyBindings-1_1.dtd"));
+                case "-//NetBeans//DTD Editor Preferences 1.0//EN":
+                    return new InputSource(TestEntityCatalogImpl.class.getResourceAsStream("/org/netbeans/modules/editor/settings/storage/preferences/EditorPreferences-1_0.dtd"));
+            }
+            System.err.println("publicID=" + publicID);
+            return null;
+        }
+
     }
 }

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
@@ -726,7 +726,6 @@ public class CompletionTestBase extends CompletionTestBaseBase {
                 case "-//NetBeans//DTD Editor Preferences 1.0//EN":
                     return new InputSource(TestEntityCatalogImpl.class.getResourceAsStream("/org/netbeans/modules/editor/settings/storage/preferences/EditorPreferences-1_0.dtd"));
             }
-            System.err.println("publicID=" + publicID);
             return null;
         }
 


### PR DESCRIPTION
… tests.

Adding the DTDs to the web was nice, but didn't seem to help the builds much. So trying to resolve this for java.completion tests by using the local copies of the DTDs.